### PR TITLE
Update mblt-model-zoo to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Current Mobilint Qwen2/3-VL notes:
 By default, `vllm-mblt` follows the runtime layout encoded in the Mobilint model artifact/config. Use
 `--model-loader-extra-config` only when you intentionally want to override runtime placement or testing knobs.
 
-Runtime settings such as `dev_no`, `target_cores`, `target_clusters`, `core_mode`, and `max_batch_size` are
-forwarded to `from_pretrained(...)` through `--model-loader-extra-config`.
+Runtime settings such as `dev_no`, `target_cores`, `target_clusters`, `core_mode`, and `max_batch_size` can be
+provided through `--model-loader-extra-config`.
 For detailed `core_mode` and multicore runtime layout guidance, see the
 [Mobilint multicore documentation](https://docs.mobilint.com/v1.2/en/multicore.html).
 
@@ -127,6 +127,19 @@ vllm serve mobilint/Llama-3.2-1B-Instruct \
   --trust-remote-code \
   --model-loader-extra-config '{"dev_no": 0, "target_cores": ["1:0"]}'
 ```
+
+For VLMs such as `mobilint/Qwen3-VL-2B-Instruct`, shared runtime layout keys are applied to both Mobilint
+submodules by forwarding them as model-zoo VLM subconfig keys (`vision_*` and `text_*`). Use explicit prefixed
+keys when the vision encoder and text model need different placement:
+
+```bash
+vllm serve mobilint/Qwen3-VL-2B-Instruct \
+  --trust-remote-code \
+  --model-loader-extra-config '{"dev_no": 0, "core_mode": "global4", "vision_core_mode": "single"}'
+```
+
+For VLM-specific MXQ path overrides, use `vision_mxq_path` and/or `text_mxq_path`; a single top-level `mxq_path`
+is only meaningful for single-module text models.
 
 ### Chunked Prefill Auto-Tuning
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ can be served through familiar vLLM commands and OpenAI-compatible APIs.
 
 - Python 3.10+
 - `vllm==0.11.2`
-- `mblt-model-zoo[transformers] >= 1.5.1`
+- `mblt-model-zoo[transformers] >= 2.1.0`
 - A Mobilint NPU environment. If you are not yet a Mobilint customer, please contact
   [tech-support@mobilint.com](mailto:tech-support@mobilint.com).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = [
 ]
 dependencies = [
     "vllm>=0.11.2,<=0.11.2",
-    "mblt-model-zoo[transformers]>=1.5.1",
+    "mblt-model-zoo[transformers]>=2.1.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -16,6 +16,7 @@ def _make_vllm_config(
     loader_core_mode=None,
     loader_extra_config=None,
     hf_core_mode=None,
+    hf_model_type="qwen2",
     max_batch_size=None,
     scheduler_max_num_batched_tokens=2048,
     scheduler_max_num_seqs=None,
@@ -32,7 +33,10 @@ def _make_vllm_config(
         ),
         model_config=SimpleNamespace(
             hf_config=SimpleNamespace(
-                npu_prefill_chunk_size=npu_prefill_chunk_size, max_batch_size=max_batch_size, core_mode=hf_core_mode
+                model_type=hf_model_type,
+                npu_prefill_chunk_size=npu_prefill_chunk_size,
+                max_batch_size=max_batch_size,
+                core_mode=hf_core_mode,
             )
         ),
         load_config=SimpleNamespace(model_loader_extra_config=loader_extra_config),
@@ -60,6 +64,7 @@ class TestMbltPlatformPrefill:
         config = _make_vllm_config(
             {"single": 64, "global4": 256},
             loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+            hf_model_type="mobilint-qwen3_vl",
         )
 
         assert resolve_npu_prefill_chunk_size(config) == 64
@@ -68,11 +73,24 @@ class TestMbltPlatformPrefill:
         config = _make_vllm_config(
             {"single": 64, "global4": 256},
             loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+            hf_model_type="mobilint-qwen3_vl",
         )
 
         MbltPlatform.check_and_update_config(config)
 
         assert config.scheduler_config.max_num_batched_tokens == 64
+
+    def test_text_only_uses_shared_core_mode_for_scheduler_prefill_limit(self) -> None:
+        config = _make_vllm_config(
+            {"single": 64, "global4": 96},
+            loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+            hf_model_type="qwen2",
+        )
+
+        MbltPlatform.check_and_update_config(config)
+
+        assert resolve_npu_prefill_chunk_size(config) == 96
+        assert config.scheduler_config.max_num_batched_tokens == 96
 
     def test_resolves_json_string_loader_max_batch_size_override(self) -> None:
         config = _make_vllm_config(
@@ -86,6 +104,7 @@ class TestMbltPlatformPrefill:
         config = _make_vllm_config(
             {"global4": 256},
             loader_extra_config={"core_mode": "global4", "max_batch_size": 16, "text_max_batch_size": 4},
+            hf_model_type="mobilint-qwen3_vl",
             max_batch_size=32,
         )
 
@@ -95,6 +114,7 @@ class TestMbltPlatformPrefill:
         config = _make_vllm_config(
             {"global4": 256},
             loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+            hf_model_type="mobilint-qwen3_vl",
             max_batch_size={"single": 4, "global4": 16},
         )
 
@@ -113,6 +133,7 @@ class TestMbltPlatformPrefill:
         config = _make_vllm_config(
             {"global4": 256},
             loader_extra_config={"core_mode": "global4", "max_batch_size": 16, "text_max_batch_size": 4},
+            hf_model_type="mobilint-qwen3_vl",
             max_batch_size=32,
         )
 
@@ -124,12 +145,39 @@ class TestMbltPlatformPrefill:
         config = _make_vllm_config(
             {"global4": 256},
             loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+            hf_model_type="mobilint-qwen3_vl",
             max_batch_size={"single": 4, "global4": 16},
         )
 
         MbltPlatform.check_and_update_config(config)
 
         assert config.scheduler_config.max_num_seqs == 4
+
+    def test_text_only_uses_shared_runtime_keys_for_scheduler_batch_limit(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 96},
+            loader_extra_config={"core_mode": "global4", "max_batch_size": 16, "text_max_batch_size": 4},
+            hf_model_type="qwen2",
+            max_batch_size=32,
+        )
+
+        MbltPlatform.check_and_update_config(config)
+
+        assert resolve_model_max_batch_size(config) == 16
+        assert config.scheduler_config.max_num_seqs == 16
+
+    def test_text_only_uses_shared_core_mode_for_scheduler_batch_mapping(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 96},
+            loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+            hf_model_type="qwen2",
+            max_batch_size={"single": 4, "global4": 16},
+        )
+
+        MbltPlatform.check_and_update_config(config)
+
+        assert resolve_model_max_batch_size(config) == 16
+        assert config.scheduler_config.max_num_seqs == 16
 
     def test_falls_back_to_hf_core_mode(self) -> None:
         config = _make_vllm_config({"single": 64, "global8": 512}, hf_core_mode="global8")

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -82,6 +82,55 @@ class TestMbltPlatformPrefill:
         )
         assert resolve_model_max_batch_size(config) == 16
 
+    def test_prefers_loader_text_max_batch_size_override(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={"core_mode": "global4", "max_batch_size": 16, "text_max_batch_size": 4},
+            max_batch_size=32,
+        )
+
+        assert resolve_model_max_batch_size(config) == 4
+
+    def test_uses_loader_text_core_mode_for_max_batch_size_mapping(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+            max_batch_size={"single": 4, "global4": 16},
+        )
+
+        assert resolve_model_max_batch_size(config) == 4
+
+    def test_falls_back_to_shared_core_mode_for_max_batch_size_mapping(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={"core_mode": "global4"},
+            max_batch_size={"single": 4, "global4": 16},
+        )
+
+        assert resolve_model_max_batch_size(config) == 16
+
+    def test_platform_uses_loader_text_max_batch_size_for_scheduler_limit(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={"core_mode": "global4", "max_batch_size": 16, "text_max_batch_size": 4},
+            max_batch_size=32,
+        )
+
+        MbltPlatform.check_and_update_config(config)
+
+        assert config.scheduler_config.max_num_seqs == 4
+
+    def test_platform_uses_loader_text_core_mode_for_scheduler_batch_limit(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+            max_batch_size={"single": 4, "global4": 16},
+        )
+
+        MbltPlatform.check_and_update_config(config)
+
+        assert config.scheduler_config.max_num_seqs == 4
+
     def test_falls_back_to_hf_core_mode(self) -> None:
         config = _make_vllm_config({"single": 64, "global8": 512}, hf_core_mode="global8")
         assert resolve_npu_prefill_chunk_size(config) == 512

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -56,6 +56,24 @@ class TestMbltPlatformPrefill:
         )
         assert resolve_npu_prefill_chunk_size(config) == 256
 
+    def test_prefers_loader_text_core_mode_for_prefill_chunk_size(self) -> None:
+        config = _make_vllm_config(
+            {"single": 64, "global4": 256},
+            loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+        )
+
+        assert resolve_npu_prefill_chunk_size(config) == 64
+
+    def test_platform_uses_loader_text_core_mode_for_scheduler_prefill_limit(self) -> None:
+        config = _make_vllm_config(
+            {"single": 64, "global4": 256},
+            loader_extra_config={"core_mode": "global4", "text_core_mode": "single"},
+        )
+
+        MbltPlatform.check_and_update_config(config)
+
+        assert config.scheduler_config.max_num_batched_tokens == 64
+
     def test_resolves_json_string_loader_max_batch_size_override(self) -> None:
         config = _make_vllm_config(
             {"global4": 256},

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -481,6 +481,27 @@ class TestMbltWorkerOptimizations:
         assert worker.max_batch_size == 4
         assert worker.free_cache_slots == [0, 1, 2, 3]
 
+    def test_init_uses_shared_text_only_max_batch_size_for_cache_slots(self, monkeypatch) -> None:
+        def worker_base_init(self, vllm_config, local_rank, rank, distributed_init_method, is_driver_worker=False):
+            self.vllm_config = vllm_config
+            self.local_rank = local_rank
+            self.rank = rank
+
+        monkeypatch.setattr("vllm_mblt.mblt_worker.WorkerBase.__init__", worker_base_init)
+        config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=128),
+            load_config=SimpleNamespace(
+                model_loader_extra_config={"core_mode": "global4", "max_batch_size": 16, "text_max_batch_size": 4}
+            ),
+            model_config=SimpleNamespace(max_model_len=1024, hf_config=SimpleNamespace(model_type="qwen2")),
+            scheduler_config=SimpleNamespace(enable_chunked_prefill=True, max_num_batched_tokens=128),
+        )
+
+        worker = MbltWorker(config, local_rank=0, rank=0, distributed_init_method="env://")
+
+        assert worker.max_batch_size == 16
+        assert worker.free_cache_slots == list(range(16))
+
     def test_load_model_passes_text_runtime_layout_kwargs_to_from_pretrained(self, monkeypatch) -> None:
         worker = MbltWorker.__new__(MbltWorker)
         worker.rank = 0

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -460,6 +460,27 @@ class TestMbltWorkerOptimizations:
         with pytest.raises(RuntimeError, match="VLM batch execution is not supported"):
             worker._ensure_batch_vlm_supported(req_state)
 
+    def test_init_uses_text_runtime_max_batch_size_for_cache_slots(self, monkeypatch) -> None:
+        def worker_base_init(self, vllm_config, local_rank, rank, distributed_init_method, is_driver_worker=False):
+            self.vllm_config = vllm_config
+            self.local_rank = local_rank
+            self.rank = rank
+
+        monkeypatch.setattr("vllm_mblt.mblt_worker.WorkerBase.__init__", worker_base_init)
+        config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=128),
+            load_config=SimpleNamespace(
+                model_loader_extra_config={"core_mode": "global4", "max_batch_size": 16, "text_max_batch_size": 4}
+            ),
+            model_config=SimpleNamespace(max_model_len=1024, hf_config=SimpleNamespace(model_type="mobilint-qwen3_vl")),
+            scheduler_config=SimpleNamespace(enable_chunked_prefill=True, max_num_batched_tokens=128),
+        )
+
+        worker = MbltWorker(config, local_rank=0, rank=0, distributed_init_method="env://")
+
+        assert worker.max_batch_size == 4
+        assert worker.free_cache_slots == [0, 1, 2, 3]
+
     def test_load_model_passes_text_runtime_layout_kwargs_to_from_pretrained(self, monkeypatch) -> None:
         worker = MbltWorker.__new__(MbltWorker)
         worker.rank = 0

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -474,9 +474,18 @@ class TestMbltWorkerOptimizations:
         worker.load_config = SimpleNamespace(
             model_loader_extra_config={
                 "dev_no": 2,
+                "mxq_path": "/tmp/model.mxq",
+                "max_batch_size": 8,
+                "npu_prefill_chunk_size": {"global8": 512},
                 "target_cores": ["1:0"],
                 "target_clusters": [0, 1],
                 "core_mode": "global8",
+                "text_core_mode": "single",
+                "text_target_cores": ["0:0"],
+                "vision_mxq_path": "/tmp/vision.mxq",
+                "vision_core_mode": "global4",
+                "vision_target_clusters": [0],
+                "unrelated": "ignored",
             }
         )
         worker.model_config = SimpleNamespace(
@@ -506,9 +515,17 @@ class TestMbltWorkerOptimizations:
                 {
                     "trust_remote_code": True,
                     "dev_no": 2,
+                    "mxq_path": "/tmp/model.mxq",
+                    "max_batch_size": 8,
+                    "npu_prefill_chunk_size": {"global8": 512},
                     "target_cores": ["1:0"],
                     "target_clusters": [0, 1],
                     "core_mode": "global8",
+                    "text_core_mode": "single",
+                    "text_target_cores": ["0:0"],
+                    "vision_mxq_path": "/tmp/vision.mxq",
+                    "vision_core_mode": "global4",
+                    "vision_target_clusters": [0],
                 },
             )
         ]

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -460,7 +460,7 @@ class TestMbltWorkerOptimizations:
         with pytest.raises(RuntimeError, match="VLM batch execution is not supported"):
             worker._ensure_batch_vlm_supported(req_state)
 
-    def test_load_model_passes_runtime_layout_kwargs_to_from_pretrained(self, monkeypatch) -> None:
+    def test_load_model_passes_text_runtime_layout_kwargs_to_from_pretrained(self, monkeypatch) -> None:
         worker = MbltWorker.__new__(MbltWorker)
         worker.rank = 0
         worker.local_rank = 0
@@ -526,6 +526,79 @@ class TestMbltWorkerOptimizations:
                     "vision_mxq_path": "/tmp/vision.mxq",
                     "vision_core_mode": "global4",
                     "vision_target_clusters": [0],
+                },
+            )
+        ]
+
+    def test_load_model_expands_vlm_runtime_layout_kwargs_to_subconfigs(self, monkeypatch) -> None:
+        worker = MbltWorker.__new__(MbltWorker)
+        worker.rank = 0
+        worker.local_rank = 0
+        worker.model = None
+        worker.cache_model = None
+        worker._infer_output_buffers = None
+        worker.max_batch_size = 1
+        worker.req_to_cache_slot = {}
+        worker.cache_slot_to_req = {}
+        worker.free_cache_slots = []
+        worker.load_config = SimpleNamespace(
+            model_loader_extra_config={
+                "dev_no": 0,
+                "mxq_path": "/tmp/ignored-top-level.mxq",
+                "max_batch_size": 4,
+                "npu_prefill_chunk_size": {"global4": 256},
+                "target_cores": ["1:0"],
+                "target_clusters": [0, 1],
+                "core_mode": "global4",
+                "text_core_mode": "single",
+                "text_target_cores": ["0:0"],
+                "vision_mxq_path": "/tmp/vision.mxq",
+                "vision_core_mode": "multi",
+                "vision_target_clusters": [0],
+            }
+        )
+        worker.model_config = SimpleNamespace(
+            model="mobilint/Qwen3-VL-2B-Instruct",
+            hf_config=SimpleNamespace(model_type="mobilint-qwen3_vl"),
+            model_kwargs={},
+            hf_overrides={},
+        )
+        worker.vllm_config = SimpleNamespace(
+            load_config=SimpleNamespace(model_loader_extra_config={}), model_config=worker.model_config
+        )
+        fake_model = SimpleNamespace(
+            eval=lambda: None,
+            get_input_embeddings=lambda: SimpleNamespace(),
+            get_cache_mxq_model=lambda: SimpleNamespace(),
+        )
+        calls = []
+
+        def from_pretrained(*args, **kwargs):
+            calls.append((args, kwargs))
+            return fake_model
+
+        monkeypatch.setattr("vllm_mblt.mblt_worker.AutoModelForImageTextToText.from_pretrained", from_pretrained)
+
+        worker.load_model()
+
+        assert calls == [
+            (
+                ("mobilint/Qwen3-VL-2B-Instruct",),
+                {
+                    "trust_remote_code": True,
+                    "vision_dev_no": 0,
+                    "text_dev_no": 0,
+                    "vision_max_batch_size": 4,
+                    "text_max_batch_size": 4,
+                    "vision_npu_prefill_chunk_size": {"global4": 256},
+                    "text_npu_prefill_chunk_size": {"global4": 256},
+                    "vision_target_cores": ["1:0"],
+                    "text_target_cores": ["0:0"],
+                    "vision_target_clusters": [0],
+                    "text_target_clusters": [0, 1],
+                    "vision_core_mode": "multi",
+                    "text_core_mode": "single",
+                    "vision_mxq_path": "/tmp/vision.mxq",
                 },
             )
         ]

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def register():

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -10,6 +10,12 @@ from vllm.platforms import Platform, PlatformEnum
 logger = init_logger(__name__)
 
 SINGLE_CORE_BATCH_MODEL_MAX_PREFILL_CHUNK_SIZE = 128
+_MULTIMODAL_HF_MODEL_TYPES = frozenset(
+    {
+        "mobilint-qwen2_vl",
+        "mobilint-qwen3_vl",
+    }
+)
 
 
 def _coerce_positive_int(value: object) -> int | None:
@@ -39,6 +45,22 @@ def _get_model_loader_extra_config(vllm_config: "VllmConfig") -> dict | None:
     return _coerce_config_dict(getattr(load_config, "model_loader_extra_config", None))
 
 
+def _get_hf_config(vllm_config: "VllmConfig") -> object:
+    model_config = getattr(vllm_config, "model_config", None)
+    return getattr(model_config, "hf_config", None)
+
+
+def _is_multimodal_hf_config(hf_config: object) -> bool:
+    model_type = getattr(hf_config, "model_type", None)
+    if not isinstance(model_type, str) and isinstance(hf_config, dict):
+        model_type = hf_config.get("model_type")
+    return isinstance(model_type, str) and model_type in _MULTIMODAL_HF_MODEL_TYPES
+
+
+def _prefer_text_runtime(vllm_config: "VllmConfig") -> bool:
+    return _is_multimodal_hf_config(_get_hf_config(vllm_config))
+
+
 def _resolve_core_mode(vllm_config: "VllmConfig", *, prefer_text_core_mode: bool = False) -> str | None:
     extra_config = _get_model_loader_extra_config(vllm_config)
     if extra_config is not None:
@@ -51,8 +73,7 @@ def _resolve_core_mode(vllm_config: "VllmConfig", *, prefer_text_core_mode: bool
         if isinstance(configured_core_mode, str) and configured_core_mode:
             return configured_core_mode
 
-    model_config = getattr(vllm_config, "model_config", None)
-    hf_config = getattr(model_config, "hf_config", None)
+    hf_config = _get_hf_config(vllm_config)
     configured_core_mode = getattr(hf_config, "core_mode", None)
     if isinstance(configured_core_mode, str) and configured_core_mode:
         return configured_core_mode
@@ -61,8 +82,7 @@ def _resolve_core_mode(vllm_config: "VllmConfig", *, prefer_text_core_mode: bool
 
 
 def _get_model_config_value(vllm_config: "VllmConfig", *field_names: str) -> object:
-    model_config = getattr(vllm_config, "model_config", None)
-    hf_config = getattr(model_config, "hf_config", None)
+    hf_config = _get_hf_config(vllm_config)
     if hf_config is None:
         return None
 
@@ -131,7 +151,7 @@ def resolve_npu_prefill_chunk_size(vllm_config: "VllmConfig") -> int | None:
         vllm_config,
         raw_chunk_size,
         field_name="npu_prefill_chunk_size",
-        prefer_text_core_mode=True,
+        prefer_text_core_mode=_prefer_text_runtime(vllm_config),
     )
 
 
@@ -159,8 +179,11 @@ def resolve_effective_npu_prefill_chunk_size(vllm_config: "VllmConfig") -> int:
 def resolve_model_max_batch_size(
     vllm_config: "VllmConfig",
     *,
-    prefer_text_runtime: bool = True,
+    prefer_text_runtime: bool | None = None,
 ) -> int | None:
+    if prefer_text_runtime is None:
+        prefer_text_runtime = _prefer_text_runtime(vllm_config)
+
     extra_config = _get_model_loader_extra_config(vllm_config)
     if extra_config is not None:
         if prefer_text_runtime:

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -39,9 +39,14 @@ def _get_model_loader_extra_config(vllm_config: "VllmConfig") -> dict | None:
     return _coerce_config_dict(getattr(load_config, "model_loader_extra_config", None))
 
 
-def _resolve_core_mode(vllm_config: "VllmConfig") -> str | None:
+def _resolve_core_mode(vllm_config: "VllmConfig", *, prefer_text_core_mode: bool = False) -> str | None:
     extra_config = _get_model_loader_extra_config(vllm_config)
     if extra_config is not None:
+        if prefer_text_core_mode:
+            configured_text_core_mode = extra_config.get("text_core_mode")
+            if isinstance(configured_text_core_mode, str) and configured_text_core_mode:
+                return configured_text_core_mode
+
         configured_core_mode = extra_config.get("core_mode")
         if isinstance(configured_core_mode, str) and configured_core_mode:
             return configured_core_mode
@@ -88,6 +93,7 @@ def _resolve_model_config_positive_int(
     raw_value: object,
     *,
     field_name: str,
+    prefer_text_core_mode: bool = False,
 ) -> int | None:
     if raw_value is None:
         return None
@@ -99,7 +105,7 @@ def _resolve_model_config_positive_int(
     if not isinstance(raw_value, dict):
         return None
 
-    core_mode = _resolve_core_mode(vllm_config)
+    core_mode = _resolve_core_mode(vllm_config, prefer_text_core_mode=prefer_text_core_mode)
     if core_mode is not None:
         chunk_size = _coerce_positive_int(raw_value.get(core_mode))
         if chunk_size is not None:
@@ -125,6 +131,7 @@ def resolve_npu_prefill_chunk_size(vllm_config: "VllmConfig") -> int | None:
         vllm_config,
         raw_chunk_size,
         field_name="npu_prefill_chunk_size",
+        prefer_text_core_mode=True,
     )
 
 

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -156,9 +156,18 @@ def resolve_effective_npu_prefill_chunk_size(vllm_config: "VllmConfig") -> int:
     return resolved_chunk_size
 
 
-def resolve_model_max_batch_size(vllm_config: "VllmConfig") -> int | None:
+def resolve_model_max_batch_size(
+    vllm_config: "VllmConfig",
+    *,
+    prefer_text_runtime: bool = True,
+) -> int | None:
     extra_config = _get_model_loader_extra_config(vllm_config)
     if extra_config is not None:
+        if prefer_text_runtime:
+            text_override = _coerce_positive_int(extra_config.get("text_max_batch_size"))
+            if text_override is not None:
+                return text_override
+
         override = _coerce_positive_int(extra_config.get("max_batch_size"))
         if override is not None:
             return override
@@ -172,6 +181,7 @@ def resolve_model_max_batch_size(vllm_config: "VllmConfig") -> int | None:
         vllm_config,
         raw_max_batch_size,
         field_name="max_batch_size",
+        prefer_text_core_mode=prefer_text_runtime,
     )
 
 

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -54,6 +54,8 @@ _MBLT_BACKEND_KWARG_PREFIXES = ("", "text_", "vision_", "encoder_", "decoder_", 
 _MBLT_BACKEND_KWARG_NAMES = frozenset(
     f"{prefix}{field}" for prefix in _MBLT_BACKEND_KWARG_PREFIXES for field in _MBLT_BACKEND_KWARG_FIELDS
 )
+_MULTIMODAL_SHARED_BACKEND_KWARG_FIELDS = _MBLT_BACKEND_KWARG_FIELDS - {"mxq_path"}
+_MULTIMODAL_BACKEND_PREFIXES = ("vision_", "text_")
 
 
 def _is_multimodal_hf_config(hf_config: object) -> bool:
@@ -64,6 +66,28 @@ def _is_multimodal_hf_config(hf_config: object) -> bool:
 def _is_qwen3_vl_hf_config(hf_config: object) -> bool:
     model_type = getattr(hf_config, "model_type", None)
     return model_type == "mobilint-qwen3_vl"
+
+
+def _normalize_model_kwargs_for_hf_config(
+    model_kwargs: dict[str, object],
+    hf_config: object,
+) -> dict[str, object]:
+    if not _is_multimodal_hf_config(hf_config):
+        return model_kwargs
+
+    normalized: dict[str, object] = {}
+    shared: dict[str, object] = {}
+    for key, value in model_kwargs.items():
+        if any(key.startswith(prefix) for prefix in _MULTIMODAL_BACKEND_PREFIXES):
+            normalized[key] = value
+        elif key in _MULTIMODAL_SHARED_BACKEND_KWARG_FIELDS:
+            shared[key] = value
+
+    for field, value in shared.items():
+        for prefix in _MULTIMODAL_BACKEND_PREFIXES:
+            normalized.setdefault(f"{prefix}{field}", value)
+
+    return normalized
 
 
 @dataclass
@@ -1302,13 +1326,15 @@ class MbltWorker(WorkerBase):
             _merge_kwargs(getattr(self.model_config, source, None))
             _merge_kwargs(getattr(self.vllm_config.model_config, source, None))
 
+        hf_config = getattr(self.model_config, "hf_config", None)
+        model_kwargs = _normalize_model_kwargs_for_hf_config(model_kwargs, hf_config)
+
         start = time.perf_counter()
         self._log_init_stage(
             "load_model:before_from_pretrained",
             model=self.model_config.model,
             model_kwargs=model_kwargs,
         )
-        hf_config = getattr(self.model_config, "hf_config", None)
         auto_model_cls = AutoModelForImageTextToText if _is_multimodal_hf_config(hf_config) else AutoModelForCausalLM
         self.model = auto_model_cls.from_pretrained(
             self.model_config.model,

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -39,6 +39,22 @@ _MULTIMODAL_HF_MODEL_TYPES = frozenset(
     }
 )
 
+_MBLT_BACKEND_KWARG_FIELDS = frozenset(
+    {
+        "mxq_path",
+        "dev_no",
+        "max_batch_size",
+        "core_mode",
+        "target_cores",
+        "target_clusters",
+        "npu_prefill_chunk_size",
+    }
+)
+_MBLT_BACKEND_KWARG_PREFIXES = ("", "text_", "vision_", "encoder_", "decoder_", "base_", "draft_", "fc_")
+_MBLT_BACKEND_KWARG_NAMES = frozenset(
+    f"{prefix}{field}" for prefix in _MBLT_BACKEND_KWARG_PREFIXES for field in _MBLT_BACKEND_KWARG_FIELDS
+)
+
 
 def _is_multimodal_hf_config(hf_config: object) -> bool:
     model_type = getattr(hf_config, "model_type", None)
@@ -1274,12 +1290,7 @@ class MbltWorker(WorkerBase):
                 except Exception:
                     return
             if isinstance(value, dict):
-                for key in (
-                    "dev_no",
-                    "target_cores",
-                    "target_clusters",
-                    "core_mode",
-                ):
+                for key in _MBLT_BACKEND_KWARG_NAMES:
                     if key in value:
                         model_kwargs[key] = value[key]
 


### PR DESCRIPTION
## Summary
- update `mblt-model-zoo` dependency to 2.1.0
- forward Mobilint backend kwargs for the model zoo 2.1 loader path
- handle VLM runtime layout overrides so `dev_no` / `core_mode` do not leak into `from_pretrained`
- update README guidance and add focused tests for the override behavior

## Changes
- `README.md`
- `pyproject.toml`
- `tests/test_mblt_worker_optimizations.py`
- `vllm_mblt/mblt_worker.py`

## Verification
- See commits for the checks run by the task agents.