### PR TITLE
Refactor Mobilint runtime KV cache management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+- Moved Mobilint runtime cache snapshot, live-cache ownership, and accelerator
+  cache slot handling out of `MbltWorker` into
+  `vllm_mblt.runtime_cache.MbltRuntimeCacheManager`.
+- Removed compatibility guarantees for old cache-related `MbltWorker` internals.
+- Removed direct imports of cache implementation details from
+  `vllm_mblt.mblt_worker`.
+- Documented that pre-1.0 releases may introduce breaking internal API changes;
+  backward compatibility is planned after 1.0.0.

--- a/KV_CACHE_REFACTOR_PLAN.md
+++ b/KV_CACHE_REFACTOR_PLAN.md
@@ -1,0 +1,234 @@
+# KV Cache Runtime Refactor Plan
+
+## Background
+
+`vllm-mblt` currently keeps most Mobilint/NPU runtime cache behavior inside
+`vllm_mblt/mblt_worker.py`. This includes request cache state, accelerator cache
+slot ownership, runtime cache dump/load, finished-request snapshots, prefix
+snapshot lookup, and cache reuse policy.
+
+This makes `MbltWorker` responsible for too many layers at once:
+
+- vLLM worker interface implementation
+- scheduler output interpretation
+- prompt embedding construction
+- Mobilint runtime inference
+- sampling/logprob handling
+- NPU runtime cache snapshot and slot lifecycle
+
+The goal of this refactor is to split the Mobilint runtime cache layer out of
+`MbltWorker` while preserving existing runtime behavior.
+
+## Design Direction
+
+Do not subclass or replace upstream vLLM's scheduler-side `KVCacheManager`.
+
+In upstream vLLM, `KVCacheManager` owns logical KV block allocation, prefix cache
+lookup, block pools, and scheduler-side request/block lifecycle. In `vllm-mblt`,
+the custom cache code is worker/runtime-side: it consumes scheduler-produced
+block IDs and maps them to Mobilint runtime cache blobs, cache slots, and
+snapshot reuse decisions.
+
+The refactor should therefore introduce a Mobilint runtime cache abstraction
+instead of another scheduler-side KV cache manager.
+
+## Proposed Module and Names
+
+Add a new module:
+
+```text
+vllm_mblt/runtime_cache.py
+```
+
+Primary class:
+
+```python
+class MbltRuntimeCacheManager:
+    ...
+```
+
+Rationale:
+
+- Avoids confusion with upstream `vllm.v1.core.kv_cache_manager.KVCacheManager`.
+- Communicates that this manager handles Mobilint runtime cache state, not
+  scheduler-side logical KV block allocation.
+- Keeps room for future runtime cache state beyond strict KV cache snapshots.
+
+Suggested supporting names:
+
+```python
+KVBlockIds = tuple[list[int], ...]
+
+@dataclass
+class RuntimeCacheSnapshot:
+    blobs: list[Any]
+    block_ids: KVBlockIds
+    first_seq_blocks: tuple[int, ...]
+    num_tokens: int
+
+@dataclass
+class RuntimeCacheRequest:
+    req_id: str
+    block_ids: KVBlockIds
+    first_seq_blocks: tuple[int, ...]
+    num_computed_tokens: int
+    cache_slot_id: int | None = None
+
+@dataclass
+class RuntimeCacheSnapshotIndexNode:
+    children: dict[int, "RuntimeCacheSnapshotIndexNode"] = field(default_factory=dict)
+    best_req_id: str | None = None
+    best_num_tokens: int = 0
+```
+
+## Boundary With Upstream vLLM
+
+The boundary between upstream scheduler-side KV management and Mobilint
+runtime-side cache management is the block ID layout emitted by upstream
+`KVCacheBlocks.get_block_ids()` and delivered through `SchedulerOutput`:
+
+```python
+tuple[list[int], ...]
+```
+
+`MbltRuntimeCacheManager` should treat this shape as its input contract. It
+should not own vLLM `Request` objects, upstream block pools, or upstream prefix
+hashing state.
+
+## Responsibilities of `MbltRuntimeCacheManager`
+
+The new manager should own:
+
+1. Block ID utilities
+   - normalize block ID layout
+   - append newly allocated block IDs
+   - extract first-sequence block IDs
+   - calculate required block counts
+
+2. Runtime cache snapshot repository
+   - request ID to snapshot mapping
+   - snapshot prefix index
+   - best-prefix lookup
+   - finished snapshot LRU cap
+
+3. Live runtime cache ownership
+   - single-cache live owner tracking
+   - batch cache slot assignment
+   - cache slot release and reuse
+
+4. Runtime dump/load policy
+   - decide when a snapshot should be dumped
+   - load own snapshot when fully compatible
+   - load shared prefix snapshot when useful
+   - reuse live accelerator cache for the same request
+   - handle cache miss fallback
+
+5. Finished-request cache handling
+   - dump final snapshots when appropriate
+   - keep finished snapshots for cross-request prefix reuse
+   - evict old finished snapshots with LRU policy
+
+## Responsibilities That Should Stay in `MbltWorker`
+
+`MbltWorker` should continue to own:
+
+- vLLM `WorkerBase` interface methods
+- model/runtime object lifecycle
+- prompt embedding and deepstack embedding construction
+- Mobilint model inference calls
+- sampling metadata and logits processing
+- request execution orchestration based on `SchedulerOutput`
+- actual qbruntime/cache-model calls through small adapter methods
+
+The worker should provide runtime cache IO callables to the manager:
+
+```python
+def _dump_runtime_cache(self, slot_id: int | None = None) -> list[Any] | None:
+    ...
+
+def _load_runtime_cache(self, blobs: list[Any], slot_id: int | None = None) -> bool:
+    ...
+```
+
+`MbltRuntimeCacheManager` should call these injected functions rather than
+importing or owning qbruntime/cache-model objects directly.
+
+## Backward Compatibility Policy
+
+Backward compatibility for internal APIs is intentionally not required for this
+refactor.
+
+The package is still pre-1.0, and internal APIs may continue to break before
+1.0.0. After 1.0.0, compatibility should be treated more conservatively.
+
+This means the refactor does not need to preserve imports or direct attributes
+such as:
+
+- `vllm_mblt.mblt_worker.CacheSnapshot`
+- `vllm_mblt.mblt_worker.SnapshotIndexNode`
+- `MbltWorker.cache_snapshots`
+- `MbltWorker.snapshot_index_root`
+- `MbltWorker.loaded_cache_req_id`
+- `MbltWorker.req_to_cache_slot`
+- `MbltWorker.cache_slot_to_req`
+- `MbltWorker.free_cache_slots`
+
+Breaking changes should be recorded in `CHANGELOG.md`.
+
+## Proposed Implementation Steps
+
+1. Add `vllm_mblt/runtime_cache.py`.
+2. Move runtime cache dataclasses and block-ID helpers from `MbltWorker` into
+   the new module.
+3. Implement `MbltRuntimeCacheManager` with snapshot repository, prefix index,
+   live-cache ownership, and batch slot management.
+4. Update `MbltWorker` to instantiate `self.runtime_cache` and delegate cache
+   decisions to it.
+5. Remove cache-specific mutable state and helper methods from `MbltWorker`.
+6. Add `CHANGELOG.md` with breaking changes only.
+7. Replace string-based cache tests with behavior-oriented tests for
+   `MbltRuntimeCacheManager`.
+8. Update worker tests to use the new module and stop depending on old worker
+   internals.
+
+## Test Plan
+
+Add focused unit tests for `vllm_mblt.runtime_cache` covering:
+
+- block ID normalization and append behavior
+- block layout mismatch errors
+- first-sequence block extraction
+- prefix-compatible token calculation
+- snapshot index lookup behavior
+- own snapshot priority
+- shared prefix snapshot reuse
+- live cache reuse for the same request
+- cache miss fallback
+- finished snapshot LRU eviction
+- batch slot allocation/release
+- slot-scoped dump/load behavior
+
+Then run, where possible:
+
+```bash
+uv run pytest tests
+uv run ruff check .
+```
+
+If full dependency installation is unavailable, run the dependency-light runtime
+cache tests separately and document any skipped validation.
+
+## Changelog Plan
+
+Create `CHANGELOG.md` and record only breaking changes for this refactor.
+
+Expected entries:
+
+- Moved Mobilint runtime cache snapshot, live-cache ownership, and accelerator
+  cache slot handling out of `MbltWorker` into
+  `vllm_mblt.runtime_cache.MbltRuntimeCacheManager`.
+- Removed compatibility guarantees for old cache-related `MbltWorker` internals.
+- Removed direct imports of cache implementation details from
+  `vllm_mblt.mblt_worker`.
+- Documented that pre-1.0 releases may introduce breaking internal API changes;
+  backward compatibility is planned after 1.0.0.

--- a/tests/test_kv_cache_swap_spec.py
+++ b/tests/test_kv_cache_swap_spec.py
@@ -40,6 +40,8 @@ def _make_worker(*, max_batch_size: int = 1, block_size: int = 4) -> MbltWorker:
         max_batch_size=max_batch_size,
         block_size=block_size,
         max_finished_snapshots=MbltWorker.MAX_FINISHED_CACHE_SNAPSHOTS,
+        dump_runtime_cache=worker._dump_runtime_cache,
+        load_runtime_cache=worker._load_runtime_cache,
     )
     return worker
 
@@ -169,9 +171,9 @@ class TestKvCacheSwapBehavior:
                 first_seq_blocks=(block_id,),
                 num_tokens=4,
             )
-            worker._touch_finished_snapshot(req_id)
+            worker.runtime_cache.touch_finished_snapshot(req_id)
 
-        worker._evict_old_finished_snapshots()
+        worker.runtime_cache.evict_old_finished_snapshots()
 
         assert worker.runtime_cache.get_snapshot("a") is None
         assert worker.runtime_cache.get_snapshot("b") is not None

--- a/tests/test_kv_cache_swap_spec.py
+++ b/tests/test_kv_cache_swap_spec.py
@@ -1,118 +1,198 @@
-import re
-from pathlib import Path
+from types import SimpleNamespace
 
-ROOT = Path(__file__).resolve().parents[1]
-WORKER_PATH = ROOT / "vllm_mblt" / "mblt_worker.py"
-RUNTIME_CACHE_PATH = ROOT / "vllm_mblt" / "runtime_cache.py"
-WORKER_CODE = WORKER_PATH.read_text(encoding="utf-8")
-RUNTIME_CACHE_CODE = RUNTIME_CACHE_PATH.read_text(encoding="utf-8")
+import numpy as np
+import pytest
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import LogitsProcessors
+
+from vllm_mblt.mblt_worker import MbltWorker, RequestState
+from vllm_mblt.runtime_cache import MbltRuntimeCacheManager
 
 
-class TestKvCacheSwapSpec:
-    """Spec-style tests for qbruntime cache swap integration.
+class RecordingCacheModel:
+    def __init__(self) -> None:
+        self.dumps: list[dict[str, int | None]] = []
+        self.loads: list[tuple[list[object], int | None]] = []
 
-    These tests are intentionally strict to provide a clear before/after signal.
-    They validate that worker code contains the required hooks for:
-    - session cache dump/load
-    - cache_size-based prefix reuse after cache load
-    - avoiding single-page shortcut mapping
-    """
+    def dump_cache_memory(self, cache_id: int | None = None) -> list[object]:
+        self.dumps.append({"cache_id": cache_id})
+        return [f"dump:{len(self.dumps)}:{cache_id}"]
 
-    def test_has_cache_dump_and_load_hooks(self) -> None:
-        assert "dump_cache_memory(" in WORKER_CODE, (
-            "Expected dump_cache_memory() hook for persisting per-session cache snapshots."
+    def load_cache_memory(self, blobs: list[object], cache_id: int | None = None) -> None:
+        self.loads.append((blobs, cache_id))
+
+
+def _make_worker(*, max_batch_size: int = 1, block_size: int = 4) -> MbltWorker:
+    worker = MbltWorker.__new__(MbltWorker)
+    worker.max_batch_size = max_batch_size
+    worker.vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        model_config=SimpleNamespace(max_model_len=128, hf_config=SimpleNamespace(model_type="qwen2")),
+    )
+    worker.model_config = worker.vllm_config.model_config
+    worker.model = SimpleNamespace(config=SimpleNamespace(vocab_size=32000))
+    worker.cache_model = RecordingCacheModel()
+    worker.req_states = {}
+    worker._warned_batch_cache_snapshot_unsupported = False
+    worker.empty_logits_processors = LogitsProcessors(None)
+    worker.empty_prompt_token_ids = None
+    worker.runtime_cache = MbltRuntimeCacheManager(
+        max_batch_size=max_batch_size,
+        block_size=block_size,
+        max_finished_snapshots=MbltWorker.MAX_FINISHED_CACHE_SNAPSHOTS,
+    )
+    return worker
+
+
+def _make_request_state(
+    worker: MbltWorker,
+    *,
+    block_ids: tuple[list[int], ...] = ([1],),
+    num_computed_tokens: int = 0,
+    prompt_len: int = 0,
+    output_token_ids: list[int] | None = None,
+    cache_slot_id: int | None = None,
+) -> RequestState:
+    sampling_params = SamplingParams.from_optional()
+    prompt_token_ids = list(range(prompt_len))
+    return RequestState(
+        is_prefill=False,
+        output_token_ids=output_token_ids or [],
+        sampling_params=sampling_params,
+        cached_sampling_state=worker._make_cached_sampling_state(sampling_params, prompt_token_ids),
+        block_ids=block_ids,
+        first_seq_blocks=tuple(block_ids[0]) if block_ids else (),
+        num_computed_tokens=num_computed_tokens,
+        num_output_tokens=0,
+        prompt_embeds=np.zeros((prompt_len, 2), dtype=np.float32),
+        prompt_deepstack_embeds=None,
+        is_multimodal=False,
+        prompt_len=prompt_len,
+        prompt_token_ids=prompt_token_ids,
+        cache_slot_id=cache_slot_id,
+        vlm_session_id=None,
+    )
+
+
+class TestKvCacheSwapBehavior:
+    def test_dump_snapshot_stores_runtime_cache_snapshot(self) -> None:
+        worker = _make_worker(block_size=4)
+        req_state = _make_request_state(worker, block_ids=([7, 8],), num_computed_tokens=6)
+
+        assert worker._dump_snapshot("req", req_state, next_num_tokens=6)
+
+        snapshot = worker.runtime_cache.get_snapshot("req")
+        assert snapshot is not None
+        assert snapshot.blobs == ["dump:1:None"]
+        assert snapshot.block_ids == ([7, 8],)
+        assert snapshot.first_seq_blocks == (7, 8)
+        assert snapshot.num_tokens == 6
+        assert worker.cache_model.dumps == [{"cache_id": None}]
+
+    def test_load_snapshot_if_needed_loads_own_snapshot_and_marks_live_request(self) -> None:
+        worker = _make_worker(block_size=4)
+        req_state = _make_request_state(worker, block_ids=([1, 2],), num_computed_tokens=8)
+        worker.runtime_cache.store_snapshot(
+            req_id="req",
+            blobs=["own-cache"],
+            block_ids=req_state.block_ids,
+            first_seq_blocks=req_state.first_seq_blocks,
+            num_tokens=8,
         )
-        assert "load_cache_memory(" in WORKER_CODE, (
-            "Expected load_cache_memory() hook for restoring selected cache snapshots."
-        )
 
-    def test_load_happens_before_infer_with_cache_size(self) -> None:
-        pattern = re.compile("load_cache_memory\\s*\\(.*?\\).*?infer\\s*\\(.*?cache_size\\s*=", re.DOTALL)
-        assert pattern.search(WORKER_CODE), (
-            "Expected cache restore followed by infer(..., cache_size=...) to bind binary cache "
-            "and effective KV length."
-        )
+        matched_tokens = worker._load_snapshot_if_needed("req", req_state)
 
-    def test_avoids_single_block_id_shortcut(self) -> None:
-        assert "block_ids[0][0]" not in WORKER_CODE, (
-            "Single block-id shortcut breaks paged block compatibility for cache swapping."
-        )
+        assert matched_tokens == 8
+        assert worker.cache_model.loads == [(["own-cache"], None)]
+        assert worker.runtime_cache.loaded_req_id == "req"
+
+    def test_live_cache_is_reused_for_same_request_without_reload(self) -> None:
+        worker = _make_worker(block_size=4)
+        req_state = _make_request_state(worker, block_ids=([1, 2],), num_computed_tokens=8)
+        worker.runtime_cache.mark_loaded_request("req")
+
+        matched_tokens = worker._load_snapshot_if_needed("req", req_state)
+
+        assert matched_tokens == 8
+        assert worker.cache_model.loads == []
+        assert worker.cache_model.dumps == []
+        assert worker.runtime_cache.loaded_req_id == "req"
+
+    def test_switching_requests_dumps_previous_live_request_before_zero_token_skip(self) -> None:
+        worker = _make_worker(block_size=4)
+        live_state = _make_request_state(worker, block_ids=([1, 2],), num_computed_tokens=8)
+        zero_state = _make_request_state(worker, block_ids=([9],), num_computed_tokens=0)
+        worker.req_states["live"] = live_state
+        worker.runtime_cache.mark_loaded_request("live")
+
+        matched_tokens = worker._load_snapshot_if_needed("zero", zero_state)
+
+        assert matched_tokens == 0
+        snapshot = worker.runtime_cache.get_snapshot("live")
+        assert snapshot is not None
+        assert snapshot.num_tokens == 8
+        assert worker.runtime_cache.loaded_req_id is None
+        assert worker.cache_model.dumps == [{"cache_id": None}]
+
+    def test_cache_miss_clears_live_request_and_falls_back_to_recompute(self) -> None:
+        worker = _make_worker(block_size=4)
+        req_state = _make_request_state(worker, block_ids=([1, 2],), num_computed_tokens=8)
+        worker.runtime_cache.mark_loaded_request("other")
+
+        matched_tokens = worker._load_snapshot_if_needed("req", req_state)
+
+        assert matched_tokens == 0
+        assert worker.runtime_cache.loaded_req_id is None
+        assert worker.cache_model.loads == []
+
+    def test_finished_request_keeps_snapshot_for_cross_request_prefix_reuse(self) -> None:
+        worker = _make_worker(block_size=4)
+        req_state = _make_request_state(worker, block_ids=([1, 2],), num_computed_tokens=8)
+        worker.req_states["finished"] = req_state
+        worker.runtime_cache.mark_loaded_request("finished")
+
+        worker._finalize_finished_request("finished")
+
+        assert worker.runtime_cache.get_snapshot("finished") is not None
+        assert list(worker.runtime_cache.finished_snapshot_lru) == ["finished"]
+        assert worker.runtime_cache.loaded_req_id is None
+        assert "finished" not in worker.req_states
+
+    def test_finished_snapshot_pool_is_lru_capped_through_runtime_cache(self) -> None:
+        worker = _make_worker(block_size=4)
+        worker.runtime_cache.max_finished_snapshots = 2
+        for req_id, block_id in (("a", 1), ("b", 2), ("c", 3)):
+            worker.runtime_cache.store_snapshot(
+                req_id=req_id,
+                blobs=[req_id],
+                block_ids=([block_id],),
+                first_seq_blocks=(block_id,),
+                num_tokens=4,
+            )
+            worker._touch_finished_snapshot(req_id)
+
+        worker._evict_old_finished_snapshots()
+
+        assert worker.runtime_cache.get_snapshot("a") is None
+        assert worker.runtime_cache.get_snapshot("b") is not None
+        assert worker.runtime_cache.get_snapshot("c") is not None
+        assert list(worker.runtime_cache.finished_snapshot_lru) == ["b", "c"]
 
     def test_cached_request_block_ids_are_appended_when_not_resumed(self) -> None:
-        assert "if new_block_ids is not None:" in WORKER_CODE, (
-            "Expected cached request updates to consider incremental new_block_ids."
-        )
-        assert "cached_request_state.block_ids = self._append_block_ids(" in WORKER_CODE, (
-            "Expected non-resumed cached requests to append new_block_ids."
-        )
+        worker = _make_worker(block_size=4)
 
-    def test_finished_request_does_not_drop_cache_snapshot(self) -> None:
-        assert "self.cache_snapshots.pop(req_id, None)" not in WORKER_CODE, (
-            "Finished requests should keep cache snapshots for cross-request prefix reuse."
-        )
+        assert worker._append_block_ids(([1], [10]), ([2, 3], [11])) == ([1, 2, 3], [10, 11])
+        with pytest.raises(RuntimeError, match="KV block_ids layout mismatch"):
+            worker._append_block_ids(([1],), ([2], [3]))
 
-    def test_finished_snapshot_pool_is_lru_capped(self) -> None:
-        assert "MAX_FINISHED_CACHE_SNAPSHOTS = 16" in WORKER_CODE, (
-            "Finished-session cache snapshots should be capped at 16 entries."
-        )
-        assert "self._evict_old_finished_snapshots(" in WORKER_CODE, (
-            "Expected eviction hook for finished-session snapshot LRU cap."
-        )
-        assert "def evict_old_finished_snapshots(" in RUNTIME_CACHE_CODE, (
-            "Expected finished-session snapshot LRU implementation in runtime_cache.py."
-        )
+    def test_batch_slot_dump_and_load_use_slot_scoped_runtime_cache(self) -> None:
+        worker = _make_worker(max_batch_size=2, block_size=4)
+        req_state = _make_request_state(worker, block_ids=([1, 2],), num_computed_tokens=8, cache_slot_id=1)
 
-    def test_dump_is_event_driven_not_unconditional(self) -> None:
-        assert "def _should_dump_snapshot_after_step(" in WORKER_CODE, (
-            "Expected explicit policy for event-driven cache dump."
-        )
-        assert "def _dump_loaded_request_before_switch(" in WORKER_CODE, (
-            "Expected live cache owner switch to be the event that can trigger snapshots."
-        )
-        pattern = re.compile(
-            r"def _dump_loaded_request_before_switch\(.*?"
-            r"if not self\._should_dump_snapshot_after_step\(.*?"
-            r"self\._dump_snapshot\(",
-            re.DOTALL,
-        )
-        assert pattern.search(WORKER_CODE), (
-            "Expected request-switch snapshot dumps to be gated by the event-driven policy."
-        )
+        assert worker._dump_snapshot("req", req_state, next_num_tokens=8, slot_id=1)
+        matched_tokens = worker._load_snapshot_if_needed("req", req_state, slot_id=1)
 
-    def test_live_request_avoids_immediate_block_boundary_dump(self) -> None:
-        assert "self.runtime_cache.mark_loaded_request(req_id)" in WORKER_CODE, (
-            "Expected execute loop to track the live accelerator cache owner."
-        )
-        assert "req_state.num_computed_tokens = next_cache_size" in WORKER_CODE, (
-            "Expected post-step token count to advance before a later request switch dump."
-        )
-        immediate_dump_pattern = re.compile(
-            r"req_state\.num_computed_tokens = next_cache_size.*?"
-            r"self\.runtime_cache\.mark_loaded_request\(req_id\).*?"
-            r"self\._dump_snapshot\(",
-            re.DOTALL,
-        )
-        assert not immediate_dump_pattern.search(WORKER_CODE), (
-            "Expected same-request decode to keep the live accelerator cache instead of immediately dumping it."
-        )
-
-    def test_live_cache_is_reused_for_same_request(self) -> None:
-        assert "if self.runtime_cache.loaded_req_id == req_id:" in WORKER_CODE, (
-            "Expected same-request decode path to reuse live accelerator cache."
-        )
-        assert "return target_tokens" in WORKER_CODE, (
-            "Expected live-cache reuse to preserve full computed-token cache_size."
-        )
-
-    def test_switch_dump_precedes_zero_token_skip_load(self) -> None:
-        pattern = re.compile(
-            r"def _load_snapshot_if_needed\(.*?"
-            r"target_tokens = req_state\.num_computed_tokens.*?"
-            r"self\._dump_loaded_request_before_switch\(.*?"
-            r"if target_tokens <= 0:",
-            re.DOTALL,
-        )
-        assert pattern.search(WORKER_CODE), (
-            "Expected live cache owner to be dumped before zero-token requests clear "
-            "runtime_cache.loaded_req_id."
-        )
+        assert matched_tokens == 8
+        assert worker.cache_model.dumps == [{"cache_id": 1}]
+        assert worker.cache_model.loads == [(["dump:1:1"], 1)]
+        assert worker.runtime_cache.live_slot_owner(1) == "req"

--- a/tests/test_kv_cache_swap_spec.py
+++ b/tests/test_kv_cache_swap_spec.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKER_PATH = ROOT / "vllm_mblt" / "mblt_worker.py"
+RUNTIME_CACHE_PATH = ROOT / "vllm_mblt" / "runtime_cache.py"
 WORKER_CODE = WORKER_PATH.read_text(encoding="utf-8")
+RUNTIME_CACHE_CODE = RUNTIME_CACHE_PATH.read_text(encoding="utf-8")
 
 
 class TestKvCacheSwapSpec:
@@ -56,6 +58,9 @@ class TestKvCacheSwapSpec:
         assert "self._evict_old_finished_snapshots(" in WORKER_CODE, (
             "Expected eviction hook for finished-session snapshot LRU cap."
         )
+        assert "def evict_old_finished_snapshots(" in RUNTIME_CACHE_CODE, (
+            "Expected finished-session snapshot LRU implementation in runtime_cache.py."
+        )
 
     def test_dump_is_event_driven_not_unconditional(self) -> None:
         assert "def _should_dump_snapshot_after_step(" in WORKER_CODE, (
@@ -75,7 +80,7 @@ class TestKvCacheSwapSpec:
         )
 
     def test_live_request_avoids_immediate_block_boundary_dump(self) -> None:
-        assert "self.loaded_cache_req_id = req_id" in WORKER_CODE, (
+        assert "self.runtime_cache.mark_loaded_request(req_id)" in WORKER_CODE, (
             "Expected execute loop to track the live accelerator cache owner."
         )
         assert "req_state.num_computed_tokens = next_cache_size" in WORKER_CODE, (
@@ -83,7 +88,7 @@ class TestKvCacheSwapSpec:
         )
         immediate_dump_pattern = re.compile(
             r"req_state\.num_computed_tokens = next_cache_size.*?"
-            r"self\.loaded_cache_req_id = req_id.*?"
+            r"self\.runtime_cache\.mark_loaded_request\(req_id\).*?"
             r"self\._dump_snapshot\(",
             re.DOTALL,
         )
@@ -92,7 +97,7 @@ class TestKvCacheSwapSpec:
         )
 
     def test_live_cache_is_reused_for_same_request(self) -> None:
-        assert "if self.loaded_cache_req_id == req_id:" in WORKER_CODE, (
+        assert "if self.runtime_cache.loaded_req_id == req_id:" in WORKER_CODE, (
             "Expected same-request decode path to reuse live accelerator cache."
         )
         assert "return target_tokens" in WORKER_CODE, (
@@ -109,5 +114,5 @@ class TestKvCacheSwapSpec:
         )
         assert pattern.search(WORKER_CODE), (
             "Expected live cache owner to be dumped before zero-token requests clear "
-            "loaded_cache_req_id."
+            "runtime_cache.loaded_req_id."
         )

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -12,7 +12,7 @@ from vllm_mblt.mblt_worker import (
     _is_multimodal_hf_config,
     _is_qwen3_vl_hf_config,
 )
-from vllm_mblt.runtime_cache import MbltRuntimeCacheManager, RuntimeCacheSnapshot
+from vllm_mblt.runtime_cache import MbltRuntimeCacheManager
 
 
 class TestMbltWorkerOptimizations:
@@ -174,14 +174,22 @@ class TestMbltWorkerOptimizations:
 
     def test_snapshot_index_can_prefer_shallower_prefix_with_more_tokens(self) -> None:
         worker = self._make_worker()
-        short_shared = RuntimeCacheSnapshot(
-            blobs=[], block_ids=([1, 2, 8],), first_seq_blocks=(1, 2, 8), num_tokens=384
+        worker.runtime_cache.store_snapshot(
+            req_id="short_shared",
+            blobs=[],
+            block_ids=([1, 2, 8],),
+            first_seq_blocks=(1, 2, 8),
+            num_tokens=384,
         )
-        deep_but_short = RuntimeCacheSnapshot(
-            blobs=[], block_ids=([1, 2, 3, 7],), first_seq_blocks=(1, 2, 3, 7), num_tokens=100
+        short_shared = worker.runtime_cache.get_snapshot("short_shared")
+        assert short_shared is not None
+        worker.runtime_cache.store_snapshot(
+            req_id="deep_but_short",
+            blobs=[],
+            block_ids=([1, 2, 3, 7],),
+            first_seq_blocks=(1, 2, 3, 7),
+            num_tokens=100,
         )
-        worker.runtime_cache.snapshots = {"short_shared": short_shared, "deep_but_short": deep_but_short}
-        worker._rebuild_snapshot_index()
         req_state = SimpleNamespace(num_computed_tokens=300, first_seq_blocks=(1, 2, 3, 9))
         snapshot, matched_tokens = worker._choose_snapshot(req_state)
         assert snapshot is short_shared

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -7,13 +7,12 @@ from vllm.sampling_params import SamplingParams
 from vllm.v1.sample.logits_processor import LogitsProcessors
 
 from vllm_mblt.mblt_worker import (
-    CacheSnapshot,
     MbltWorker,
     RequestState,
-    SnapshotIndexNode,
     _is_multimodal_hf_config,
     _is_qwen3_vl_hf_config,
 )
+from vllm_mblt.runtime_cache import MbltRuntimeCacheManager, RuntimeCacheSnapshot
 
 
 class TestMbltWorkerOptimizations:
@@ -136,8 +135,7 @@ class TestMbltWorkerOptimizations:
         worker.model = SimpleNamespace(config=SimpleNamespace(vocab_size=32000))
         worker.empty_logits_processors = LogitsProcessors(None)
         worker.empty_prompt_token_ids = torch.empty((0, 0), dtype=torch.int64)
-        worker.snapshot_index_root = SnapshotIndexNode()
-        worker.cache_snapshots = {}
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=1, block_size=128)
         worker._vlm_image_positions_by_session = {}
         return worker
 
@@ -176,11 +174,13 @@ class TestMbltWorkerOptimizations:
 
     def test_snapshot_index_can_prefer_shallower_prefix_with_more_tokens(self) -> None:
         worker = self._make_worker()
-        short_shared = CacheSnapshot(blobs=[], block_ids=([1, 2, 8],), first_seq_blocks=(1, 2, 8), num_tokens=384)
-        deep_but_short = CacheSnapshot(
+        short_shared = RuntimeCacheSnapshot(
+            blobs=[], block_ids=([1, 2, 8],), first_seq_blocks=(1, 2, 8), num_tokens=384
+        )
+        deep_but_short = RuntimeCacheSnapshot(
             blobs=[], block_ids=([1, 2, 3, 7],), first_seq_blocks=(1, 2, 3, 7), num_tokens=100
         )
-        worker.cache_snapshots = {"short_shared": short_shared, "deep_but_short": deep_but_short}
+        worker.runtime_cache.snapshots = {"short_shared": short_shared, "deep_but_short": deep_but_short}
         worker._rebuild_snapshot_index()
         req_state = SimpleNamespace(num_computed_tokens=300, first_seq_blocks=(1, 2, 3, 9))
         snapshot, matched_tokens = worker._choose_snapshot(req_state)
@@ -479,7 +479,7 @@ class TestMbltWorkerOptimizations:
         worker = MbltWorker(config, local_rank=0, rank=0, distributed_init_method="env://")
 
         assert worker.max_batch_size == 4
-        assert worker.free_cache_slots == [0, 1, 2, 3]
+        assert worker.runtime_cache.free_slots == [0, 1, 2, 3]
 
     def test_init_uses_shared_text_only_max_batch_size_for_cache_slots(self, monkeypatch) -> None:
         def worker_base_init(self, vllm_config, local_rank, rank, distributed_init_method, is_driver_worker=False):
@@ -500,7 +500,7 @@ class TestMbltWorkerOptimizations:
         worker = MbltWorker(config, local_rank=0, rank=0, distributed_init_method="env://")
 
         assert worker.max_batch_size == 16
-        assert worker.free_cache_slots == list(range(16))
+        assert worker.runtime_cache.free_slots == list(range(16))
 
     def test_load_model_passes_text_runtime_layout_kwargs_to_from_pretrained(self, monkeypatch) -> None:
         worker = MbltWorker.__new__(MbltWorker)
@@ -510,9 +510,7 @@ class TestMbltWorkerOptimizations:
         worker.cache_model = None
         worker._infer_output_buffers = None
         worker.max_batch_size = 1
-        worker.req_to_cache_slot = {}
-        worker.cache_slot_to_req = {}
-        worker.free_cache_slots = []
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=1, block_size=128)
         worker.load_config = SimpleNamespace(
             model_loader_extra_config={
                 "dev_no": 2,
@@ -580,9 +578,7 @@ class TestMbltWorkerOptimizations:
         worker.cache_model = None
         worker._infer_output_buffers = None
         worker.max_batch_size = 1
-        worker.req_to_cache_slot = {}
-        worker.cache_slot_to_req = {}
-        worker.free_cache_slots = []
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=1, block_size=128)
         worker.load_config = SimpleNamespace(
             model_loader_extra_config={
                 "dev_no": 0,

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -12,7 +12,7 @@ from vllm_mblt.mblt_worker import (
     _is_multimodal_hf_config,
     _is_qwen3_vl_hf_config,
 )
-from vllm_mblt.runtime_cache import MbltRuntimeCacheManager
+from vllm_mblt.runtime_cache import MbltRuntimeCacheManager, RuntimeCacheRequest, RuntimeCacheSnapshot
 
 
 class TestMbltWorkerOptimizations:
@@ -191,7 +191,15 @@ class TestMbltWorkerOptimizations:
             num_tokens=100,
         )
         req_state = SimpleNamespace(num_computed_tokens=300, first_seq_blocks=(1, 2, 3, 9))
-        snapshot, matched_tokens = worker._choose_snapshot(req_state)
+        match = worker.runtime_cache.choose_snapshot(
+            RuntimeCacheRequest(
+                req_id="",
+                block_ids=(),
+                first_seq_blocks=req_state.first_seq_blocks,
+                num_computed_tokens=req_state.num_computed_tokens,
+            )
+        )
+        snapshot, matched_tokens = match
         assert snapshot is short_shared
         assert matched_tokens == 256
 

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -12,7 +12,7 @@ from vllm_mblt.mblt_worker import (
     _is_multimodal_hf_config,
     _is_qwen3_vl_hf_config,
 )
-from vllm_mblt.runtime_cache import MbltRuntimeCacheManager, RuntimeCacheRequest, RuntimeCacheSnapshot
+from vllm_mblt.runtime_cache import MbltRuntimeCacheManager, RuntimeCacheRequest
 
 
 class TestMbltWorkerOptimizations:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -1,0 +1,117 @@
+from vllm_mblt.runtime_cache import MbltRuntimeCacheManager, RuntimeCacheRequest
+
+
+def _put_snapshot(
+    manager: MbltRuntimeCacheManager,
+    req_id: str,
+    blocks: list[int],
+    tokens: int,
+) -> None:
+    manager.put_snapshot(
+        req_id=req_id,
+        blobs=[f"blob:{req_id}"],
+        block_ids=(blocks,),
+        num_tokens=tokens,
+    )
+
+
+class TestMbltRuntimeCacheManagerSnapshots:
+    def test_best_prefix_lookup_uses_deepest_indexed_match(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4)
+        _put_snapshot(manager, "short", [1], 4)
+        _put_snapshot(manager, "long", [1, 2, 3], 12)
+
+        match = manager.choose_prefix_snapshot((1, 2, 9), target_tokens=10)
+
+        assert match.req_id == "long"
+        assert match.snapshot is manager.get_snapshot("long")
+        assert match.matched_tokens == 8
+        assert not match.is_own_snapshot
+
+    def test_own_snapshot_has_priority_when_fully_compatible(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4)
+        _put_snapshot(manager, "other", [1, 2, 3], 12)
+        _put_snapshot(manager, "req", [1, 2], 8)
+
+        match = manager.choose_snapshot(
+            RuntimeCacheRequest(
+                req_id="req",
+                block_ids=([1, 2],),
+                first_seq_blocks=(1, 2),
+                num_computed_tokens=8,
+            )
+        )
+
+        assert match.req_id == "req"
+        assert match.snapshot is manager.get_snapshot("req")
+        assert match.matched_tokens == 8
+        assert match.is_own_snapshot
+
+    def test_partial_own_snapshot_falls_back_to_best_shared_prefix(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4)
+        _put_snapshot(manager, "req", [1], 4)
+        _put_snapshot(manager, "other", [1, 2, 3], 12)
+
+        match = manager.choose_snapshot(
+            RuntimeCacheRequest(
+                req_id="req",
+                block_ids=([1, 2, 3],),
+                first_seq_blocks=(1, 2, 3),
+                num_computed_tokens=10,
+            )
+        )
+
+        assert match.req_id == "other"
+        assert match.snapshot is manager.get_snapshot("other")
+        assert match.matched_tokens == 10
+        assert not match.is_own_snapshot
+
+    def test_snapshot_update_and_removal_refresh_prefix_index(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4)
+        _put_snapshot(manager, "req", [1, 2], 8)
+
+        assert manager.choose_prefix_snapshot((1, 2), target_tokens=8).req_id == "req"
+
+        _put_snapshot(manager, "req", [5, 6], 8)
+
+        assert manager.choose_prefix_snapshot((1, 2), target_tokens=8).snapshot is None
+        assert manager.choose_prefix_snapshot((5, 6), target_tokens=8).req_id == "req"
+
+        removed = manager.remove_snapshot("req")
+
+        assert removed is not None
+        assert manager.choose_prefix_snapshot((5, 6), target_tokens=8).snapshot is None
+
+    def test_finished_snapshot_lru_cap_evicts_oldest_and_rebuilds_index(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4, max_finished_cache_snapshots=2)
+        _put_snapshot(manager, "a", [1], 4)
+        _put_snapshot(manager, "b", [2], 4)
+        _put_snapshot(manager, "c", [3], 4)
+
+        assert manager.mark_snapshot_finished("a") == []
+        assert manager.mark_snapshot_finished("b") == []
+        manager.loaded_cache_req_id = "a"
+        evicted = manager.mark_snapshot_finished("c")
+
+        assert evicted == ["a"]
+        assert manager.get_snapshot("a") is None
+        assert manager.loaded_cache_req_id is None
+        assert list(manager.finished_snapshot_lru) == ["b", "c"]
+        assert manager.choose_prefix_snapshot((1,), target_tokens=4).snapshot is None
+        assert manager.choose_prefix_snapshot((2,), target_tokens=4).req_id == "b"
+
+    def test_finished_snapshot_lru_touch_preserves_recent_snapshot(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4, max_finished_cache_snapshots=2)
+        _put_snapshot(manager, "a", [1], 4)
+        _put_snapshot(manager, "b", [2], 4)
+        _put_snapshot(manager, "c", [3], 4)
+
+        manager.mark_snapshot_finished("a")
+        manager.mark_snapshot_finished("b")
+        manager.mark_snapshot_finished("a")
+        evicted = manager.mark_snapshot_finished("c")
+
+        assert evicted == ["b"]
+        assert list(manager.finished_snapshot_lru) == ["a", "c"]
+        assert manager.get_snapshot("a") is not None
+        assert manager.get_snapshot("b") is None

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -1,117 +1,203 @@
-from vllm_mblt.runtime_cache import MbltRuntimeCacheManager, RuntimeCacheRequest
+import pytest
+
+from vllm_mblt.runtime_cache import (
+    MbltRuntimeCacheManager,
+    RuntimeCacheRequest,
+    append_block_ids,
+    first_seq_blocks,
+    normalize_block_ids,
+    prefix_compatible_tokens,
+)
 
 
-def _put_snapshot(
+def _request(req_id: str, blocks: tuple[int, ...], tokens: int) -> RuntimeCacheRequest:
+    return RuntimeCacheRequest(
+        req_id=req_id,
+        block_ids=(list(blocks),),
+        first_seq_blocks=blocks,
+        num_computed_tokens=tokens,
+    )
+
+
+def _store_snapshot(
     manager: MbltRuntimeCacheManager,
     req_id: str,
-    blocks: list[int],
+    blocks: tuple[int, ...],
     tokens: int,
+    blobs: list[object] | None = None,
 ) -> None:
-    manager.put_snapshot(
+    manager.store_snapshot(
         req_id=req_id,
-        blobs=[f"blob:{req_id}"],
-        block_ids=(blocks,),
+        blobs=blobs if blobs is not None else [f"blob:{req_id}"],
+        block_ids=(list(blocks),),
+        first_seq_blocks=blocks,
         num_tokens=tokens,
     )
 
 
-class TestMbltRuntimeCacheManagerSnapshots:
-    def test_best_prefix_lookup_uses_deepest_indexed_match(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4)
-        _put_snapshot(manager, "short", [1], 4)
-        _put_snapshot(manager, "long", [1, 2, 3], 12)
+class TestRuntimeCacheBlockHelpers:
+    def test_normalize_block_ids_copies_sequences_and_append_preserves_layout(self) -> None:
+        source = ([1, 2], [3])
 
-        match = manager.choose_prefix_snapshot((1, 2, 9), target_tokens=10)
+        normalized = normalize_block_ids(source)
+        appended = append_block_ids(normalized, ([4], [5, 6]))
+
+        source[0].append(99)
+        assert normalized == ([1, 2], [3])
+        assert appended == ([1, 2, 4], [3, 5, 6])
+        assert appended is not normalized
+
+    def test_append_initializes_empty_block_ids_from_new_layout(self) -> None:
+        new_blocks = ([10], [20, 21])
+
+        appended = append_block_ids((), new_blocks)
+
+        new_blocks[0].append(99)
+
+        assert appended == ([10], [20, 21])
+
+    def test_append_raises_for_block_layout_mismatch(self) -> None:
+        with pytest.raises(RuntimeError, match="layout mismatch"):
+            append_block_ids(([1], [2]), ([3],))
+
+    def test_first_seq_blocks_extracts_first_sequence_or_empty_tuple(self) -> None:
+        assert first_seq_blocks(([1, 2], [3, 4])) == (1, 2)
+        assert first_seq_blocks(()) == ()
+
+    @pytest.mark.parametrize(
+        ("target_blocks", "target_tokens", "snapshot_blocks", "snapshot_tokens", "expected"),
+        [
+            ((1, 2), 0, (1, 2), 8, 0),
+            ((1, 2), 8, (9, 2), 8, 0),
+            ((1, 2, 3), 10, (1, 2, 9), 12, 8),
+            ((1, 2, 3), 10, (1, 2, 3), 6, 6),
+            ((1, 2, 3), 10, (1, 2, 3), 12, 10),
+        ],
+    )
+    def test_prefix_compatible_tokens_caps_by_prefix_target_and_snapshot(
+        self,
+        target_blocks: tuple[int, ...],
+        target_tokens: int,
+        snapshot_blocks: tuple[int, ...],
+        snapshot_tokens: int,
+        expected: int,
+    ) -> None:
+        assert prefix_compatible_tokens(target_blocks, target_tokens, snapshot_blocks, snapshot_tokens, 4) == expected
+
+
+class TestMbltRuntimeCacheManagerSnapshots:
+    def test_snapshot_index_lookup_uses_deepest_compatible_prefix(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4)
+        _store_snapshot(manager, "short", (1,), 4)
+        _store_snapshot(manager, "long", (1, 2, 3), 12)
+
+        match = manager.choose_prefix_snapshot(_request("req", (1, 2, 9), 10))
 
         assert match.req_id == "long"
         assert match.snapshot is manager.get_snapshot("long")
         assert match.matched_tokens == 8
-        assert not match.is_own_snapshot
 
     def test_own_snapshot_has_priority_when_fully_compatible(self) -> None:
         manager = MbltRuntimeCacheManager(block_size=4)
-        _put_snapshot(manager, "other", [1, 2, 3], 12)
-        _put_snapshot(manager, "req", [1, 2], 8)
+        _store_snapshot(manager, "other", (1, 2, 3), 12)
+        _store_snapshot(manager, "req", (1, 2), 8)
 
-        match = manager.choose_snapshot(
-            RuntimeCacheRequest(
-                req_id="req",
-                block_ids=([1, 2],),
-                first_seq_blocks=(1, 2),
-                num_computed_tokens=8,
-            )
-        )
+        snapshot, matched_tokens = manager.choose_snapshot(_request("req", (1, 2), 8))
 
-        assert match.req_id == "req"
-        assert match.snapshot is manager.get_snapshot("req")
-        assert match.matched_tokens == 8
-        assert match.is_own_snapshot
+        assert snapshot is manager.get_snapshot("req")
+        assert matched_tokens == 8
 
-    def test_partial_own_snapshot_falls_back_to_best_shared_prefix(self) -> None:
+    def test_shared_prefix_snapshot_reuse_when_own_snapshot_is_partial(self) -> None:
         manager = MbltRuntimeCacheManager(block_size=4)
-        _put_snapshot(manager, "req", [1], 4)
-        _put_snapshot(manager, "other", [1, 2, 3], 12)
+        _store_snapshot(manager, "req", (1,), 4)
+        _store_snapshot(manager, "other", (1, 2, 3), 12)
 
-        match = manager.choose_snapshot(
-            RuntimeCacheRequest(
-                req_id="req",
-                block_ids=([1, 2, 3],),
-                first_seq_blocks=(1, 2, 3),
-                num_computed_tokens=10,
-            )
-        )
+        snapshot, matched_tokens = manager.choose_snapshot(_request("req", (1, 2, 3), 10))
 
-        assert match.req_id == "other"
-        assert match.snapshot is manager.get_snapshot("other")
-        assert match.matched_tokens == 10
-        assert not match.is_own_snapshot
+        assert snapshot is manager.get_snapshot("other")
+        assert matched_tokens == 10
+
+    def test_cache_miss_fallback_returns_no_snapshot_or_tokens(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4)
+        _store_snapshot(manager, "other", (1, 2), 8)
+
+        snapshot, matched_tokens = manager.choose_snapshot(_request("req", (9, 2), 8))
+
+        assert snapshot is None
+        assert matched_tokens == 0
 
     def test_snapshot_update_and_removal_refresh_prefix_index(self) -> None:
         manager = MbltRuntimeCacheManager(block_size=4)
-        _put_snapshot(manager, "req", [1, 2], 8)
+        _store_snapshot(manager, "req", (1, 2), 8)
 
-        assert manager.choose_prefix_snapshot((1, 2), target_tokens=8).req_id == "req"
+        assert manager.choose_prefix_snapshot(_request("new", (1, 2), 8)).req_id == "req"
+        _store_snapshot(manager, "req", (5, 6), 8)
 
-        _put_snapshot(manager, "req", [5, 6], 8)
+        assert manager.choose_prefix_snapshot(_request("new", (1, 2), 8)).snapshot is None
+        assert manager.choose_prefix_snapshot(_request("new", (5, 6), 8)).req_id == "req"
+        assert manager.remove_snapshot("req") is not None
+        assert manager.choose_prefix_snapshot(_request("new", (5, 6), 8)).snapshot is None
 
-        assert manager.choose_prefix_snapshot((1, 2), target_tokens=8).snapshot is None
-        assert manager.choose_prefix_snapshot((5, 6), target_tokens=8).req_id == "req"
+    def test_live_cache_reuse_for_same_request_is_tracked_without_snapshot_load(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4)
 
-        removed = manager.remove_snapshot("req")
+        manager.mark_loaded_request("req")
 
-        assert removed is not None
-        assert manager.choose_prefix_snapshot((5, 6), target_tokens=8).snapshot is None
+        assert manager.loaded_req_id == "req"
+        manager.clear_loaded_request("other")
+        assert manager.loaded_req_id == "req"
+        manager.clear_loaded_request("req")
+        assert manager.loaded_req_id is None
 
-    def test_finished_snapshot_lru_cap_evicts_oldest_and_rebuilds_index(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4, max_finished_cache_snapshots=2)
-        _put_snapshot(manager, "a", [1], 4)
-        _put_snapshot(manager, "b", [2], 4)
-        _put_snapshot(manager, "c", [3], 4)
+    def test_finished_snapshot_lru_eviction_removes_snapshot_index_and_live_owner(self) -> None:
+        manager = MbltRuntimeCacheManager(block_size=4, max_finished_snapshots=2)
+        _store_snapshot(manager, "a", (1,), 4)
+        _store_snapshot(manager, "b", (2,), 4)
+        _store_snapshot(manager, "c", (3,), 4)
 
         assert manager.mark_snapshot_finished("a") == []
         assert manager.mark_snapshot_finished("b") == []
-        manager.loaded_cache_req_id = "a"
+        manager.mark_loaded_request("a")
         evicted = manager.mark_snapshot_finished("c")
 
         assert evicted == ["a"]
         assert manager.get_snapshot("a") is None
-        assert manager.loaded_cache_req_id is None
+        assert manager.loaded_req_id is None
         assert list(manager.finished_snapshot_lru) == ["b", "c"]
-        assert manager.choose_prefix_snapshot((1,), target_tokens=4).snapshot is None
-        assert manager.choose_prefix_snapshot((2,), target_tokens=4).req_id == "b"
+        assert manager.choose_prefix_snapshot(_request("new", (1,), 4)).snapshot is None
 
-    def test_finished_snapshot_lru_touch_preserves_recent_snapshot(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4, max_finished_cache_snapshots=2)
-        _put_snapshot(manager, "a", [1], 4)
-        _put_snapshot(manager, "b", [2], 4)
-        _put_snapshot(manager, "c", [3], 4)
 
-        manager.mark_snapshot_finished("a")
-        manager.mark_snapshot_finished("b")
-        manager.mark_snapshot_finished("a")
-        evicted = manager.mark_snapshot_finished("c")
+class TestMbltRuntimeCacheManagerSlots:
+    def test_batch_slot_allocation_release_and_reuse(self) -> None:
+        manager = MbltRuntimeCacheManager(max_batch_size=2, block_size=4)
 
-        assert evicted == ["b"]
-        assert list(manager.finished_snapshot_lru) == ["a", "c"]
-        assert manager.get_snapshot("a") is not None
-        assert manager.get_snapshot("b") is None
+        assert manager.assign_slot("a") == 0
+        assert manager.assign_slot("b") == 1
+        assert manager.assign_slot("a") == 0
+        with pytest.raises(RuntimeError, match="No free accelerator cache slots"):
+            manager.assign_slot("c")
+
+        manager.release_slot("a")
+
+        assert manager.live_slot_owner(0) is None
+        assert manager.assign_slot("c") == 0
+
+    def test_slot_scoped_dump_and_load_pass_cache_id_to_injected_callables(self) -> None:
+        manager = MbltRuntimeCacheManager(max_batch_size=2, block_size=4)
+        dump_calls: list[dict[str, int]] = []
+        load_calls: list[tuple[list[object], dict[str, int]]] = []
+
+        def dump_cache(**kwargs: int) -> list[object]:
+            dump_calls.append(kwargs)
+            return ["dumped", kwargs.get("cache_id")]
+
+        def load_cache(blobs: list[object], **kwargs: int) -> None:
+            load_calls.append((blobs, kwargs))
+
+        assert manager.dump_runtime_cache(dump_cache) == ["dumped", None]
+        assert manager.dump_runtime_cache(dump_cache, slot_id=1) == ["dumped", 1]
+        assert manager.load_runtime_cache(load_cache, ["blob"])
+        assert manager.load_runtime_cache(load_cache, ["slot-blob"], slot_id=1)
+
+        assert dump_calls == [{}, {"cache_id": 1}]
+        assert load_calls == [(["blob"], {}), (["slot-blob"], {"cache_id": 1})]

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -7,7 +7,16 @@ from vllm_mblt.runtime_cache import (
     first_seq_blocks,
     normalize_block_ids,
     prefix_compatible_tokens,
+    required_blocks,
 )
+
+
+def _make_manager(*, block_size: int = 4, max_batch_size: int = 2, max_finished_snapshots: int = 16):
+    return MbltRuntimeCacheManager(
+        max_batch_size=max_batch_size,
+        block_size=block_size,
+        max_finished_snapshots=max_finished_snapshots,
+    )
 
 
 def _request(req_id: str, blocks: tuple[int, ...], tokens: int) -> RuntimeCacheRequest:
@@ -22,30 +31,37 @@ def _request(req_id: str, blocks: tuple[int, ...], tokens: int) -> RuntimeCacheR
 def _store_snapshot(
     manager: MbltRuntimeCacheManager,
     req_id: str,
-    blocks: tuple[int, ...],
+    blocks: tuple[int, ...] | list[int],
     tokens: int,
+    *,
     blobs: list[object] | None = None,
 ) -> None:
+    block_tuple = tuple(blocks)
+    block_ids = (list(block_tuple),)
     manager.store_snapshot(
         req_id=req_id,
         blobs=blobs if blobs is not None else [f"blob:{req_id}"],
-        block_ids=(list(blocks),),
-        first_seq_blocks=blocks,
+        block_ids=block_ids,
+        first_seq_blocks=first_seq_blocks(block_ids),
         num_tokens=tokens,
     )
 
 
 class TestRuntimeCacheBlockHelpers:
-    def test_normalize_block_ids_copies_sequences_and_append_preserves_layout(self) -> None:
-        source = ([1, 2], [3])
+    def test_normalize_and_append_block_ids_copy_inputs(self) -> None:
+        current = ([1, 2], [10])
+        new = ([3], [11, 12])
 
-        normalized = normalize_block_ids(source)
-        appended = append_block_ids(normalized, ([4], [5, 6]))
+        normalized = normalize_block_ids(current)
+        appended = append_block_ids(normalized, new)
 
-        source[0].append(99)
-        assert normalized == ([1, 2], [3])
-        assert appended == ([1, 2, 4], [3, 5, 6])
-        assert appended is not normalized
+        current[0].append(99)
+        new[0].append(99)
+        assert normalized == ([1, 2], [10])
+        assert normalized is not current
+        assert normalized[0] is not current[0]
+        assert appended == ([1, 2, 3], [10, 11, 12])
+        assert first_seq_blocks(appended) == (1, 2, 3)
 
     def test_append_initializes_empty_block_ids_from_new_layout(self) -> None:
         new_blocks = ([10], [20, 21])
@@ -53,16 +69,20 @@ class TestRuntimeCacheBlockHelpers:
         appended = append_block_ids((), new_blocks)
 
         new_blocks[0].append(99)
-
         assert appended == ([10], [20, 21])
 
-    def test_append_raises_for_block_layout_mismatch(self) -> None:
-        with pytest.raises(RuntimeError, match="layout mismatch"):
-            append_block_ids(([1], [2]), ([3],))
+    def test_append_block_ids_rejects_sequence_layout_mismatch(self) -> None:
+        with pytest.raises(RuntimeError, match="KV block_ids layout mismatch"):
+            append_block_ids(([1],), ([2], [3]))
 
-    def test_first_seq_blocks_extracts_first_sequence_or_empty_tuple(self) -> None:
-        assert first_seq_blocks(([1, 2], [3, 4])) == (1, 2)
-        assert first_seq_blocks(()) == ()
+    def test_required_blocks_and_prefix_compatible_tokens(self) -> None:
+        assert required_blocks(0, 4) == 0
+        assert required_blocks(1, 4) == 1
+        assert required_blocks(5, 4) == 2
+
+        assert prefix_compatible_tokens((1, 2, 3), 10, (1, 2, 9), 12, 4) == 8
+        assert prefix_compatible_tokens((1, 2), 6, (1, 2, 3), 12, 4) == 6
+        assert prefix_compatible_tokens((1, 2), 6, (9, 2), 8, 4) == 0
 
     @pytest.mark.parametrize(
         ("target_blocks", "target_tokens", "snapshot_blocks", "snapshot_tokens", "expected"),
@@ -87,7 +107,7 @@ class TestRuntimeCacheBlockHelpers:
 
 class TestMbltRuntimeCacheManagerSnapshots:
     def test_snapshot_index_lookup_uses_deepest_compatible_prefix(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4)
+        manager = _make_manager(block_size=4)
         _store_snapshot(manager, "short", (1,), 4)
         _store_snapshot(manager, "long", (1, 2, 3), 12)
 
@@ -96,9 +116,10 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert match.req_id == "long"
         assert match.snapshot is manager.get_snapshot("long")
         assert match.matched_tokens == 8
+        assert not match.is_own_snapshot
 
     def test_own_snapshot_has_priority_when_fully_compatible(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4)
+        manager = _make_manager(block_size=4)
         _store_snapshot(manager, "other", (1, 2, 3), 12)
         _store_snapshot(manager, "req", (1, 2), 8)
 
@@ -108,7 +129,7 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert matched_tokens == 8
 
     def test_shared_prefix_snapshot_reuse_when_own_snapshot_is_partial(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4)
+        manager = _make_manager(block_size=4)
         _store_snapshot(manager, "req", (1,), 4)
         _store_snapshot(manager, "other", (1, 2, 3), 12)
 
@@ -118,7 +139,7 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert matched_tokens == 10
 
     def test_cache_miss_fallback_returns_no_snapshot_or_tokens(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4)
+        manager = _make_manager(block_size=4)
         _store_snapshot(manager, "other", (1, 2), 8)
 
         snapshot, matched_tokens = manager.choose_snapshot(_request("req", (9, 2), 8))
@@ -127,7 +148,7 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert matched_tokens == 0
 
     def test_snapshot_update_and_removal_refresh_prefix_index(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4)
+        manager = _make_manager(block_size=4)
         _store_snapshot(manager, "req", (1, 2), 8)
 
         assert manager.choose_prefix_snapshot(_request("new", (1, 2), 8)).req_id == "req"
@@ -138,11 +159,11 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert manager.remove_snapshot("req") is not None
         assert manager.choose_prefix_snapshot(_request("new", (5, 6), 8)).snapshot is None
 
-    def test_live_cache_reuse_for_same_request_is_tracked_without_snapshot_load(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4)
+    def test_live_cache_reuse_policy_and_cache_miss_state(self) -> None:
+        manager = _make_manager(block_size=4)
 
+        assert manager.loaded_req_id is None
         manager.mark_loaded_request("req")
-
         assert manager.loaded_req_id == "req"
         manager.clear_loaded_request("other")
         assert manager.loaded_req_id == "req"
@@ -150,7 +171,7 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert manager.loaded_req_id is None
 
     def test_finished_snapshot_lru_eviction_removes_snapshot_index_and_live_owner(self) -> None:
-        manager = MbltRuntimeCacheManager(block_size=4, max_finished_snapshots=2)
+        manager = _make_manager(block_size=4, max_finished_snapshots=2)
         _store_snapshot(manager, "a", (1,), 4)
         _store_snapshot(manager, "b", (2,), 4)
         _store_snapshot(manager, "c", (3,), 4)
@@ -165,11 +186,28 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert manager.loaded_req_id is None
         assert list(manager.finished_snapshot_lru) == ["b", "c"]
         assert manager.choose_prefix_snapshot(_request("new", (1,), 4)).snapshot is None
+        assert manager.choose_prefix_snapshot(_request("new", (2,), 4)).req_id == "b"
+
+    def test_finished_snapshot_lru_touch_preserves_recent_snapshot(self) -> None:
+        manager = _make_manager(block_size=4, max_finished_snapshots=2)
+        _store_snapshot(manager, "a", (1,), 4)
+        _store_snapshot(manager, "b", (2,), 4)
+        _store_snapshot(manager, "c", (3,), 4)
+
+        manager.mark_snapshot_finished("a")
+        manager.mark_snapshot_finished("b")
+        manager.mark_snapshot_finished("a")
+        evicted = manager.mark_snapshot_finished("c")
+
+        assert evicted == ["b"]
+        assert list(manager.finished_snapshot_lru) == ["a", "c"]
+        assert manager.get_snapshot("a") is not None
+        assert manager.get_snapshot("b") is None
 
 
 class TestMbltRuntimeCacheManagerSlots:
     def test_batch_slot_allocation_release_and_reuse(self) -> None:
-        manager = MbltRuntimeCacheManager(max_batch_size=2, block_size=4)
+        manager = _make_manager(max_batch_size=2)
 
         assert manager.assign_slot("a") == 0
         assert manager.assign_slot("b") == 1
@@ -181,9 +219,10 @@ class TestMbltRuntimeCacheManagerSlots:
 
         assert manager.live_slot_owner(0) is None
         assert manager.assign_slot("c") == 0
+        assert manager.get_slot("c") == 0
 
     def test_slot_scoped_dump_and_load_pass_cache_id_to_injected_callables(self) -> None:
-        manager = MbltRuntimeCacheManager(max_batch_size=2, block_size=4)
+        manager = _make_manager(max_batch_size=2)
         dump_calls: list[dict[str, int]] = []
         load_calls: list[tuple[list[object], dict[str, int]]] = []
 

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -19,12 +19,19 @@ def _make_manager(*, block_size: int = 4, max_batch_size: int = 2, max_finished_
     )
 
 
-def _request(req_id: str, blocks: tuple[int, ...], tokens: int) -> RuntimeCacheRequest:
+def _request(
+    req_id: str,
+    blocks: tuple[int, ...],
+    tokens: int,
+    *,
+    cache_slot_id: int | None = None,
+) -> RuntimeCacheRequest:
     return RuntimeCacheRequest(
         req_id=req_id,
         block_ids=(list(blocks),),
         first_seq_blocks=blocks,
         num_computed_tokens=tokens,
+        cache_slot_id=cache_slot_id,
     )
 
 
@@ -205,6 +212,112 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert manager.get_snapshot("b") is None
 
 
+class TestMbltRuntimeCacheManagerRuntimeDecisions:
+    def test_single_cache_reuses_live_owner_without_loading(self) -> None:
+        manager = _make_manager(block_size=4)
+        manager.mark_loaded_request("req")
+        load_calls = []
+
+        result = manager.load_snapshot_for_request(
+            _request("req", (1, 2), 8),
+            lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
+        )
+
+        assert result.matched_tokens == 8
+        assert result.reused_live_cache
+        assert not result.loaded
+        assert load_calls == []
+        assert manager.loaded_req_id == "req"
+
+    def test_single_cache_loads_fully_compatible_own_snapshot(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(manager, "req", (1, 2), 8)
+        load_calls = []
+
+        result = manager.load_snapshot_for_request(
+            _request("req", (1, 2), 8),
+            lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
+        )
+
+        assert result.matched_tokens == 8
+        assert result.loaded
+        assert result.is_own_snapshot
+        assert result.loaded_snapshot_req_id == "req"
+        assert load_calls == [(["blob:req"], None)]
+        assert manager.loaded_req_id == "req"
+
+    def test_single_cache_loads_useful_shared_prefix_snapshot(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(manager, "shared", (1, 2, 3), 12)
+        load_calls = []
+
+        result = manager.load_snapshot_for_request(
+            _request("req", (1, 2, 9), 10),
+            lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
+        )
+
+        assert result.matched_tokens == 8
+        assert result.loaded
+        assert not result.is_own_snapshot
+        assert result.loaded_snapshot_req_id == "shared"
+        assert load_calls == [(["blob:shared"], None)]
+        assert manager.loaded_req_id == "req"
+
+    def test_single_cache_miss_clears_live_owner(self) -> None:
+        manager = _make_manager(block_size=4)
+        manager.mark_loaded_request("other")
+
+        result = manager.load_snapshot_for_request(_request("req", (9,), 4), lambda blobs, slot_id: True)
+
+        assert result.matched_tokens == 0
+        assert result.cache_miss
+        assert manager.loaded_req_id is None
+
+    def test_dump_snapshot_if_needed_uses_injected_callable_and_block_boundary_policy(self) -> None:
+        manager = _make_manager(block_size=4)
+        dump_calls = []
+
+        dumped = manager.dump_snapshot_if_needed(
+            _request("req", (1,), 4),
+            lambda slot_id: dump_calls.append(slot_id) or ["blob:req:4"],
+        )
+
+        assert dumped
+        assert dump_calls == [None]
+        assert manager.get_snapshot("req").blobs == ["blob:req:4"]
+
+        block_growth_dumped = manager.dump_snapshot_if_needed(
+            _request("req", (1, 2), 5),
+            lambda slot_id: dump_calls.append(slot_id) or ["blob:req:5"],
+        )
+
+        assert block_growth_dumped
+        assert dump_calls == [None, None]
+        assert manager.get_snapshot("req").blobs == ["blob:req:5"]
+
+        not_dumped = manager.dump_snapshot_if_needed(
+            _request("req", (1, 2), 6),
+            lambda slot_id: dump_calls.append(slot_id) or ["blob:req:6"],
+        )
+
+        assert not not_dumped
+        assert dump_calls == [None, None]
+        assert manager.get_snapshot("req").blobs == ["blob:req:5"]
+
+    def test_dump_live_request_before_switch_dumps_current_owner_when_needed(self) -> None:
+        manager = _make_manager(block_size=4)
+        manager.mark_loaded_request("old")
+
+        dumped = manager.dump_live_request_before_switch(
+            next_req_id="new",
+            live_request=_request("old", (1, 2), 8),
+            dump_runtime_cache=lambda slot_id: ["blob:old"],
+        )
+
+        assert dumped
+        assert manager.get_snapshot("old").num_tokens == 8
+
+
 class TestMbltRuntimeCacheManagerSlots:
     def test_batch_slot_allocation_release_and_reuse(self) -> None:
         manager = _make_manager(max_batch_size=2)
@@ -212,12 +325,18 @@ class TestMbltRuntimeCacheManagerSlots:
         assert manager.assign_slot("a") == 0
         assert manager.assign_slot("b") == 1
         assert manager.assign_slot("a") == 0
+        assert manager.req_to_cache_slot == {"a": 0, "b": 1}
+        assert manager.cache_slot_to_req == {0: "a", 1: "b"}
+        assert manager.free_cache_slots == []
         with pytest.raises(RuntimeError, match="No free accelerator cache slots"):
             manager.assign_slot("c")
 
         manager.release_slot("a")
 
         assert manager.live_slot_owner(0) is None
+        assert manager.req_to_cache_slot == {"b": 1}
+        assert manager.cache_slot_to_req == {1: "b"}
+        assert manager.free_cache_slots == [0]
         assert manager.assign_slot("c") == 0
         assert manager.get_slot("c") == 0
 
@@ -240,3 +359,57 @@ class TestMbltRuntimeCacheManagerSlots:
 
         assert dump_calls == [{}, {"cache_id": 1}]
         assert load_calls == [(["blob"], {}), (["slot-blob"], {"cache_id": 1})]
+
+    def test_slot_load_reuses_live_owner_and_uses_slot_scoped_loads(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        manager.mark_slot_owner(slot_id, "req")
+        load_calls = []
+
+        reused = manager.load_snapshot_for_slot(
+            _request("req", (1,), 4, cache_slot_id=slot_id),
+            lambda blobs, load_slot_id: load_calls.append((blobs, load_slot_id)) or True,
+        )
+
+        assert reused.reused_live_cache
+        assert reused.matched_tokens == 4
+        assert load_calls == []
+
+        _store_snapshot(manager, "other", (7, 8), 8)
+        loaded = manager.load_snapshot_for_slot(
+            _request("new", (7, 9), 8, cache_slot_id=slot_id),
+            lambda blobs, load_slot_id: load_calls.append((blobs, load_slot_id)) or True,
+        )
+
+        assert loaded.loaded
+        assert loaded.matched_tokens == 4
+        assert loaded.loaded_snapshot_req_id == "other"
+        assert load_calls == [(["blob:other"], slot_id)]
+        assert manager.live_slot_owner(slot_id) == "new"
+
+    def test_slot_cache_miss_marks_slot_owner_for_rebuild(self) -> None:
+        manager = _make_manager(max_batch_size=1, block_size=4)
+        slot_id = manager.assign_slot("req")
+
+        result = manager.load_snapshot_for_slot(
+            _request("req", (99,), 4, cache_slot_id=slot_id),
+            lambda blobs, load_slot_id: True,
+        )
+
+        assert result.cache_miss
+        assert result.matched_tokens == 0
+        assert manager.live_slot_owner(slot_id) == "req"
+
+    def test_slot_scoped_dump_passes_cache_slot_to_injected_callable(self) -> None:
+        manager = _make_manager(max_batch_size=1, block_size=4)
+        slot_id = manager.assign_slot("req")
+        dump_calls = []
+
+        dumped = manager.dump_snapshot_if_needed(
+            _request("req", (1,), 4, cache_slot_id=slot_id),
+            lambda dump_slot_id: dump_calls.append(dump_slot_id) or ["slot-blob"],
+        )
+
+        assert dumped
+        assert dump_calls == [slot_id]
+        assert manager.get_snapshot("req").blobs == ["slot-blob"]

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1,7 +1,6 @@
 import math
 import os
 import time
-from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -30,12 +29,11 @@ from vllm.v1.worker.worker_base import WorkerBase
 from vllm_mblt.mblt_platform import resolve_model_max_batch_size
 from vllm_mblt.runtime_cache import (
     KVBlockIds,
-    RuntimeCacheSnapshot,
-    RuntimeCacheSnapshotIndexNode,
+    MbltRuntimeCacheManager,
+    RuntimeCacheRequest,
     append_block_ids,
     first_seq_blocks,
     normalize_block_ids,
-    prefix_compatible_tokens,
     required_blocks,
 )
 
@@ -119,9 +117,6 @@ class RequestState:
     vlm_session_id: Optional[str]
 
 
-CacheSnapshot = RuntimeCacheSnapshot
-
-
 @dataclass
 class CachedSamplingState:
     temperature: float
@@ -135,10 +130,6 @@ class CachedSamplingState:
     bad_words_token_ids: Optional[list[list[int]]]
     prompt_token_ids: torch.Tensor
     has_penalties: bool
-
-
-SnapshotIndexNode = RuntimeCacheSnapshotIndexNode
-
 
 class MbltWorker(WorkerBase):
     MAX_FINISHED_CACHE_SNAPSHOTS = 16
@@ -157,21 +148,18 @@ class MbltWorker(WorkerBase):
         self.input_embeddings: Optional[nn.Module] = None
         self.cache_model: Optional[Any] = None
         self._infer_output_buffers: Optional[list[np.ndarray]] = None
-        self.snapshot_index_root = SnapshotIndexNode()
 
         self.req_states: Dict[str, RequestState] = {}
-        self.cache_snapshots: Dict[str, CacheSnapshot] = {}
-        self.finished_snapshot_lru: OrderedDict[str, None] = OrderedDict()
-        self.loaded_cache_req_id: Optional[str] = None
-        self.req_to_cache_slot: dict[str, int] = {}
-        self.cache_slot_to_req: dict[int, str] = {}
-        self.free_cache_slots: list[int] = []
         self._warned_batch_cache_snapshot_unsupported = False
         self._vlm_image_positions_by_session: dict[str, tuple[int, int, Optional[tuple[bool, ...]]]] = {}
 
         self.max_batch_size = resolve_model_max_batch_size(self.vllm_config) or 1
-        self._reset_cache_slots()
         self.max_seq_len = self.vllm_config.model_config.max_model_len
+        self.runtime_cache = MbltRuntimeCacheManager(
+            max_batch_size=self.max_batch_size,
+            block_size=self._kv_block_size(),
+            max_finished_snapshots=self.MAX_FINISHED_CACHE_SNAPSHOTS,
+        )
         self.sampler = Sampler(logprobs_mode="raw_logits")
         self.empty_logits_processors = LogitsProcessors(None)
         self.empty_prompt_token_ids = torch.empty((0, 0), dtype=torch.int64)
@@ -200,9 +188,7 @@ class MbltWorker(WorkerBase):
         logger.info("[mblt-init] %s %s%s", stage, details, suffix)
 
     def _reset_cache_slots(self) -> None:
-        self.req_to_cache_slot = {}
-        self.cache_slot_to_req = {}
-        self.free_cache_slots = list(range(max(0, self.max_batch_size)))
+        self.runtime_cache.reset_slots(max_batch_size=self.max_batch_size)
 
     def _is_batch_model(self) -> bool:
         return self.max_batch_size > 1
@@ -336,35 +322,13 @@ class MbltWorker(WorkerBase):
         positions_by_session[session_id] = position
 
     def _get_cache_slot(self, req_id: str) -> int:
-        slot_id = self.req_to_cache_slot.get(req_id)
-        if slot_id is None:
-            raise RuntimeError(f"No accelerator cache slot is assigned for req_id={req_id}.")
-        return slot_id
+        return self.runtime_cache.get_slot(req_id)
 
     def _assign_cache_slot(self, req_id: str) -> int:
-        slot_id = self.req_to_cache_slot.get(req_id)
-        if slot_id is not None:
-            return slot_id
-        if not self.free_cache_slots:
-            raise RuntimeError(
-                "No free accelerator cache slots remain for batch execution. "
-                f"req_id={req_id}, max_batch_size={self.max_batch_size}"
-            )
-        slot_id = self.free_cache_slots.pop(0)
-        self.req_to_cache_slot[req_id] = slot_id
-        self.cache_slot_to_req[slot_id] = req_id
-        return slot_id
+        return self.runtime_cache.assign_slot(req_id)
 
     def _release_cache_slot(self, req_id: str) -> None:
-        slot_id = self.req_to_cache_slot.pop(req_id, None)
-        if slot_id is None:
-            return
-        owner = self.cache_slot_to_req.get(slot_id)
-        if owner == req_id:
-            self.cache_slot_to_req.pop(slot_id, None)
-        if slot_id not in self.free_cache_slots:
-            self.free_cache_slots.append(slot_id)
-            self.free_cache_slots.sort()
+        self.runtime_cache.release_slot(req_id)
 
     def _dump_runtime_cache(self, slot_id: Optional[int] = None) -> Optional[list[Any]]:
         cache_model = self._get_cache_model()
@@ -661,62 +625,29 @@ class MbltWorker(WorkerBase):
         return merged_prompt_embeds, deepstack_prompt_embeds
 
     def _touch_finished_snapshot(self, req_id: str) -> None:
-        if req_id in self.finished_snapshot_lru:
-            self.finished_snapshot_lru.move_to_end(req_id)
-        else:
-            self.finished_snapshot_lru[req_id] = None
-
-    @staticmethod
-    def _update_snapshot_index_node(
-        node: SnapshotIndexNode,
-        req_id: str,
-        num_tokens: int,
-    ) -> None:
-        if num_tokens >= node.best_num_tokens:
-            node.best_req_id = req_id
-            node.best_num_tokens = num_tokens
+        self.runtime_cache.touch_finished_snapshot(req_id)
 
     def _rebuild_snapshot_index(self) -> None:
-        root = SnapshotIndexNode()
-        for req_id, snapshot in self.cache_snapshots.items():
-            node = root
-            self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
-            for block_id in snapshot.first_seq_blocks:
-                node = node.children.setdefault(block_id, SnapshotIndexNode())
-                self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
-        self.snapshot_index_root = root
+        self.runtime_cache.rebuild_snapshot_index()
 
     def _evict_old_finished_snapshots(self, print_debug: bool = False) -> None:
-        evicted = False
-        while len(self.finished_snapshot_lru) > self.MAX_FINISHED_CACHE_SNAPSHOTS:
-            evicted_req_id, _ = self.finished_snapshot_lru.popitem(last=False)
-            self.cache_snapshots.pop(evicted_req_id, None)
-            evicted = True
-            if self.loaded_cache_req_id == evicted_req_id:
-                self.loaded_cache_req_id = None
+        for evicted_req_id in self.runtime_cache.evict_old_finished_snapshots():
             if print_debug:
                 print(f"[cache] evict-finished req={evicted_req_id} reason=lru-cap")
-        if evicted:
-            self._rebuild_snapshot_index()
 
     def _should_dump_snapshot_after_step(
         self,
         req_id: str,
         next_num_tokens: int,
     ) -> bool:
-        snapshot = self.cache_snapshots.get(req_id)
-        if snapshot is None:
-            return True
-        if next_num_tokens <= snapshot.num_tokens:
-            return False
-        return self._required_blocks(next_num_tokens) > self._required_blocks(snapshot.num_tokens)
+        return self.runtime_cache.should_dump_snapshot_after_step(req_id, next_num_tokens)
 
     def _dump_loaded_request_before_switch(
         self,
         next_req_id: str,
         print_debug: bool = False,
     ) -> None:
-        loaded_req_id = self.loaded_cache_req_id
+        loaded_req_id = self.runtime_cache.loaded_req_id
         if loaded_req_id is None or loaded_req_id == next_req_id:
             return
         loaded_req_state = self.req_states.get(loaded_req_id)
@@ -746,45 +677,23 @@ class MbltWorker(WorkerBase):
         snapshot_blocks: tuple[int, ...],
         snapshot_tokens: int,
     ) -> int:
-        return prefix_compatible_tokens(
-            target_blocks,
-            target_tokens,
-            snapshot_blocks,
-            snapshot_tokens,
-            self._kv_block_size(),
+        return self.runtime_cache.compatible_tokens(
+            target_blocks=target_blocks,
+            target_tokens=target_tokens,
+            snapshot_blocks=snapshot_blocks,
+            snapshot_tokens=snapshot_tokens,
         )
 
-    def _choose_snapshot(self, req_state: RequestState) -> tuple[Optional[CacheSnapshot], int]:
-        target_tokens = req_state.num_computed_tokens
-        if target_tokens <= 0:
-            return None, 0
-
-        target_blocks = req_state.first_seq_blocks
-        if not target_blocks:
-            return None, 0
-
-        best_snapshot: Optional[CacheSnapshot] = None
-        best_tokens = 0
-        node = self.snapshot_index_root
-        for depth, block_id in enumerate(target_blocks, start=1):
-            node = node.children.get(block_id)
-            if node is None or node.best_req_id is None:
-                break
-
-            snapshot = self.cache_snapshots.get(node.best_req_id)
-            if snapshot is None:
-                continue
-
-            matched_tokens = min(
-                snapshot.num_tokens,
-                depth * self._kv_block_size(),
-                target_tokens,
+    def _choose_snapshot(self, req_state: RequestState):
+        return self.runtime_cache.choose_snapshot(
+            RuntimeCacheRequest(
+                req_id="",
+                block_ids=getattr(req_state, "block_ids", ()),
+                first_seq_blocks=req_state.first_seq_blocks,
+                num_computed_tokens=req_state.num_computed_tokens,
+                cache_slot_id=getattr(req_state, "cache_slot_id", None),
             )
-            if matched_tokens > best_tokens:
-                best_tokens = matched_tokens
-                best_snapshot = snapshot
-
-        return best_snapshot, best_tokens
+        )
 
     def _build_input_embeds(
         self,
@@ -1100,19 +1009,19 @@ class MbltWorker(WorkerBase):
         )
 
         if target_tokens <= 0:
-            self.loaded_cache_req_id = None
+            self.runtime_cache.clear_loaded_request()
             if print_debug:
                 print(f"[cache] req={req_id} skip-load target_tokens=0")
             return 0
 
         # If the active accelerator cache already belongs to this request,
         # it already contains the up-to-date KV state from previous steps.
-        if self.loaded_cache_req_id == req_id:
+        if self.runtime_cache.loaded_req_id == req_id:
             if print_debug:
                 print(f"[cache] req={req_id} reuse-live-cache matched={target_tokens}/{target_tokens}")
             return target_tokens
 
-        own_snapshot = self.cache_snapshots.get(req_id)
+        own_snapshot = self.runtime_cache.get_snapshot(req_id)
         if own_snapshot is not None:
             matched_tokens = self._prefix_compatible_tokens(
                 target_blocks=req_state.first_seq_blocks,
@@ -1121,11 +1030,11 @@ class MbltWorker(WorkerBase):
                 snapshot_tokens=own_snapshot.num_tokens,
             )
             if matched_tokens >= target_tokens:
-                if self.loaded_cache_req_id != req_id:
+                if self.runtime_cache.loaded_req_id != req_id:
                     cache_model = self._get_cache_model()
                     # load_cache_memory(...) must happen before infer(..., cache_size=...)
                     cache_model.load_cache_memory(own_snapshot.blobs)
-                    self.loaded_cache_req_id = req_id
+                    self.runtime_cache.mark_loaded_request(req_id)
                     if print_debug:
                         print(f"[cache] req={req_id} load-own matched={matched_tokens}/{target_tokens}")
                 elif print_debug:
@@ -1134,7 +1043,7 @@ class MbltWorker(WorkerBase):
 
         snapshot, matched_tokens = self._choose_snapshot(req_state)
         if snapshot is None or matched_tokens <= 0:
-            self.loaded_cache_req_id = None
+            self.runtime_cache.clear_loaded_request()
             if print_debug:
                 print(f"[cache] req={req_id} cache-miss fallback matched=0/{target_tokens}")
             return 0
@@ -1142,7 +1051,7 @@ class MbltWorker(WorkerBase):
         cache_model = self._get_cache_model()
         # load_cache_memory(...) must happen before infer(..., cache_size=...)
         cache_model.load_cache_memory(snapshot.blobs)
-        self.loaded_cache_req_id = req_id
+        self.runtime_cache.mark_loaded_request(req_id)
         if print_debug:
             print(f"[cache] req={req_id} load-shared matched={matched_tokens}/{target_tokens}")
         return matched_tokens
@@ -1161,13 +1070,13 @@ class MbltWorker(WorkerBase):
         if target_tokens <= 0:
             return 0
 
-        live_owner = self.cache_slot_to_req.get(slot_id)
+        live_owner = self.runtime_cache.live_slot_owner(slot_id)
         if live_owner == req_id:
             if print_debug:
                 print(f"[cache] req={req_id} slot={slot_id} reuse-live-cache matched={target_tokens}/{target_tokens}")
             return target_tokens
 
-        own_snapshot = self.cache_snapshots.get(req_id)
+        own_snapshot = self.runtime_cache.get_snapshot(req_id)
         if own_snapshot is not None:
             matched_tokens = self._prefix_compatible_tokens(
                 target_blocks=req_state.first_seq_blocks,
@@ -1177,7 +1086,7 @@ class MbltWorker(WorkerBase):
             )
             if matched_tokens >= target_tokens:
                 if self._load_runtime_cache(own_snapshot.blobs, slot_id=slot_id):
-                    self.cache_slot_to_req[slot_id] = req_id
+                    self.runtime_cache.mark_slot_owner(slot_id, req_id)
                     if print_debug:
                         print(f"[cache] req={req_id} slot={slot_id} load-own matched={matched_tokens}/{target_tokens}")
                     return target_tokens
@@ -1185,12 +1094,12 @@ class MbltWorker(WorkerBase):
         snapshot, matched_tokens = self._choose_snapshot(req_state)
         if snapshot is not None and matched_tokens > 0:
             if self._load_runtime_cache(snapshot.blobs, slot_id=slot_id):
-                self.cache_slot_to_req[slot_id] = req_id
+                self.runtime_cache.mark_slot_owner(slot_id, req_id)
                 if print_debug:
                     print(f"[cache] req={req_id} slot={slot_id} load-shared matched={matched_tokens}/{target_tokens}")
                 return matched_tokens
 
-        self.cache_slot_to_req[slot_id] = req_id
+        self.runtime_cache.mark_slot_owner(slot_id, req_id)
         if print_debug:
             print(f"[cache] req={req_id} slot={slot_id} cache-miss fallback matched=0/{target_tokens}")
         return 0
@@ -1203,8 +1112,6 @@ class MbltWorker(WorkerBase):
         slot_id: Optional[int] = None,
         print_debug: bool = False,
     ) -> bool:
-        # Active request snapshots are not part of the finished-session LRU pool.
-        self.finished_snapshot_lru.pop(req_id, None)
         blobs = self._dump_runtime_cache(slot_id=slot_id)
         if blobs is None:
             if self._is_batch_model() and not self._warned_batch_cache_snapshot_unsupported:
@@ -1214,19 +1121,18 @@ class MbltWorker(WorkerBase):
                 )
                 self._warned_batch_cache_snapshot_unsupported = True
             return False
-        stored_tokens = max(0, int(next_num_tokens))
-        self.cache_snapshots[req_id] = CacheSnapshot(
+        self.runtime_cache.store_snapshot(
+            req_id=req_id,
             blobs=blobs,
-            block_ids=self._normalize_block_ids(req_state.block_ids),
+            block_ids=req_state.block_ids,
             first_seq_blocks=req_state.first_seq_blocks,
-            num_tokens=stored_tokens,
+            num_tokens=next_num_tokens,
         )
-        self._rebuild_snapshot_index()
         if print_debug:
             num_blocks = len(req_state.first_seq_blocks)
             print(
-                f"[cache] req={req_id} dump tokens={stored_tokens} "
-                f"blocks={num_blocks} snapshots={len(self.cache_snapshots)}"
+                f"[cache] req={req_id} dump tokens={max(0, int(next_num_tokens))} "
+                f"blocks={num_blocks} snapshots={self.runtime_cache.snapshot_count()}"
             )
         return True
 
@@ -1256,7 +1162,7 @@ class MbltWorker(WorkerBase):
                 ):
                     print(f"[cache] req={req_id} slot={finished_slot_id} dump-on-finish")
             elif (
-                self.loaded_cache_req_id == req_id
+                self.runtime_cache.loaded_req_id == req_id
                 and should_dump
                 and self._dump_snapshot(
                     req_id=req_id,
@@ -1267,11 +1173,10 @@ class MbltWorker(WorkerBase):
                 and print_debug
             ):
                 print(f"[cache] req={req_id} dump-on-finish")
-        if req_id in self.cache_snapshots:
+        if self.runtime_cache.has_snapshot(req_id):
             self._touch_finished_snapshot(req_id)
         self._evict_old_finished_snapshots(print_debug=print_debug)
-        if self.loaded_cache_req_id == req_id:
-            self.loaded_cache_req_id = None
+        self.runtime_cache.clear_loaded_request(req_id)
         if self._is_batch_model():
             self._release_cache_slot(req_id)
 
@@ -1645,7 +1550,7 @@ class MbltWorker(WorkerBase):
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
                 req_state.num_computed_tokens = next_cache_sizes[i]
-                self.cache_slot_to_req[cache_ids[i]] = req_id
+                self.runtime_cache.mark_slot_owner(cache_ids[i], req_id)
                 if self._should_sample_after_step(
                     req_state,
                     scheduled_end_positions[i],
@@ -1693,7 +1598,7 @@ class MbltWorker(WorkerBase):
                 # next_cache_size tokens, so later same-request decode can reuse it
                 # without forcing a block-boundary snapshot dump.
                 req_state.num_computed_tokens = next_cache_size
-                self.loaded_cache_req_id = req_id
+                self.runtime_cache.mark_loaded_request(req_id)
                 if self._should_sample_after_step(
                     req_state,
                     scheduled_end,
@@ -1833,6 +1738,4 @@ class MbltWorker(WorkerBase):
         self.cache_model = None
         self.input_embeddings = None
         self._infer_output_buffers = None
-        self.loaded_cache_req_id = None
-        self._reset_cache_slots()
-        self.snapshot_index_root = SnapshotIndexNode()
+        self.runtime_cache.reset()

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -2,7 +2,7 @@ import math
 import os
 import time
 from collections import OrderedDict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import numpy as np
@@ -28,6 +28,16 @@ from vllm.v1.sample.sampler import Sampler
 from vllm.v1.worker.worker_base import WorkerBase
 
 from vllm_mblt.mblt_platform import resolve_model_max_batch_size
+from vllm_mblt.runtime_cache import (
+    KVBlockIds,
+    RuntimeCacheSnapshot,
+    RuntimeCacheSnapshotIndexNode,
+    append_block_ids,
+    first_seq_blocks,
+    normalize_block_ids,
+    prefix_compatible_tokens,
+    required_blocks,
+)
 
 logger = init_logger(__name__)
 
@@ -96,7 +106,7 @@ class RequestState:
     output_token_ids: list[int]
     sampling_params: SamplingParams
     cached_sampling_state: "CachedSamplingState"
-    block_ids: tuple[list[int], ...]
+    block_ids: KVBlockIds
     first_seq_blocks: tuple[int, ...]
     num_computed_tokens: int
     num_output_tokens: int
@@ -109,12 +119,7 @@ class RequestState:
     vlm_session_id: Optional[str]
 
 
-@dataclass
-class CacheSnapshot:
-    blobs: list[Any]
-    block_ids: tuple[list[int], ...]
-    first_seq_blocks: tuple[int, ...]
-    num_tokens: int
+CacheSnapshot = RuntimeCacheSnapshot
 
 
 @dataclass
@@ -132,11 +137,7 @@ class CachedSamplingState:
     has_penalties: bool
 
 
-@dataclass
-class SnapshotIndexNode:
-    children: dict[int, "SnapshotIndexNode"] = field(default_factory=dict)
-    best_req_id: Optional[str] = None
-    best_num_tokens: int = 0
+SnapshotIndexNode = RuntimeCacheSnapshotIndexNode
 
 
 class MbltWorker(WorkerBase):
@@ -215,29 +216,18 @@ class MbltWorker(WorkerBase):
     def _num_blocks_per_request(self) -> int:
         return max(1, math.ceil(self.max_seq_len / self._kv_block_size()))
 
-    def _normalize_block_ids(self, block_ids: tuple[list[int], ...]) -> tuple[list[int], ...]:
-        return tuple(list(seq) for seq in block_ids)
+    def _normalize_block_ids(self, block_ids: KVBlockIds) -> KVBlockIds:
+        return normalize_block_ids(block_ids)
 
     def _append_block_ids(
         self,
-        current_block_ids: tuple[list[int], ...],
-        new_block_ids: tuple[list[int], ...],
-    ) -> tuple[list[int], ...]:
-        if not current_block_ids:
-            return self._normalize_block_ids(new_block_ids)
-        if len(current_block_ids) != len(new_block_ids):
-            raise RuntimeError(
-                f"KV block_ids layout mismatch: current={len(current_block_ids)} seqs, new={len(new_block_ids)} seqs"
-            )
-        merged_block_ids: list[list[int]] = []
-        for current_seq_blocks, new_seq_blocks in zip(current_block_ids, new_block_ids):
-            merged_block_ids.append(list(current_seq_blocks) + list(new_seq_blocks))
-        return tuple(merged_block_ids)
+        current_block_ids: KVBlockIds,
+        new_block_ids: KVBlockIds,
+    ) -> KVBlockIds:
+        return append_block_ids(current_block_ids, new_block_ids)
 
-    def _first_seq_blocks(self, block_ids: tuple[list[int], ...]) -> tuple[int, ...]:
-        if len(block_ids) == 0:
-            return ()
-        return tuple(block_ids[0])
+    def _first_seq_blocks(self, block_ids: KVBlockIds) -> tuple[int, ...]:
+        return first_seq_blocks(block_ids)
 
     def _get_cache_model(self) -> Any:
         if self.cache_model is None:
@@ -747,9 +737,7 @@ class MbltWorker(WorkerBase):
             print(f"[cache] req={loaded_req_id} dump-before-switch next={next_req_id}")
 
     def _required_blocks(self, num_tokens: int) -> int:
-        if num_tokens <= 0:
-            return 0
-        return math.ceil(num_tokens / self._kv_block_size())
+        return required_blocks(num_tokens, self._kv_block_size())
 
     def _prefix_compatible_tokens(
         self,
@@ -758,23 +746,13 @@ class MbltWorker(WorkerBase):
         snapshot_blocks: tuple[int, ...],
         snapshot_tokens: int,
     ) -> int:
-        if target_tokens <= 0 or snapshot_tokens <= 0:
-            return 0
-
-        needed_target_blocks = self._required_blocks(target_tokens)
-        common_blocks = 0
-        for i in range(min(needed_target_blocks, len(target_blocks), len(snapshot_blocks))):
-            if target_blocks[i] != snapshot_blocks[i]:
-                break
-            common_blocks += 1
-
-        if common_blocks == 0:
-            return 0
-
-        if common_blocks >= needed_target_blocks:
-            return min(target_tokens, snapshot_tokens)
-
-        return min(snapshot_tokens, common_blocks * self._kv_block_size(), target_tokens)
+        return prefix_compatible_tokens(
+            target_blocks,
+            target_tokens,
+            snapshot_blocks,
+            snapshot_tokens,
+            self._kv_block_size(),
+        )
 
     def _choose_snapshot(self, req_state: RequestState) -> tuple[Optional[CacheSnapshot], int]:
         target_tokens = req_state.num_computed_tokens

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -159,6 +159,8 @@ class MbltWorker(WorkerBase):
             max_batch_size=self.max_batch_size,
             block_size=self._kv_block_size(),
             max_finished_snapshots=self.MAX_FINISHED_CACHE_SNAPSHOTS,
+            dump_runtime_cache=self._dump_runtime_cache,
+            load_runtime_cache=self._load_runtime_cache,
         )
         self.sampler = Sampler(logprobs_mode="raw_logits")
         self.empty_logits_processors = LogitsProcessors(None)
@@ -188,6 +190,10 @@ class MbltWorker(WorkerBase):
         logger.info("[mblt-init] %s %s%s", stage, details, suffix)
 
     def _reset_cache_slots(self) -> None:
+        self.runtime_cache.set_io_adapters(
+            dump_runtime_cache=self._dump_runtime_cache,
+            load_runtime_cache=self._load_runtime_cache,
+        )
         self.runtime_cache.reset_slots(max_batch_size=self.max_batch_size)
 
     def _is_batch_model(self) -> bool:
@@ -624,24 +630,6 @@ class MbltWorker(WorkerBase):
 
         return merged_prompt_embeds, deepstack_prompt_embeds
 
-    def _touch_finished_snapshot(self, req_id: str) -> None:
-        self.runtime_cache.touch_finished_snapshot(req_id)
-
-    def _rebuild_snapshot_index(self) -> None:
-        self.runtime_cache.rebuild_snapshot_index()
-
-    def _evict_old_finished_snapshots(self, print_debug: bool = False) -> None:
-        for evicted_req_id in self.runtime_cache.evict_old_finished_snapshots():
-            if print_debug:
-                print(f"[cache] evict-finished req={evicted_req_id} reason=lru-cap")
-
-    def _should_dump_snapshot_after_step(
-        self,
-        req_id: str,
-        next_num_tokens: int,
-    ) -> bool:
-        return self.runtime_cache.should_dump_snapshot_after_step(req_id, next_num_tokens)
-
     def _dump_loaded_request_before_switch(
         self,
         next_req_id: str,
@@ -653,7 +641,7 @@ class MbltWorker(WorkerBase):
         loaded_req_state = self.req_states.get(loaded_req_id)
         if loaded_req_state is None:
             return
-        if not self._should_dump_snapshot_after_step(
+        if not self.runtime_cache.should_dump_snapshot_after_step(
             loaded_req_id,
             loaded_req_state.num_computed_tokens,
         ):
@@ -666,34 +654,6 @@ class MbltWorker(WorkerBase):
         )
         if print_debug:
             print(f"[cache] req={loaded_req_id} dump-before-switch next={next_req_id}")
-
-    def _required_blocks(self, num_tokens: int) -> int:
-        return required_blocks(num_tokens, self._kv_block_size())
-
-    def _prefix_compatible_tokens(
-        self,
-        target_blocks: tuple[int, ...],
-        target_tokens: int,
-        snapshot_blocks: tuple[int, ...],
-        snapshot_tokens: int,
-    ) -> int:
-        return self.runtime_cache.compatible_tokens(
-            target_blocks=target_blocks,
-            target_tokens=target_tokens,
-            snapshot_blocks=snapshot_blocks,
-            snapshot_tokens=snapshot_tokens,
-        )
-
-    def _choose_snapshot(self, req_state: RequestState):
-        return self.runtime_cache.choose_snapshot(
-            RuntimeCacheRequest(
-                req_id="",
-                block_ids=getattr(req_state, "block_ids", ()),
-                first_seq_blocks=req_state.first_seq_blocks,
-                num_computed_tokens=req_state.num_computed_tokens,
-                cache_slot_id=getattr(req_state, "cache_slot_id", None),
-            )
-        )
 
     def _build_input_embeds(
         self,
@@ -1002,59 +962,33 @@ class MbltWorker(WorkerBase):
                 print_debug=print_debug,
             )
 
-        target_tokens = req_state.num_computed_tokens
         self._dump_loaded_request_before_switch(
             next_req_id=req_id,
             print_debug=print_debug,
         )
 
-        if target_tokens <= 0:
-            self.runtime_cache.clear_loaded_request()
-            if print_debug:
-                print(f"[cache] req={req_id} skip-load target_tokens=0")
-            return 0
-
-        # If the active accelerator cache already belongs to this request,
-        # it already contains the up-to-date KV state from previous steps.
-        if self.runtime_cache.loaded_req_id == req_id:
-            if print_debug:
-                print(f"[cache] req={req_id} reuse-live-cache matched={target_tokens}/{target_tokens}")
-            return target_tokens
-
-        own_snapshot = self.runtime_cache.get_snapshot(req_id)
-        if own_snapshot is not None:
-            matched_tokens = self._prefix_compatible_tokens(
-                target_blocks=req_state.first_seq_blocks,
-                target_tokens=target_tokens,
-                snapshot_blocks=own_snapshot.first_seq_blocks,
-                snapshot_tokens=own_snapshot.num_tokens,
+        target_tokens = req_state.num_computed_tokens
+        result = self.runtime_cache.load_for_request(
+            RuntimeCacheRequest(
+                req_id=req_id,
+                block_ids=req_state.block_ids,
+                first_seq_blocks=req_state.first_seq_blocks,
+                num_computed_tokens=target_tokens,
+                cache_slot_id=slot_id,
             )
-            if matched_tokens >= target_tokens:
-                if self.runtime_cache.loaded_req_id != req_id:
-                    cache_model = self._get_cache_model()
-                    # load_cache_memory(...) must happen before infer(..., cache_size=...)
-                    cache_model.load_cache_memory(own_snapshot.blobs)
-                    self.runtime_cache.mark_loaded_request(req_id)
-                    if print_debug:
-                        print(f"[cache] req={req_id} load-own matched={matched_tokens}/{target_tokens}")
-                elif print_debug:
-                    print(f"[cache] req={req_id} reuse-loaded-own matched={matched_tokens}/{target_tokens}")
-                return target_tokens
-
-        snapshot, matched_tokens = self._choose_snapshot(req_state)
-        if snapshot is None or matched_tokens <= 0:
-            self.runtime_cache.clear_loaded_request()
-            if print_debug:
-                print(f"[cache] req={req_id} cache-miss fallback matched=0/{target_tokens}")
-            return 0
-
-        cache_model = self._get_cache_model()
-        # load_cache_memory(...) must happen before infer(..., cache_size=...)
-        cache_model.load_cache_memory(snapshot.blobs)
-        self.runtime_cache.mark_loaded_request(req_id)
+        )
         if print_debug:
-            print(f"[cache] req={req_id} load-shared matched={matched_tokens}/{target_tokens}")
-        return matched_tokens
+            if result.action == "skip-empty":
+                print(f"[cache] req={req_id} skip-load target_tokens=0")
+            elif result.action == "reuse-live":
+                print(f"[cache] req={req_id} reuse-live-cache matched={target_tokens}/{target_tokens}")
+            elif result.action == "load-own":
+                print(f"[cache] req={req_id} load-own matched={result.matched_tokens}/{target_tokens}")
+            elif result.action == "load-shared":
+                print(f"[cache] req={req_id} load-shared matched={result.matched_tokens}/{target_tokens}")
+            else:
+                print(f"[cache] req={req_id} cache-miss fallback matched=0/{target_tokens}")
+        return result.matched_tokens
 
     def _load_snapshot_for_batch_slot(
         self,
@@ -1067,42 +1001,26 @@ class MbltWorker(WorkerBase):
             raise RuntimeError(f"Batch execution requires a cache slot for req_id={req_id}.")
 
         target_tokens = req_state.num_computed_tokens
-        if target_tokens <= 0:
-            return 0
-
-        live_owner = self.runtime_cache.live_slot_owner(slot_id)
-        if live_owner == req_id:
-            if print_debug:
-                print(f"[cache] req={req_id} slot={slot_id} reuse-live-cache matched={target_tokens}/{target_tokens}")
-            return target_tokens
-
-        own_snapshot = self.runtime_cache.get_snapshot(req_id)
-        if own_snapshot is not None:
-            matched_tokens = self._prefix_compatible_tokens(
-                target_blocks=req_state.first_seq_blocks,
-                target_tokens=target_tokens,
-                snapshot_blocks=own_snapshot.first_seq_blocks,
-                snapshot_tokens=own_snapshot.num_tokens,
-            )
-            if matched_tokens >= target_tokens:
-                if self._load_runtime_cache(own_snapshot.blobs, slot_id=slot_id):
-                    self.runtime_cache.mark_slot_owner(slot_id, req_id)
-                    if print_debug:
-                        print(f"[cache] req={req_id} slot={slot_id} load-own matched={matched_tokens}/{target_tokens}")
-                    return target_tokens
-
-        snapshot, matched_tokens = self._choose_snapshot(req_state)
-        if snapshot is not None and matched_tokens > 0:
-            if self._load_runtime_cache(snapshot.blobs, slot_id=slot_id):
-                self.runtime_cache.mark_slot_owner(slot_id, req_id)
-                if print_debug:
-                    print(f"[cache] req={req_id} slot={slot_id} load-shared matched={matched_tokens}/{target_tokens}")
-                return matched_tokens
-
-        self.runtime_cache.mark_slot_owner(slot_id, req_id)
+        result = self.runtime_cache.load_for_slot(
+            RuntimeCacheRequest(
+                req_id=req_id,
+                block_ids=req_state.block_ids,
+                first_seq_blocks=req_state.first_seq_blocks,
+                num_computed_tokens=target_tokens,
+                cache_slot_id=slot_id,
+            ),
+            slot_id=slot_id,
+        )
         if print_debug:
-            print(f"[cache] req={req_id} slot={slot_id} cache-miss fallback matched=0/{target_tokens}")
-        return 0
+            if result.action == "reuse-live":
+                print(f"[cache] req={req_id} slot={slot_id} reuse-live-cache matched={target_tokens}/{target_tokens}")
+            elif result.action == "load-own":
+                print(f"[cache] req={req_id} slot={slot_id} load-own matched={result.matched_tokens}/{target_tokens}")
+            elif result.action == "load-shared":
+                print(f"[cache] req={req_id} slot={slot_id} load-shared matched={result.matched_tokens}/{target_tokens}")
+            else:
+                print(f"[cache] req={req_id} slot={slot_id} cache-miss fallback matched=0/{target_tokens}")
+        return result.matched_tokens
 
     def _dump_snapshot(
         self,
@@ -1112,8 +1030,14 @@ class MbltWorker(WorkerBase):
         slot_id: Optional[int] = None,
         print_debug: bool = False,
     ) -> bool:
-        blobs = self._dump_runtime_cache(slot_id=slot_id)
-        if blobs is None:
+        snapshot = self.runtime_cache.dump_and_store_snapshot(
+            req_id=req_id,
+            block_ids=req_state.block_ids,
+            first_seq_blocks=req_state.first_seq_blocks,
+            num_tokens=next_num_tokens,
+            slot_id=slot_id,
+        )
+        if snapshot is None:
             if self._is_batch_model() and not self._warned_batch_cache_snapshot_unsupported:
                 logger.warning(
                     "Batch cache runtime does not expose slot-scoped dump/load APIs. "
@@ -1121,13 +1045,6 @@ class MbltWorker(WorkerBase):
                 )
                 self._warned_batch_cache_snapshot_unsupported = True
             return False
-        self.runtime_cache.store_snapshot(
-            req_id=req_id,
-            blobs=blobs,
-            block_ids=req_state.block_ids,
-            first_seq_blocks=req_state.first_seq_blocks,
-            num_tokens=next_num_tokens,
-        )
         if print_debug:
             num_blocks = len(req_state.first_seq_blocks)
             print(
@@ -1144,7 +1061,7 @@ class MbltWorker(WorkerBase):
         finished_req_state = self.req_states.pop(req_id, None)
         finished_slot_id = finished_req_state.cache_slot_id if finished_req_state is not None else None
         if finished_req_state is not None:
-            should_dump = self._should_dump_snapshot_after_step(
+            should_dump = self.runtime_cache.should_dump_snapshot_after_step(
                 req_id,
                 finished_req_state.num_computed_tokens,
             )
@@ -1173,9 +1090,9 @@ class MbltWorker(WorkerBase):
                 and print_debug
             ):
                 print(f"[cache] req={req_id} dump-on-finish")
-        if self.runtime_cache.has_snapshot(req_id):
-            self._touch_finished_snapshot(req_id)
-        self._evict_old_finished_snapshots(print_debug=print_debug)
+        for evicted_req_id in self.runtime_cache.mark_snapshot_finished(req_id):
+            if print_debug:
+                print(f"[cache] evict-finished req={evicted_req_id} reason=lru-cap")
         self.runtime_cache.clear_loaded_request(req_id)
         if self._is_batch_model():
             self._release_cache_slot(req_id)

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -34,7 +34,6 @@ from vllm_mblt.runtime_cache import (
     append_block_ids,
     first_seq_blocks,
     normalize_block_ids,
-    required_blocks,
 )
 
 logger = init_logger(__name__)
@@ -1017,7 +1016,10 @@ class MbltWorker(WorkerBase):
             elif result.action == "load-own":
                 print(f"[cache] req={req_id} slot={slot_id} load-own matched={result.matched_tokens}/{target_tokens}")
             elif result.action == "load-shared":
-                print(f"[cache] req={req_id} slot={slot_id} load-shared matched={result.matched_tokens}/{target_tokens}")
+                print(
+                    f"[cache] req={req_id} slot={slot_id} "
+                    f"load-shared matched={result.matched_tokens}/{target_tokens}"
+                )
             else:
                 print(f"[cache] req={req_id} slot={slot_id} cache-miss fallback matched=0/{target_tokens}")
         return result.matched_tokens

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -85,3 +85,199 @@ def prefix_compatible_tokens(
         return min(target_tokens, snapshot_tokens)
 
     return min(snapshot_tokens, common_blocks * block_size, target_tokens)
+
+
+class MbltRuntimeCacheManager:
+    """Owns Mobilint runtime cache snapshots and accelerator slot state.
+
+    This module intentionally deals only in plain Python values and callbacks.
+    It does not import or depend on qbruntime/cache-model implementation types.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_batch_size: int,
+        block_size: int,
+        max_finished_snapshots: int = 16,
+    ) -> None:
+        self.max_batch_size = max(0, int(max_batch_size))
+        self.block_size = int(block_size)
+        self.max_finished_snapshots = int(max_finished_snapshots)
+        self.snapshots: dict[str, RuntimeCacheSnapshot] = {}
+        self.finished_snapshot_lru: dict[str, None] = {}
+        self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
+        self.loaded_req_id: str | None = None
+        self.req_to_slot: dict[str, int] = {}
+        self.slot_to_req: dict[int, str] = {}
+        self.free_slots: list[int] = []
+        self.reset_slots(max_batch_size=self.max_batch_size)
+
+    def reset_slots(self, *, max_batch_size: int | None = None) -> None:
+        if max_batch_size is not None:
+            self.max_batch_size = max(0, int(max_batch_size))
+        self.req_to_slot = {}
+        self.slot_to_req = {}
+        self.free_slots = list(range(self.max_batch_size))
+
+    def get_slot(self, req_id: str) -> int:
+        slot_id = self.req_to_slot.get(req_id)
+        if slot_id is None:
+            raise RuntimeError(f"No accelerator cache slot is assigned for req_id={req_id}.")
+        return slot_id
+
+    def assign_slot(self, req_id: str) -> int:
+        slot_id = self.req_to_slot.get(req_id)
+        if slot_id is not None:
+            return slot_id
+        if not self.free_slots:
+            raise RuntimeError(
+                "No free accelerator cache slots remain for batch execution. "
+                f"req_id={req_id}, max_batch_size={self.max_batch_size}"
+            )
+        slot_id = self.free_slots.pop(0)
+        self.req_to_slot[req_id] = slot_id
+        self.slot_to_req[slot_id] = req_id
+        return slot_id
+
+    def release_slot(self, req_id: str) -> None:
+        slot_id = self.req_to_slot.pop(req_id, None)
+        if slot_id is None:
+            return
+        if self.slot_to_req.get(slot_id) == req_id:
+            self.slot_to_req.pop(slot_id, None)
+        if slot_id not in self.free_slots:
+            self.free_slots.append(slot_id)
+            self.free_slots.sort()
+
+    def live_slot_owner(self, slot_id: int) -> str | None:
+        return self.slot_to_req.get(slot_id)
+
+    def mark_slot_owner(self, slot_id: int, req_id: str) -> None:
+        self.slot_to_req[slot_id] = req_id
+
+    def clear_loaded_request(self, req_id: str | None = None) -> None:
+        if req_id is None or self.loaded_req_id == req_id:
+            self.loaded_req_id = None
+
+    def mark_loaded_request(self, req_id: str) -> None:
+        self.loaded_req_id = req_id
+
+    def get_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
+        return self.snapshots.get(req_id)
+
+    def has_snapshot(self, req_id: str) -> bool:
+        return req_id in self.snapshots
+
+    def snapshot_count(self) -> int:
+        return len(self.snapshots)
+
+    def store_snapshot(
+        self,
+        *,
+        req_id: str,
+        blobs: list[Any],
+        block_ids: KVBlockIds,
+        first_seq_blocks: tuple[int, ...],
+        num_tokens: int,
+    ) -> None:
+        self.finished_snapshot_lru.pop(req_id, None)
+        self.snapshots[req_id] = RuntimeCacheSnapshot(
+            blobs=blobs,
+            block_ids=normalize_block_ids(block_ids),
+            first_seq_blocks=first_seq_blocks,
+            num_tokens=max(0, int(num_tokens)),
+        )
+        self.rebuild_snapshot_index()
+
+    @staticmethod
+    def _update_snapshot_index_node(
+        node: RuntimeCacheSnapshotIndexNode,
+        req_id: str,
+        num_tokens: int,
+    ) -> None:
+        if num_tokens >= node.best_num_tokens:
+            node.best_req_id = req_id
+            node.best_num_tokens = num_tokens
+
+    def rebuild_snapshot_index(self) -> None:
+        root = RuntimeCacheSnapshotIndexNode()
+        for req_id, snapshot in self.snapshots.items():
+            node = root
+            self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
+            for block_id in snapshot.first_seq_blocks:
+                node = node.children.setdefault(block_id, RuntimeCacheSnapshotIndexNode())
+                self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
+        self.snapshot_index_root = root
+
+    def choose_snapshot(self, request: RuntimeCacheRequest) -> tuple[RuntimeCacheSnapshot | None, int]:
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0 or not request.first_seq_blocks:
+            return None, 0
+
+        best_snapshot: RuntimeCacheSnapshot | None = None
+        best_tokens = 0
+        node = self.snapshot_index_root
+        for depth, block_id in enumerate(request.first_seq_blocks, start=1):
+            node = node.children.get(block_id)
+            if node is None or node.best_req_id is None:
+                break
+
+            snapshot = self.snapshots.get(node.best_req_id)
+            if snapshot is None:
+                continue
+
+            matched_tokens = min(snapshot.num_tokens, depth * self.block_size, target_tokens)
+            if matched_tokens > best_tokens:
+                best_tokens = matched_tokens
+                best_snapshot = snapshot
+
+        return best_snapshot, best_tokens
+
+    def compatible_tokens(
+        self,
+        *,
+        target_blocks: tuple[int, ...],
+        target_tokens: int,
+        snapshot_blocks: tuple[int, ...],
+        snapshot_tokens: int,
+    ) -> int:
+        return prefix_compatible_tokens(
+            target_blocks,
+            target_tokens,
+            snapshot_blocks,
+            snapshot_tokens,
+            self.block_size,
+        )
+
+    def should_dump_snapshot_after_step(self, req_id: str, next_num_tokens: int) -> bool:
+        snapshot = self.snapshots.get(req_id)
+        if snapshot is None:
+            return True
+        if next_num_tokens <= snapshot.num_tokens:
+            return False
+        return required_blocks(next_num_tokens, self.block_size) > required_blocks(snapshot.num_tokens, self.block_size)
+
+    def touch_finished_snapshot(self, req_id: str) -> None:
+        self.finished_snapshot_lru.pop(req_id, None)
+        self.finished_snapshot_lru[req_id] = None
+
+    def evict_old_finished_snapshots(self) -> list[str]:
+        evicted: list[str] = []
+        while len(self.finished_snapshot_lru) > self.max_finished_snapshots:
+            evicted_req_id = next(iter(self.finished_snapshot_lru))
+            self.finished_snapshot_lru.pop(evicted_req_id, None)
+            self.snapshots.pop(evicted_req_id, None)
+            if self.loaded_req_id == evicted_req_id:
+                self.loaded_req_id = None
+            evicted.append(evicted_req_id)
+        if evicted:
+            self.rebuild_snapshot_index()
+        return evicted
+
+    def reset(self) -> None:
+        self.snapshots.clear()
+        self.finished_snapshot_lru.clear()
+        self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
+        self.loaded_req_id = None
+        self.reset_slots()

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -1,8 +1,12 @@
 import math
+from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
+
 
 KVBlockIds = tuple[list[int], ...]
+RuntimeCacheDumpFn = Callable[[int | None], list[Any] | None]
+RuntimeCacheLoadFn = Callable[[list[Any], int | None], bool]
 
 
 @dataclass
@@ -35,6 +39,17 @@ class RuntimeCacheSnapshotMatch:
     matched_tokens: int
     req_id: str | None = None
     is_own_snapshot: bool = False
+
+    def __iter__(self):
+        yield self.snapshot
+        yield self.matched_tokens
+
+
+@dataclass
+class RuntimeCacheLoadResult:
+    matched_tokens: int
+    action: str
+    snapshot_req_id: str | None = None
 
 
 def normalize_block_ids(block_ids: KVBlockIds) -> KVBlockIds:
@@ -98,28 +113,101 @@ def prefix_compatible_tokens(
 class MbltRuntimeCacheManager:
     """Owns Mobilint runtime cache snapshots and accelerator slot state.
 
-    This module intentionally deals only in plain Python values and callbacks.
-    It does not import or depend on qbruntime/cache-model implementation types.
+    The manager stores opaque runtime blobs and calls injected dump/load adapters
+    for qbruntime/cache-model IO. It intentionally does not import or own vLLM
+    worker/request objects or qbruntime implementation types.
     """
+
+    DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS = 16
 
     def __init__(
         self,
+        block_size: int,
+        max_finished_cache_snapshots: int | None = None,
         *,
         max_batch_size: int = 1,
-        block_size: int,
-        max_finished_snapshots: int = 16,
+        max_finished_snapshots: int | None = None,
+        dump_runtime_cache: RuntimeCacheDumpFn | None = None,
+        load_runtime_cache: RuntimeCacheLoadFn | None = None,
     ) -> None:
+        if max_finished_snapshots is None:
+            max_finished_snapshots = max_finished_cache_snapshots
+        if max_finished_snapshots is None:
+            max_finished_snapshots = self.DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS
+
         self.max_batch_size = max(0, int(max_batch_size))
         self.block_size = int(block_size)
-        self.max_finished_snapshots = int(max_finished_snapshots)
+        self.max_finished_cache_snapshots = int(max_finished_snapshots)
+        self._dump_runtime_cache_fn = dump_runtime_cache
+        self._load_runtime_cache_fn = load_runtime_cache
+
         self.snapshots: dict[str, RuntimeCacheSnapshot] = {}
-        self.finished_snapshot_lru: dict[str, None] = {}
         self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
+        self.finished_snapshot_lru: OrderedDict[str, None] = OrderedDict()
         self.loaded_req_id: str | None = None
         self.req_to_slot: dict[str, int] = {}
         self.slot_to_req: dict[int, str] = {}
         self.free_slots: list[int] = []
         self.reset_slots(max_batch_size=self.max_batch_size)
+
+    @property
+    def cache_snapshots(self) -> dict[str, RuntimeCacheSnapshot]:
+        return self.snapshots
+
+    @cache_snapshots.setter
+    def cache_snapshots(self, value: dict[str, RuntimeCacheSnapshot]) -> None:
+        self.snapshots = value
+
+    @property
+    def loaded_cache_req_id(self) -> str | None:
+        return self.loaded_req_id
+
+    @loaded_cache_req_id.setter
+    def loaded_cache_req_id(self, value: str | None) -> None:
+        self.loaded_req_id = value
+
+    @property
+    def req_to_cache_slot(self) -> dict[str, int]:
+        return self.req_to_slot
+
+    @property
+    def cache_slot_to_req(self) -> dict[int, str]:
+        return self.slot_to_req
+
+    @property
+    def free_cache_slots(self) -> list[int]:
+        return self.free_slots
+
+    @property
+    def max_finished_snapshots(self) -> int:
+        return self.max_finished_cache_snapshots
+
+    @max_finished_snapshots.setter
+    def max_finished_snapshots(self, value: int) -> None:
+        self.max_finished_cache_snapshots = int(value)
+
+    def set_io_adapters(
+        self,
+        *,
+        dump_runtime_cache: RuntimeCacheDumpFn | None = None,
+        load_runtime_cache: RuntimeCacheLoadFn | None = None,
+    ) -> None:
+        if dump_runtime_cache is not None:
+            self._dump_runtime_cache_fn = dump_runtime_cache
+        if load_runtime_cache is not None:
+            self._load_runtime_cache_fn = load_runtime_cache
+
+    def dump_runtime_cache(self, dump_cache: Any, slot_id: int | None = None) -> list[Any] | None:
+        if slot_id is None:
+            return dump_cache()
+        return dump_cache(cache_id=slot_id)
+
+    def load_runtime_cache(self, load_cache: Any, blobs: list[Any], slot_id: int | None = None) -> bool:
+        if slot_id is None:
+            load_cache(blobs)
+        else:
+            load_cache(blobs, cache_id=slot_id)
+        return True
 
     def reset_slots(self, *, max_batch_size: int | None = None) -> None:
         if max_batch_size is not None:
@@ -180,6 +268,26 @@ class MbltRuntimeCacheManager:
     def snapshot_count(self) -> int:
         return len(self.snapshots)
 
+    def put_snapshot(
+        self,
+        req_id: str,
+        blobs: list[Any],
+        block_ids: KVBlockIds,
+        num_tokens: int,
+        first_seq_block_ids: tuple[int, ...] | None = None,
+    ) -> RuntimeCacheSnapshot:
+        normalized_block_ids = normalize_block_ids(block_ids)
+        snapshot = RuntimeCacheSnapshot(
+            blobs=blobs,
+            block_ids=normalized_block_ids,
+            first_seq_blocks=first_seq_block_ids if first_seq_block_ids is not None else first_seq_blocks(normalized_block_ids),
+            num_tokens=max(0, int(num_tokens)),
+        )
+        self.finished_snapshot_lru.pop(req_id, None)
+        self.snapshots[req_id] = snapshot
+        self.rebuild_snapshot_index()
+        return snapshot
+
     def store_snapshot(
         self,
         *,
@@ -188,15 +296,36 @@ class MbltRuntimeCacheManager:
         block_ids: KVBlockIds,
         first_seq_blocks: tuple[int, ...],
         num_tokens: int,
-    ) -> None:
-        self.finished_snapshot_lru.pop(req_id, None)
-        self.snapshots[req_id] = RuntimeCacheSnapshot(
+    ) -> RuntimeCacheSnapshot:
+        return self.put_snapshot(
+            req_id=req_id,
             blobs=blobs,
-            block_ids=normalize_block_ids(block_ids),
-            first_seq_blocks=first_seq_blocks,
-            num_tokens=max(0, int(num_tokens)),
+            block_ids=block_ids,
+            first_seq_block_ids=first_seq_blocks,
+            num_tokens=num_tokens,
         )
-        self.rebuild_snapshot_index()
+
+    def dump_and_store_snapshot(
+        self,
+        *,
+        req_id: str,
+        block_ids: KVBlockIds,
+        first_seq_blocks: tuple[int, ...],
+        num_tokens: int,
+        slot_id: int | None = None,
+    ) -> RuntimeCacheSnapshot | None:
+        if self._dump_runtime_cache_fn is None:
+            raise RuntimeError("Runtime cache dump adapter is not configured.")
+        blobs = self._dump_runtime_cache_fn(slot_id)
+        if blobs is None:
+            return None
+        return self.store_snapshot(
+            req_id=req_id,
+            blobs=blobs,
+            block_ids=block_ids,
+            first_seq_blocks=first_seq_blocks,
+            num_tokens=num_tokens,
+        )
 
     def remove_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
         snapshot = self.snapshots.pop(req_id, None)
@@ -227,16 +356,84 @@ class MbltRuntimeCacheManager:
                 self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
         self.snapshot_index_root = root
 
-    def choose_prefix_snapshot(self, request: RuntimeCacheRequest) -> RuntimeCacheSnapshotMatch:
-        target_tokens = request.num_computed_tokens
-        if target_tokens <= 0 or not request.first_seq_blocks:
+    def mark_snapshot_finished(self, req_id: str) -> list[str]:
+        if req_id in self.snapshots:
+            self.touch_finished_snapshot(req_id)
+        return self.evict_old_finished_snapshots()
+
+    def touch_finished_snapshot(self, req_id: str) -> None:
+        if req_id in self.finished_snapshot_lru:
+            self.finished_snapshot_lru.move_to_end(req_id)
+        else:
+            self.finished_snapshot_lru[req_id] = None
+
+    def evict_old_finished_snapshots(self) -> list[str]:
+        evicted_req_ids: list[str] = []
+        while len(self.finished_snapshot_lru) > self.max_finished_cache_snapshots:
+            evicted_req_id, _ = self.finished_snapshot_lru.popitem(last=False)
+            self.snapshots.pop(evicted_req_id, None)
+            if self.loaded_req_id == evicted_req_id:
+                self.loaded_req_id = None
+            evicted_req_ids.append(evicted_req_id)
+        if evicted_req_ids:
+            self.rebuild_snapshot_index()
+        return evicted_req_ids
+
+    def required_blocks(self, num_tokens: int) -> int:
+        return required_blocks(num_tokens, self.block_size)
+
+    def prefix_compatible_tokens(
+        self,
+        target_blocks: tuple[int, ...],
+        target_tokens: int,
+        snapshot_blocks: tuple[int, ...],
+        snapshot_tokens: int,
+    ) -> int:
+        return prefix_compatible_tokens(
+            target_blocks,
+            target_tokens,
+            snapshot_blocks,
+            snapshot_tokens,
+            self.block_size,
+        )
+
+    def compatible_tokens(
+        self,
+        *,
+        target_blocks: tuple[int, ...],
+        target_tokens: int,
+        snapshot_blocks: tuple[int, ...],
+        snapshot_tokens: int,
+    ) -> int:
+        return self.prefix_compatible_tokens(target_blocks, target_tokens, snapshot_blocks, snapshot_tokens)
+
+    def should_dump_snapshot_after_step(self, req_id: str, next_num_tokens: int) -> bool:
+        snapshot = self.snapshots.get(req_id)
+        if snapshot is None:
+            return True
+        if next_num_tokens <= snapshot.num_tokens:
+            return False
+        return self.required_blocks(next_num_tokens) > self.required_blocks(snapshot.num_tokens)
+
+    def choose_prefix_snapshot(
+        self,
+        target_blocks: RuntimeCacheRequest | tuple[int, ...],
+        target_tokens: int | None = None,
+    ) -> RuntimeCacheSnapshotMatch:
+        if isinstance(target_blocks, RuntimeCacheRequest):
+            request = target_blocks
+            target_blocks = request.first_seq_blocks
+            target_tokens = request.num_computed_tokens
+        if target_tokens is None:
+            raise TypeError("target_tokens is required when target_blocks is not a RuntimeCacheRequest")
+        if target_tokens <= 0 or not target_blocks:
             return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
 
         best_snapshot: RuntimeCacheSnapshot | None = None
         best_req_id: str | None = None
         best_tokens = 0
         node = self.snapshot_index_root
-        for depth, block_id in enumerate(request.first_seq_blocks, start=1):
+        for depth, block_id in enumerate(target_blocks, start=1):
             node = node.children.get(block_id)
             if node is None or node.best_req_id is None:
                 break
@@ -253,82 +450,77 @@ class MbltRuntimeCacheManager:
 
         return RuntimeCacheSnapshotMatch(snapshot=best_snapshot, matched_tokens=best_tokens, req_id=best_req_id)
 
-    def choose_snapshot(self, request: RuntimeCacheRequest) -> tuple[RuntimeCacheSnapshot | None, int]:
+    def choose_snapshot(self, request: RuntimeCacheRequest) -> RuntimeCacheSnapshotMatch:
         target_tokens = request.num_computed_tokens
         if target_tokens <= 0:
-            return None, 0
+            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
 
         own_snapshot = self.snapshots.get(request.req_id)
         if own_snapshot is not None:
-            matched_tokens = self.compatible_tokens(
+            matched_tokens = self.prefix_compatible_tokens(
                 target_blocks=request.first_seq_blocks,
                 target_tokens=target_tokens,
                 snapshot_blocks=own_snapshot.first_seq_blocks,
                 snapshot_tokens=own_snapshot.num_tokens,
             )
             if matched_tokens >= target_tokens:
-                return own_snapshot, target_tokens
+                return RuntimeCacheSnapshotMatch(
+                    snapshot=own_snapshot,
+                    matched_tokens=target_tokens,
+                    req_id=request.req_id,
+                    is_own_snapshot=True,
+                )
 
-        match = self.choose_prefix_snapshot(request)
-        return match.snapshot, match.matched_tokens
+        return self.choose_prefix_snapshot(request.first_seq_blocks, target_tokens)
 
-    def compatible_tokens(
-        self,
-        *,
-        target_blocks: tuple[int, ...],
-        target_tokens: int,
-        snapshot_blocks: tuple[int, ...],
-        snapshot_tokens: int,
-    ) -> int:
-        return prefix_compatible_tokens(
-            target_blocks,
-            target_tokens,
-            snapshot_blocks,
-            snapshot_tokens,
-            self.block_size,
-        )
+    def load_for_request(self, request: RuntimeCacheRequest) -> RuntimeCacheLoadResult:
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            self.clear_loaded_request()
+            return RuntimeCacheLoadResult(matched_tokens=0, action="skip-empty")
 
-    def should_dump_snapshot_after_step(self, req_id: str, next_num_tokens: int) -> bool:
-        snapshot = self.snapshots.get(req_id)
-        if snapshot is None:
-            return True
-        if next_num_tokens <= snapshot.num_tokens:
-            return False
-        return required_blocks(next_num_tokens, self.block_size) > required_blocks(snapshot.num_tokens, self.block_size)
+        if self.loaded_req_id == request.req_id:
+            return RuntimeCacheLoadResult(matched_tokens=target_tokens, action="reuse-live", snapshot_req_id=request.req_id)
 
-    def dump_runtime_cache(self, dump_cache: Any, slot_id: int | None = None) -> list[Any] | None:
-        if slot_id is None:
-            return dump_cache()
-        return dump_cache(cache_id=slot_id)
+        match = self.choose_snapshot(request)
+        if match.snapshot is None or match.matched_tokens <= 0:
+            self.clear_loaded_request()
+            return RuntimeCacheLoadResult(matched_tokens=0, action="miss")
 
-    def load_runtime_cache(self, load_cache: Any, blobs: list[Any], slot_id: int | None = None) -> bool:
-        if slot_id is None:
-            load_cache(blobs)
-        else:
-            load_cache(blobs, cache_id=slot_id)
-        return True
+        if self._load_runtime_cache_fn is None:
+            raise RuntimeError("Runtime cache load adapter is not configured.")
+        if not self._load_runtime_cache_fn(match.snapshot.blobs, None):
+            self.clear_loaded_request()
+            return RuntimeCacheLoadResult(matched_tokens=0, action="load-failed", snapshot_req_id=match.req_id)
 
-    def touch_finished_snapshot(self, req_id: str) -> None:
-        self.finished_snapshot_lru.pop(req_id, None)
-        self.finished_snapshot_lru[req_id] = None
+        self.mark_loaded_request(request.req_id)
+        action = "load-own" if match.is_own_snapshot else "load-shared"
+        return RuntimeCacheLoadResult(matched_tokens=match.matched_tokens, action=action, snapshot_req_id=match.req_id)
 
-    def mark_snapshot_finished(self, req_id: str) -> list[str]:
-        if req_id in self.snapshots:
-            self.touch_finished_snapshot(req_id)
-        return self.evict_old_finished_snapshots()
+    def load_for_slot(self, request: RuntimeCacheRequest, slot_id: int) -> RuntimeCacheLoadResult:
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            self.mark_slot_owner(slot_id, request.req_id)
+            return RuntimeCacheLoadResult(matched_tokens=0, action="skip-empty", snapshot_req_id=request.req_id)
 
-    def evict_old_finished_snapshots(self) -> list[str]:
-        evicted: list[str] = []
-        while len(self.finished_snapshot_lru) > self.max_finished_snapshots:
-            evicted_req_id = next(iter(self.finished_snapshot_lru))
-            self.finished_snapshot_lru.pop(evicted_req_id, None)
-            self.snapshots.pop(evicted_req_id, None)
-            if self.loaded_req_id == evicted_req_id:
-                self.loaded_req_id = None
-            evicted.append(evicted_req_id)
-        if evicted:
-            self.rebuild_snapshot_index()
-        return evicted
+        if self.live_slot_owner(slot_id) == request.req_id:
+            return RuntimeCacheLoadResult(matched_tokens=target_tokens, action="reuse-live", snapshot_req_id=request.req_id)
+
+        match = self.choose_snapshot(request)
+        if match.snapshot is not None and match.matched_tokens > 0:
+            if self._load_runtime_cache_fn is None:
+                raise RuntimeError("Runtime cache load adapter is not configured.")
+            if self._load_runtime_cache_fn(match.snapshot.blobs, slot_id):
+                self.mark_slot_owner(slot_id, request.req_id)
+                action = "load-own" if match.is_own_snapshot else "load-shared"
+                return RuntimeCacheLoadResult(
+                    matched_tokens=match.matched_tokens,
+                    action=action,
+                    snapshot_req_id=match.req_id,
+                )
+
+        self.mark_slot_owner(slot_id, request.req_id)
+        return RuntimeCacheLoadResult(matched_tokens=0, action="miss")
 
     def reset(self) -> None:
         self.snapshots.clear()

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -1,4 +1,5 @@
 import math
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -27,6 +28,219 @@ class RuntimeCacheSnapshotIndexNode:
     children: dict[int, "RuntimeCacheSnapshotIndexNode"] = field(default_factory=dict)
     best_req_id: str | None = None
     best_num_tokens: int = 0
+
+
+@dataclass
+class RuntimeCacheSnapshotMatch:
+    snapshot: RuntimeCacheSnapshot | None
+    matched_tokens: int
+    req_id: str | None = None
+    is_own_snapshot: bool = False
+
+
+class MbltRuntimeCacheManager:
+    """Owns Mobilint runtime cache snapshot state.
+
+    The manager intentionally stores opaque cache blobs only. It does not import
+    qbruntime cache models or vLLM request/runtime objects; callers provide the
+    block-ID metadata and perform actual dump/load operations at the boundary.
+    """
+
+    DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS = 16
+
+    def __init__(
+        self,
+        block_size: int,
+        max_finished_cache_snapshots: int = DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS,
+    ) -> None:
+        self.block_size = int(block_size)
+        self.max_finished_cache_snapshots = int(max_finished_cache_snapshots)
+        self.cache_snapshots: dict[str, RuntimeCacheSnapshot] = {}
+        self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
+        self.finished_snapshot_lru: OrderedDict[str, None] = OrderedDict()
+        self.loaded_cache_req_id: str | None = None
+
+    @staticmethod
+    def _update_snapshot_index_node(
+        node: RuntimeCacheSnapshotIndexNode,
+        req_id: str,
+        num_tokens: int,
+    ) -> None:
+        if num_tokens >= node.best_num_tokens:
+            node.best_req_id = req_id
+            node.best_num_tokens = num_tokens
+
+    def rebuild_snapshot_index(self) -> None:
+        root = RuntimeCacheSnapshotIndexNode()
+        for req_id, snapshot in self.cache_snapshots.items():
+            node = root
+            self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
+            for block_id in snapshot.first_seq_blocks:
+                node = node.children.setdefault(block_id, RuntimeCacheSnapshotIndexNode())
+                self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
+        self.snapshot_index_root = root
+
+    def put_snapshot(
+        self,
+        req_id: str,
+        blobs: list[Any],
+        block_ids: KVBlockIds,
+        num_tokens: int,
+        first_seq_block_ids: tuple[int, ...] | None = None,
+    ) -> RuntimeCacheSnapshot:
+        """Store or replace a request snapshot and update the prefix index.
+
+        A freshly stored snapshot represents active request state, so it is
+        removed from the finished-session LRU pool until the caller explicitly
+        marks it finished.
+        """
+
+        self.finished_snapshot_lru.pop(req_id, None)
+        normalized_block_ids = normalize_block_ids(block_ids)
+        snapshot = RuntimeCacheSnapshot(
+            blobs=blobs,
+            block_ids=normalized_block_ids,
+            first_seq_blocks=(
+                first_seq_block_ids if first_seq_block_ids is not None else first_seq_blocks(normalized_block_ids)
+            ),
+            num_tokens=max(0, int(num_tokens)),
+        )
+        self.cache_snapshots[req_id] = snapshot
+        self.rebuild_snapshot_index()
+        return snapshot
+
+    def remove_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
+        snapshot = self.cache_snapshots.pop(req_id, None)
+        self.finished_snapshot_lru.pop(req_id, None)
+        if self.loaded_cache_req_id == req_id:
+            self.loaded_cache_req_id = None
+        if snapshot is not None:
+            self.rebuild_snapshot_index()
+        return snapshot
+
+    def get_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
+        return self.cache_snapshots.get(req_id)
+
+    def touch_finished_snapshot(self, req_id: str) -> None:
+        if req_id in self.finished_snapshot_lru:
+            self.finished_snapshot_lru.move_to_end(req_id)
+        else:
+            self.finished_snapshot_lru[req_id] = None
+
+    def mark_snapshot_finished(self, req_id: str) -> list[str]:
+        """Add an existing snapshot to the finished LRU and evict over-cap entries."""
+
+        if req_id in self.cache_snapshots:
+            self.touch_finished_snapshot(req_id)
+        return self.evict_old_finished_snapshots()
+
+    def evict_old_finished_snapshots(self) -> list[str]:
+        evicted_req_ids: list[str] = []
+        while len(self.finished_snapshot_lru) > self.max_finished_cache_snapshots:
+            evicted_req_id, _ = self.finished_snapshot_lru.popitem(last=False)
+            self.cache_snapshots.pop(evicted_req_id, None)
+            evicted_req_ids.append(evicted_req_id)
+            if self.loaded_cache_req_id == evicted_req_id:
+                self.loaded_cache_req_id = None
+        if evicted_req_ids:
+            self.rebuild_snapshot_index()
+        return evicted_req_ids
+
+    def required_blocks(self, num_tokens: int) -> int:
+        return required_blocks(num_tokens, self.block_size)
+
+    def prefix_compatible_tokens(
+        self,
+        target_blocks: tuple[int, ...],
+        target_tokens: int,
+        snapshot_blocks: tuple[int, ...],
+        snapshot_tokens: int,
+    ) -> int:
+        return prefix_compatible_tokens(
+            target_blocks,
+            target_tokens,
+            snapshot_blocks,
+            snapshot_tokens,
+            self.block_size,
+        )
+
+    def should_dump_snapshot_after_step(self, req_id: str, next_num_tokens: int) -> bool:
+        snapshot = self.cache_snapshots.get(req_id)
+        if snapshot is None:
+            return True
+        if next_num_tokens <= snapshot.num_tokens:
+            return False
+        return self.required_blocks(next_num_tokens) > self.required_blocks(snapshot.num_tokens)
+
+    def choose_prefix_snapshot(
+        self,
+        target_blocks: tuple[int, ...],
+        target_tokens: int,
+    ) -> RuntimeCacheSnapshotMatch:
+        """Return the best indexed prefix snapshot for the target first sequence.
+
+        This mirrors the legacy worker lookup: walk the target block path and at
+        each depth consider that index node's best snapshot, capped by depth,
+        block size, snapshot tokens, and target tokens.
+        """
+
+        if target_tokens <= 0 or not target_blocks:
+            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
+
+        best_snapshot: RuntimeCacheSnapshot | None = None
+        best_req_id: str | None = None
+        best_tokens = 0
+        node = self.snapshot_index_root
+        for depth, block_id in enumerate(target_blocks, start=1):
+            node = node.children.get(block_id)
+            if node is None or node.best_req_id is None:
+                break
+
+            snapshot = self.cache_snapshots.get(node.best_req_id)
+            if snapshot is None:
+                continue
+
+            matched_tokens = min(
+                snapshot.num_tokens,
+                depth * self.block_size,
+                target_tokens,
+            )
+            if matched_tokens > best_tokens:
+                best_tokens = matched_tokens
+                best_snapshot = snapshot
+                best_req_id = node.best_req_id
+
+        return RuntimeCacheSnapshotMatch(snapshot=best_snapshot, matched_tokens=best_tokens, req_id=best_req_id)
+
+    def choose_snapshot(self, request: RuntimeCacheRequest) -> RuntimeCacheSnapshotMatch:
+        """Choose a cache snapshot for a request, preserving legacy priority.
+
+        A fully compatible snapshot from the same request wins before shared
+        prefix lookup. If the own snapshot is only partially compatible, the
+        indexed best-prefix path is used, matching the existing worker behavior.
+        """
+
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
+
+        own_snapshot = self.cache_snapshots.get(request.req_id)
+        if own_snapshot is not None:
+            matched_tokens = self.prefix_compatible_tokens(
+                target_blocks=request.first_seq_blocks,
+                target_tokens=target_tokens,
+                snapshot_blocks=own_snapshot.first_seq_blocks,
+                snapshot_tokens=own_snapshot.num_tokens,
+            )
+            if matched_tokens >= target_tokens:
+                return RuntimeCacheSnapshotMatch(
+                    snapshot=own_snapshot,
+                    matched_tokens=target_tokens,
+                    req_id=request.req_id,
+                    is_own_snapshot=True,
+                )
+
+        return self.choose_prefix_snapshot(request.first_seq_blocks, target_tokens)
 
 
 def normalize_block_ids(block_ids: KVBlockIds) -> KVBlockIds:

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -1,5 +1,4 @@
 import math
-from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -36,211 +35,6 @@ class RuntimeCacheSnapshotMatch:
     matched_tokens: int
     req_id: str | None = None
     is_own_snapshot: bool = False
-
-
-class MbltRuntimeCacheManager:
-    """Owns Mobilint runtime cache snapshot state.
-
-    The manager intentionally stores opaque cache blobs only. It does not import
-    qbruntime cache models or vLLM request/runtime objects; callers provide the
-    block-ID metadata and perform actual dump/load operations at the boundary.
-    """
-
-    DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS = 16
-
-    def __init__(
-        self,
-        block_size: int,
-        max_finished_cache_snapshots: int = DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS,
-    ) -> None:
-        self.block_size = int(block_size)
-        self.max_finished_cache_snapshots = int(max_finished_cache_snapshots)
-        self.cache_snapshots: dict[str, RuntimeCacheSnapshot] = {}
-        self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
-        self.finished_snapshot_lru: OrderedDict[str, None] = OrderedDict()
-        self.loaded_cache_req_id: str | None = None
-
-    @staticmethod
-    def _update_snapshot_index_node(
-        node: RuntimeCacheSnapshotIndexNode,
-        req_id: str,
-        num_tokens: int,
-    ) -> None:
-        if num_tokens >= node.best_num_tokens:
-            node.best_req_id = req_id
-            node.best_num_tokens = num_tokens
-
-    def rebuild_snapshot_index(self) -> None:
-        root = RuntimeCacheSnapshotIndexNode()
-        for req_id, snapshot in self.cache_snapshots.items():
-            node = root
-            self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
-            for block_id in snapshot.first_seq_blocks:
-                node = node.children.setdefault(block_id, RuntimeCacheSnapshotIndexNode())
-                self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
-        self.snapshot_index_root = root
-
-    def put_snapshot(
-        self,
-        req_id: str,
-        blobs: list[Any],
-        block_ids: KVBlockIds,
-        num_tokens: int,
-        first_seq_block_ids: tuple[int, ...] | None = None,
-    ) -> RuntimeCacheSnapshot:
-        """Store or replace a request snapshot and update the prefix index.
-
-        A freshly stored snapshot represents active request state, so it is
-        removed from the finished-session LRU pool until the caller explicitly
-        marks it finished.
-        """
-
-        self.finished_snapshot_lru.pop(req_id, None)
-        normalized_block_ids = normalize_block_ids(block_ids)
-        snapshot = RuntimeCacheSnapshot(
-            blobs=blobs,
-            block_ids=normalized_block_ids,
-            first_seq_blocks=(
-                first_seq_block_ids if first_seq_block_ids is not None else first_seq_blocks(normalized_block_ids)
-            ),
-            num_tokens=max(0, int(num_tokens)),
-        )
-        self.cache_snapshots[req_id] = snapshot
-        self.rebuild_snapshot_index()
-        return snapshot
-
-    def remove_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
-        snapshot = self.cache_snapshots.pop(req_id, None)
-        self.finished_snapshot_lru.pop(req_id, None)
-        if self.loaded_cache_req_id == req_id:
-            self.loaded_cache_req_id = None
-        if snapshot is not None:
-            self.rebuild_snapshot_index()
-        return snapshot
-
-    def get_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
-        return self.cache_snapshots.get(req_id)
-
-    def touch_finished_snapshot(self, req_id: str) -> None:
-        if req_id in self.finished_snapshot_lru:
-            self.finished_snapshot_lru.move_to_end(req_id)
-        else:
-            self.finished_snapshot_lru[req_id] = None
-
-    def mark_snapshot_finished(self, req_id: str) -> list[str]:
-        """Add an existing snapshot to the finished LRU and evict over-cap entries."""
-
-        if req_id in self.cache_snapshots:
-            self.touch_finished_snapshot(req_id)
-        return self.evict_old_finished_snapshots()
-
-    def evict_old_finished_snapshots(self) -> list[str]:
-        evicted_req_ids: list[str] = []
-        while len(self.finished_snapshot_lru) > self.max_finished_cache_snapshots:
-            evicted_req_id, _ = self.finished_snapshot_lru.popitem(last=False)
-            self.cache_snapshots.pop(evicted_req_id, None)
-            evicted_req_ids.append(evicted_req_id)
-            if self.loaded_cache_req_id == evicted_req_id:
-                self.loaded_cache_req_id = None
-        if evicted_req_ids:
-            self.rebuild_snapshot_index()
-        return evicted_req_ids
-
-    def required_blocks(self, num_tokens: int) -> int:
-        return required_blocks(num_tokens, self.block_size)
-
-    def prefix_compatible_tokens(
-        self,
-        target_blocks: tuple[int, ...],
-        target_tokens: int,
-        snapshot_blocks: tuple[int, ...],
-        snapshot_tokens: int,
-    ) -> int:
-        return prefix_compatible_tokens(
-            target_blocks,
-            target_tokens,
-            snapshot_blocks,
-            snapshot_tokens,
-            self.block_size,
-        )
-
-    def should_dump_snapshot_after_step(self, req_id: str, next_num_tokens: int) -> bool:
-        snapshot = self.cache_snapshots.get(req_id)
-        if snapshot is None:
-            return True
-        if next_num_tokens <= snapshot.num_tokens:
-            return False
-        return self.required_blocks(next_num_tokens) > self.required_blocks(snapshot.num_tokens)
-
-    def choose_prefix_snapshot(
-        self,
-        target_blocks: tuple[int, ...],
-        target_tokens: int,
-    ) -> RuntimeCacheSnapshotMatch:
-        """Return the best indexed prefix snapshot for the target first sequence.
-
-        This mirrors the legacy worker lookup: walk the target block path and at
-        each depth consider that index node's best snapshot, capped by depth,
-        block size, snapshot tokens, and target tokens.
-        """
-
-        if target_tokens <= 0 or not target_blocks:
-            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
-
-        best_snapshot: RuntimeCacheSnapshot | None = None
-        best_req_id: str | None = None
-        best_tokens = 0
-        node = self.snapshot_index_root
-        for depth, block_id in enumerate(target_blocks, start=1):
-            node = node.children.get(block_id)
-            if node is None or node.best_req_id is None:
-                break
-
-            snapshot = self.cache_snapshots.get(node.best_req_id)
-            if snapshot is None:
-                continue
-
-            matched_tokens = min(
-                snapshot.num_tokens,
-                depth * self.block_size,
-                target_tokens,
-            )
-            if matched_tokens > best_tokens:
-                best_tokens = matched_tokens
-                best_snapshot = snapshot
-                best_req_id = node.best_req_id
-
-        return RuntimeCacheSnapshotMatch(snapshot=best_snapshot, matched_tokens=best_tokens, req_id=best_req_id)
-
-    def choose_snapshot(self, request: RuntimeCacheRequest) -> RuntimeCacheSnapshotMatch:
-        """Choose a cache snapshot for a request, preserving legacy priority.
-
-        A fully compatible snapshot from the same request wins before shared
-        prefix lookup. If the own snapshot is only partially compatible, the
-        indexed best-prefix path is used, matching the existing worker behavior.
-        """
-
-        target_tokens = request.num_computed_tokens
-        if target_tokens <= 0:
-            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
-
-        own_snapshot = self.cache_snapshots.get(request.req_id)
-        if own_snapshot is not None:
-            matched_tokens = self.prefix_compatible_tokens(
-                target_blocks=request.first_seq_blocks,
-                target_tokens=target_tokens,
-                snapshot_blocks=own_snapshot.first_seq_blocks,
-                snapshot_tokens=own_snapshot.num_tokens,
-            )
-            if matched_tokens >= target_tokens:
-                return RuntimeCacheSnapshotMatch(
-                    snapshot=own_snapshot,
-                    matched_tokens=target_tokens,
-                    req_id=request.req_id,
-                    is_own_snapshot=True,
-                )
-
-        return self.choose_prefix_snapshot(request.first_seq_blocks, target_tokens)
 
 
 def normalize_block_ids(block_ids: KVBlockIds) -> KVBlockIds:
@@ -311,7 +105,7 @@ class MbltRuntimeCacheManager:
     def __init__(
         self,
         *,
-        max_batch_size: int,
+        max_batch_size: int = 1,
         block_size: int,
         max_finished_snapshots: int = 16,
     ) -> None:
@@ -404,6 +198,15 @@ class MbltRuntimeCacheManager:
         )
         self.rebuild_snapshot_index()
 
+    def remove_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
+        snapshot = self.snapshots.pop(req_id, None)
+        self.finished_snapshot_lru.pop(req_id, None)
+        if self.loaded_req_id == req_id:
+            self.loaded_req_id = None
+        if snapshot is not None:
+            self.rebuild_snapshot_index()
+        return snapshot
+
     @staticmethod
     def _update_snapshot_index_node(
         node: RuntimeCacheSnapshotIndexNode,
@@ -424,12 +227,13 @@ class MbltRuntimeCacheManager:
                 self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
         self.snapshot_index_root = root
 
-    def choose_snapshot(self, request: RuntimeCacheRequest) -> tuple[RuntimeCacheSnapshot | None, int]:
+    def choose_prefix_snapshot(self, request: RuntimeCacheRequest) -> RuntimeCacheSnapshotMatch:
         target_tokens = request.num_computed_tokens
         if target_tokens <= 0 or not request.first_seq_blocks:
-            return None, 0
+            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
 
         best_snapshot: RuntimeCacheSnapshot | None = None
+        best_req_id: str | None = None
         best_tokens = 0
         node = self.snapshot_index_root
         for depth, block_id in enumerate(request.first_seq_blocks, start=1):
@@ -445,8 +249,28 @@ class MbltRuntimeCacheManager:
             if matched_tokens > best_tokens:
                 best_tokens = matched_tokens
                 best_snapshot = snapshot
+                best_req_id = node.best_req_id
 
-        return best_snapshot, best_tokens
+        return RuntimeCacheSnapshotMatch(snapshot=best_snapshot, matched_tokens=best_tokens, req_id=best_req_id)
+
+    def choose_snapshot(self, request: RuntimeCacheRequest) -> tuple[RuntimeCacheSnapshot | None, int]:
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            return None, 0
+
+        own_snapshot = self.snapshots.get(request.req_id)
+        if own_snapshot is not None:
+            matched_tokens = self.compatible_tokens(
+                target_blocks=request.first_seq_blocks,
+                target_tokens=target_tokens,
+                snapshot_blocks=own_snapshot.first_seq_blocks,
+                snapshot_tokens=own_snapshot.num_tokens,
+            )
+            if matched_tokens >= target_tokens:
+                return own_snapshot, target_tokens
+
+        match = self.choose_prefix_snapshot(request)
+        return match.snapshot, match.matched_tokens
 
     def compatible_tokens(
         self,
@@ -472,9 +296,26 @@ class MbltRuntimeCacheManager:
             return False
         return required_blocks(next_num_tokens, self.block_size) > required_blocks(snapshot.num_tokens, self.block_size)
 
+    def dump_runtime_cache(self, dump_cache: Any, slot_id: int | None = None) -> list[Any] | None:
+        if slot_id is None:
+            return dump_cache()
+        return dump_cache(cache_id=slot_id)
+
+    def load_runtime_cache(self, load_cache: Any, blobs: list[Any], slot_id: int | None = None) -> bool:
+        if slot_id is None:
+            load_cache(blobs)
+        else:
+            load_cache(blobs, cache_id=slot_id)
+        return True
+
     def touch_finished_snapshot(self, req_id: str) -> None:
         self.finished_snapshot_lru.pop(req_id, None)
         self.finished_snapshot_lru[req_id] = None
+
+    def mark_snapshot_finished(self, req_id: str) -> list[str]:
+        if req_id in self.snapshots:
+            self.touch_finished_snapshot(req_id)
+        return self.evict_old_finished_snapshots()
 
     def evict_old_finished_snapshots(self) -> list[str]:
         evicted: list[str] = []

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -1,0 +1,87 @@
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+KVBlockIds = tuple[list[int], ...]
+
+
+@dataclass
+class RuntimeCacheSnapshot:
+    blobs: list[Any]
+    block_ids: KVBlockIds
+    first_seq_blocks: tuple[int, ...]
+    num_tokens: int
+
+
+@dataclass
+class RuntimeCacheRequest:
+    req_id: str
+    block_ids: KVBlockIds
+    first_seq_blocks: tuple[int, ...]
+    num_computed_tokens: int
+    cache_slot_id: int | None = None
+
+
+@dataclass
+class RuntimeCacheSnapshotIndexNode:
+    children: dict[int, "RuntimeCacheSnapshotIndexNode"] = field(default_factory=dict)
+    best_req_id: str | None = None
+    best_num_tokens: int = 0
+
+
+def normalize_block_ids(block_ids: KVBlockIds) -> KVBlockIds:
+    return tuple(list(seq) for seq in block_ids)
+
+
+def append_block_ids(
+    current_block_ids: KVBlockIds,
+    new_block_ids: KVBlockIds,
+) -> KVBlockIds:
+    if not current_block_ids:
+        return normalize_block_ids(new_block_ids)
+    if len(current_block_ids) != len(new_block_ids):
+        raise RuntimeError(
+            f"KV block_ids layout mismatch: current={len(current_block_ids)} seqs, new={len(new_block_ids)} seqs"
+        )
+    merged_block_ids: list[list[int]] = []
+    for current_seq_blocks, new_seq_blocks in zip(current_block_ids, new_block_ids):
+        merged_block_ids.append(list(current_seq_blocks) + list(new_seq_blocks))
+    return tuple(merged_block_ids)
+
+
+def first_seq_blocks(block_ids: KVBlockIds) -> tuple[int, ...]:
+    if len(block_ids) == 0:
+        return ()
+    return tuple(block_ids[0])
+
+
+def required_blocks(num_tokens: int, block_size: int) -> int:
+    if num_tokens <= 0:
+        return 0
+    return math.ceil(num_tokens / block_size)
+
+
+def prefix_compatible_tokens(
+    target_blocks: tuple[int, ...],
+    target_tokens: int,
+    snapshot_blocks: tuple[int, ...],
+    snapshot_tokens: int,
+    block_size: int,
+) -> int:
+    if target_tokens <= 0 or snapshot_tokens <= 0:
+        return 0
+
+    needed_target_blocks = required_blocks(target_tokens, block_size)
+    common_blocks = 0
+    for i in range(min(needed_target_blocks, len(target_blocks), len(snapshot_blocks))):
+        if target_blocks[i] != snapshot_blocks[i]:
+            break
+        common_blocks += 1
+
+    if common_blocks == 0:
+        return 0
+
+    if common_blocks >= needed_target_blocks:
+        return min(target_tokens, snapshot_tokens)
+
+    return min(snapshot_tokens, common_blocks * block_size, target_tokens)

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -1,12 +1,14 @@
 import math
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
-
+from typing import Any
 
 KVBlockIds = tuple[list[int], ...]
 RuntimeCacheDumpFn = Callable[[int | None], list[Any] | None]
 RuntimeCacheLoadFn = Callable[[list[Any], int | None], bool]
+DumpRuntimeCache = RuntimeCacheDumpFn
+LoadRuntimeCache = RuntimeCacheLoadFn
 
 
 @dataclass
@@ -41,6 +43,7 @@ class RuntimeCacheSnapshotMatch:
     is_own_snapshot: bool = False
 
     def __iter__(self):
+        # Preserve the worker-facing legacy shape: snapshot, matched_tokens.
         yield self.snapshot
         yield self.matched_tokens
 
@@ -48,8 +51,509 @@ class RuntimeCacheSnapshotMatch:
 @dataclass
 class RuntimeCacheLoadResult:
     matched_tokens: int
-    action: str
+    loaded: bool = False
+    reused_live_cache: bool = False
+    cache_miss: bool = False
+    loaded_snapshot_req_id: str | None = None
+    is_own_snapshot: bool = False
+    action: str = "cache-miss"
     snapshot_req_id: str | None = None
+
+
+class MbltRuntimeCacheManager:
+    """Owns Mobilint runtime cache snapshots and accelerator ownership state.
+
+    The manager intentionally stores opaque cache blobs only. It does not import
+    qbruntime cache models or vLLM runtime objects. Actual cache dump/load IO is
+    performed only through callables injected by the worker/integration layer.
+    """
+
+    DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS = 16
+
+    def __init__(
+        self,
+        block_size: int,
+        max_finished_cache_snapshots: int | None = None,
+        *,
+        max_batch_size: int = 1,
+        max_finished_snapshots: int | None = None,
+        dump_runtime_cache: RuntimeCacheDumpFn | None = None,
+        load_runtime_cache: RuntimeCacheLoadFn | None = None,
+    ) -> None:
+        if max_finished_snapshots is None:
+            max_finished_snapshots = max_finished_cache_snapshots
+        if max_finished_snapshots is None:
+            max_finished_snapshots = self.DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS
+
+        self.block_size = int(block_size)
+        self.max_batch_size = max(0, int(max_batch_size))
+        self.max_finished_cache_snapshots = int(max_finished_snapshots)
+        self._dump_runtime_cache_fn = dump_runtime_cache
+        self._load_runtime_cache_fn = load_runtime_cache
+
+        self.snapshots: dict[str, RuntimeCacheSnapshot] = {}
+        self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
+        self.finished_snapshot_lru: OrderedDict[str, None] = OrderedDict()
+
+        # Single-cache runtime owner.
+        self.loaded_req_id: str | None = None
+
+        # Batch cache slot assignment and live slot owners.
+        self.req_to_slot: dict[str, int] = {}
+        self.slot_to_req: dict[int, str] = {}
+        self.slot_live_req: dict[int, str] = {}
+        self.free_slots: list[int] = []
+        self.reset_slots(max_batch_size=self.max_batch_size)
+
+    @property
+    def cache_snapshots(self) -> dict[str, RuntimeCacheSnapshot]:
+        return self.snapshots
+
+    @cache_snapshots.setter
+    def cache_snapshots(self, snapshots: dict[str, RuntimeCacheSnapshot]) -> None:
+        self.snapshots = snapshots
+        self.rebuild_snapshot_index()
+
+    @property
+    def loaded_cache_req_id(self) -> str | None:
+        return self.loaded_req_id
+
+    @loaded_cache_req_id.setter
+    def loaded_cache_req_id(self, req_id: str | None) -> None:
+        self.loaded_req_id = req_id
+
+    @property
+    def req_to_cache_slot(self) -> dict[str, int]:
+        return self.req_to_slot
+
+    @property
+    def cache_slot_to_req(self) -> dict[int, str]:
+        return self.slot_to_req
+
+    @property
+    def free_cache_slots(self) -> list[int]:
+        return self.free_slots
+
+    def reset_slots(self, *, max_batch_size: int | None = None) -> None:
+        if max_batch_size is not None:
+            self.max_batch_size = max(0, int(max_batch_size))
+        self.req_to_slot = {}
+        self.slot_to_req = {}
+        self.slot_live_req = {}
+        self.free_slots = list(range(self.max_batch_size))
+
+    def get_slot(self, req_id: str) -> int:
+        slot_id = self.req_to_slot.get(req_id)
+        if slot_id is None:
+            raise RuntimeError(f"No accelerator cache slot is assigned for req_id={req_id}.")
+        return slot_id
+
+    def assign_slot(self, req_id: str) -> int:
+        existing_slot = self.req_to_slot.get(req_id)
+        if existing_slot is not None:
+            return existing_slot
+        if not self.free_slots:
+            raise RuntimeError(
+                "No free accelerator cache slots remain for batch execution. "
+                f"req_id={req_id}, max_batch_size={self.max_batch_size}"
+            )
+        slot_id = self.free_slots.pop(0)
+        self.req_to_slot[req_id] = slot_id
+        self.slot_to_req[slot_id] = req_id
+        return slot_id
+
+    def release_slot(self, req_id: str) -> None:
+        slot_id = self.req_to_slot.pop(req_id, None)
+        if slot_id is None:
+            return
+        if self.slot_to_req.get(slot_id) == req_id:
+            self.slot_to_req.pop(slot_id, None)
+        if self.slot_live_req.get(slot_id) == req_id:
+            self.slot_live_req.pop(slot_id, None)
+        if slot_id not in self.free_slots:
+            self.free_slots.append(slot_id)
+            self.free_slots.sort()
+
+    def live_slot_owner(self, slot_id: int) -> str | None:
+        return self.slot_live_req.get(slot_id)
+
+    def mark_slot_owner(self, slot_id: int, req_id: str) -> None:
+        self.slot_live_req[slot_id] = req_id
+
+    def clear_loaded_request(self, req_id: str | None = None) -> None:
+        if req_id is None or self.loaded_req_id == req_id:
+            self.loaded_req_id = None
+
+    def mark_loaded_request(self, req_id: str) -> None:
+        self.loaded_req_id = req_id
+
+    def get_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
+        return self.snapshots.get(req_id)
+
+    def has_snapshot(self, req_id: str) -> bool:
+        return req_id in self.snapshots
+
+    def snapshot_count(self) -> int:
+        return len(self.snapshots)
+
+    def put_snapshot(
+        self,
+        req_id: str,
+        blobs: list[Any],
+        block_ids: KVBlockIds,
+        num_tokens: int,
+        first_seq_block_ids: tuple[int, ...] | None = None,
+    ) -> RuntimeCacheSnapshot:
+        return self.store_snapshot(
+            req_id=req_id,
+            blobs=blobs,
+            block_ids=block_ids,
+            first_seq_blocks=first_seq_block_ids if first_seq_block_ids is not None else first_seq_blocks(block_ids),
+            num_tokens=num_tokens,
+        )
+
+    def store_snapshot(
+        self,
+        *,
+        req_id: str,
+        blobs: list[Any],
+        block_ids: KVBlockIds,
+        first_seq_blocks: tuple[int, ...],
+        num_tokens: int,
+    ) -> RuntimeCacheSnapshot:
+        self.finished_snapshot_lru.pop(req_id, None)
+        snapshot = RuntimeCacheSnapshot(
+            blobs=blobs,
+            block_ids=normalize_block_ids(block_ids),
+            first_seq_blocks=tuple(first_seq_blocks),
+            num_tokens=max(0, int(num_tokens)),
+        )
+        self.snapshots[req_id] = snapshot
+        self.rebuild_snapshot_index()
+        return snapshot
+
+    def remove_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
+        snapshot = self.snapshots.pop(req_id, None)
+        self.finished_snapshot_lru.pop(req_id, None)
+        self.clear_loaded_request(req_id)
+        if snapshot is not None:
+            self.rebuild_snapshot_index()
+        return snapshot
+
+    @staticmethod
+    def _update_snapshot_index_node(
+        node: RuntimeCacheSnapshotIndexNode,
+        req_id: str,
+        num_tokens: int,
+    ) -> None:
+        if num_tokens >= node.best_num_tokens:
+            node.best_req_id = req_id
+            node.best_num_tokens = num_tokens
+
+    def rebuild_snapshot_index(self) -> None:
+        root = RuntimeCacheSnapshotIndexNode()
+        for req_id, snapshot in self.snapshots.items():
+            node = root
+            self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
+            for block_id in snapshot.first_seq_blocks:
+                node = node.children.setdefault(block_id, RuntimeCacheSnapshotIndexNode())
+                self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
+        self.snapshot_index_root = root
+
+    @property
+    def max_finished_snapshots(self) -> int:
+        return self.max_finished_cache_snapshots
+
+    @max_finished_snapshots.setter
+    def max_finished_snapshots(self, value: int) -> None:
+        self.max_finished_cache_snapshots = int(value)
+
+    def set_io_adapters(
+        self,
+        *,
+        dump_runtime_cache: RuntimeCacheDumpFn | None = None,
+        load_runtime_cache: RuntimeCacheLoadFn | None = None,
+    ) -> None:
+        if dump_runtime_cache is not None:
+            self._dump_runtime_cache_fn = dump_runtime_cache
+        if load_runtime_cache is not None:
+            self._load_runtime_cache_fn = load_runtime_cache
+
+    def dump_runtime_cache(self, dump_cache: Any, slot_id: int | None = None) -> list[Any] | None:
+        if slot_id is None:
+            return dump_cache()
+        return dump_cache(cache_id=slot_id)
+
+    def load_runtime_cache(self, load_cache: Any, blobs: list[Any], slot_id: int | None = None) -> bool:
+        if slot_id is None:
+            load_cache(blobs)
+        else:
+            load_cache(blobs, cache_id=slot_id)
+        return True
+
+    def dump_and_store_snapshot(
+        self,
+        *,
+        req_id: str,
+        block_ids: KVBlockIds,
+        first_seq_blocks: tuple[int, ...],
+        num_tokens: int,
+        slot_id: int | None = None,
+    ) -> RuntimeCacheSnapshot | None:
+        if self._dump_runtime_cache_fn is None:
+            raise RuntimeError("Runtime cache dump adapter is not configured.")
+        blobs = self._dump_runtime_cache_fn(slot_id)
+        if blobs is None:
+            return None
+        return self.store_snapshot(
+            req_id=req_id,
+            blobs=blobs,
+            block_ids=block_ids,
+            first_seq_blocks=first_seq_blocks,
+            num_tokens=num_tokens,
+        )
+
+    def choose_prefix_snapshot(
+        self,
+        target_blocks: RuntimeCacheRequest | tuple[int, ...],
+        target_tokens: int | None = None,
+    ) -> RuntimeCacheSnapshotMatch:
+        if isinstance(target_blocks, RuntimeCacheRequest):
+            request = target_blocks
+            target_blocks = request.first_seq_blocks
+            target_tokens = request.num_computed_tokens
+        if target_tokens is None:
+            raise TypeError("target_tokens is required when target_blocks is not a RuntimeCacheRequest")
+        if target_tokens <= 0 or not target_blocks:
+            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
+
+        best_snapshot: RuntimeCacheSnapshot | None = None
+        best_req_id: str | None = None
+        best_tokens = 0
+        node = self.snapshot_index_root
+        for depth, block_id in enumerate(target_blocks, start=1):
+            node = node.children.get(block_id)
+            if node is None or node.best_req_id is None:
+                break
+
+            snapshot = self.snapshots.get(node.best_req_id)
+            if snapshot is None:
+                continue
+
+            matched_tokens = min(snapshot.num_tokens, depth * self.block_size, target_tokens)
+            if matched_tokens > best_tokens:
+                best_tokens = matched_tokens
+                best_snapshot = snapshot
+                best_req_id = node.best_req_id
+
+        return RuntimeCacheSnapshotMatch(snapshot=best_snapshot, matched_tokens=best_tokens, req_id=best_req_id)
+
+    def choose_snapshot(self, request: RuntimeCacheRequest) -> RuntimeCacheSnapshotMatch:
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
+
+        own_snapshot = self.snapshots.get(request.req_id)
+        if own_snapshot is not None:
+            matched_tokens = self.compatible_tokens(
+                target_blocks=request.first_seq_blocks,
+                target_tokens=target_tokens,
+                snapshot_blocks=own_snapshot.first_seq_blocks,
+                snapshot_tokens=own_snapshot.num_tokens,
+            )
+            if matched_tokens >= target_tokens:
+                return RuntimeCacheSnapshotMatch(
+                    snapshot=own_snapshot,
+                    matched_tokens=target_tokens,
+                    req_id=request.req_id,
+                    is_own_snapshot=True,
+                )
+
+        return self.choose_prefix_snapshot(request.first_seq_blocks, target_tokens)
+
+    def compatible_tokens(
+        self,
+        *,
+        target_blocks: tuple[int, ...],
+        target_tokens: int,
+        snapshot_blocks: tuple[int, ...],
+        snapshot_tokens: int,
+    ) -> int:
+        return prefix_compatible_tokens(
+            target_blocks,
+            target_tokens,
+            snapshot_blocks,
+            snapshot_tokens,
+            self.block_size,
+        )
+
+    def required_blocks(self, num_tokens: int) -> int:
+        return required_blocks(num_tokens, self.block_size)
+
+    def should_dump_snapshot_after_step(self, req_id: str, next_num_tokens: int) -> bool:
+        snapshot = self.snapshots.get(req_id)
+        if snapshot is None:
+            return True
+        if next_num_tokens <= snapshot.num_tokens:
+            return False
+        return self.required_blocks(next_num_tokens) > self.required_blocks(snapshot.num_tokens)
+
+    def dump_snapshot_if_needed(
+        self,
+        request: RuntimeCacheRequest,
+        dump_runtime_cache: DumpRuntimeCache | None = None,
+    ) -> bool:
+        if not self.should_dump_snapshot_after_step(request.req_id, request.num_computed_tokens):
+            return False
+        dump_runtime_cache = dump_runtime_cache or self._dump_runtime_cache_fn
+        if dump_runtime_cache is None:
+            raise RuntimeError("Runtime cache dump adapter is not configured.")
+        blobs = dump_runtime_cache(request.cache_slot_id)
+        if blobs is None:
+            return False
+        self.store_snapshot(
+            req_id=request.req_id,
+            blobs=blobs,
+            block_ids=request.block_ids,
+            first_seq_blocks=request.first_seq_blocks,
+            num_tokens=request.num_computed_tokens,
+        )
+        return True
+
+    def dump_live_request_before_switch(
+        self,
+        *,
+        next_req_id: str,
+        live_request: RuntimeCacheRequest | None,
+        dump_runtime_cache: DumpRuntimeCache,
+    ) -> bool:
+        if self.loaded_req_id is None or self.loaded_req_id == next_req_id:
+            return False
+        if live_request is None or live_request.req_id != self.loaded_req_id:
+            return False
+        return self.dump_snapshot_if_needed(live_request, dump_runtime_cache)
+
+    def load_snapshot_for_request(
+        self,
+        request: RuntimeCacheRequest,
+        load_runtime_cache: LoadRuntimeCache | None = None,
+    ) -> RuntimeCacheLoadResult:
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            self.clear_loaded_request()
+            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True, action="skip-empty")
+
+        if self.loaded_req_id == request.req_id:
+            return RuntimeCacheLoadResult(
+                matched_tokens=target_tokens,
+                reused_live_cache=True,
+                action="reuse-live",
+                snapshot_req_id=request.req_id,
+            )
+
+        match = self.choose_snapshot(request)
+        if match.snapshot is None or match.matched_tokens <= 0:
+            self.clear_loaded_request()
+            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+
+        load_runtime_cache = load_runtime_cache or self._load_runtime_cache_fn
+        if load_runtime_cache is None:
+            raise RuntimeError("Runtime cache load adapter is not configured.")
+        if load_runtime_cache(match.snapshot.blobs, None):
+            self.mark_loaded_request(request.req_id)
+            return RuntimeCacheLoadResult(
+                matched_tokens=match.matched_tokens,
+                loaded=True,
+                loaded_snapshot_req_id=match.req_id,
+                is_own_snapshot=match.is_own_snapshot,
+                action="load-own" if match.is_own_snapshot else "load-shared",
+                snapshot_req_id=match.req_id,
+            )
+
+        self.clear_loaded_request()
+        return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+
+    def load_for_request(self, request: RuntimeCacheRequest) -> RuntimeCacheLoadResult:
+        return self.load_snapshot_for_request(request)
+
+    def load_snapshot_for_slot(
+        self,
+        request: RuntimeCacheRequest,
+        load_runtime_cache: LoadRuntimeCache | None = None,
+    ) -> RuntimeCacheLoadResult:
+        slot_id = request.cache_slot_id
+        if slot_id is None:
+            raise RuntimeError(f"Batch execution requires a cache slot for req_id={request.req_id}.")
+
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True, action="skip-empty")
+
+        if self.live_slot_owner(slot_id) == request.req_id:
+            return RuntimeCacheLoadResult(
+                matched_tokens=target_tokens,
+                reused_live_cache=True,
+                action="reuse-live",
+                snapshot_req_id=request.req_id,
+            )
+
+        match = self.choose_snapshot(request)
+        if match.snapshot is not None and match.matched_tokens > 0:
+            load_runtime_cache = load_runtime_cache or self._load_runtime_cache_fn
+            if load_runtime_cache is None:
+                raise RuntimeError("Runtime cache load adapter is not configured.")
+            if load_runtime_cache(match.snapshot.blobs, slot_id):
+                self.mark_slot_owner(slot_id, request.req_id)
+                return RuntimeCacheLoadResult(
+                    matched_tokens=match.matched_tokens,
+                    loaded=True,
+                    loaded_snapshot_req_id=match.req_id,
+                    is_own_snapshot=match.is_own_snapshot,
+                    action="load-own" if match.is_own_snapshot else "load-shared",
+                    snapshot_req_id=match.req_id,
+                )
+
+        self.mark_slot_owner(slot_id, request.req_id)
+        return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+
+    def load_for_slot(self, request: RuntimeCacheRequest, slot_id: int | None = None) -> RuntimeCacheLoadResult:
+        if slot_id is not None and request.cache_slot_id != slot_id:
+            request = RuntimeCacheRequest(
+                req_id=request.req_id,
+                block_ids=request.block_ids,
+                first_seq_blocks=request.first_seq_blocks,
+                num_computed_tokens=request.num_computed_tokens,
+                cache_slot_id=slot_id,
+            )
+        return self.load_snapshot_for_slot(request)
+
+    def touch_finished_snapshot(self, req_id: str) -> None:
+        if req_id not in self.snapshots:
+            return
+        self.finished_snapshot_lru.pop(req_id, None)
+        self.finished_snapshot_lru[req_id] = None
+
+    def mark_snapshot_finished(self, req_id: str) -> list[str]:
+        self.touch_finished_snapshot(req_id)
+        return self.evict_old_finished_snapshots()
+
+    def evict_old_finished_snapshots(self) -> list[str]:
+        evicted: list[str] = []
+        while len(self.finished_snapshot_lru) > self.max_finished_cache_snapshots:
+            evicted_req_id, _ = self.finished_snapshot_lru.popitem(last=False)
+            self.snapshots.pop(evicted_req_id, None)
+            self.clear_loaded_request(evicted_req_id)
+            evicted.append(evicted_req_id)
+        if evicted:
+            self.rebuild_snapshot_index()
+        return evicted
+
+    def reset(self) -> None:
+        self.snapshots.clear()
+        self.finished_snapshot_lru.clear()
+        self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
+        self.loaded_req_id = None
+        self.reset_slots()
 
 
 def normalize_block_ids(block_ids: KVBlockIds) -> KVBlockIds:
@@ -108,423 +612,3 @@ def prefix_compatible_tokens(
         return min(target_tokens, snapshot_tokens)
 
     return min(snapshot_tokens, common_blocks * block_size, target_tokens)
-
-
-class MbltRuntimeCacheManager:
-    """Owns Mobilint runtime cache snapshots and accelerator slot state.
-
-    The manager stores opaque runtime blobs and calls injected dump/load adapters
-    for qbruntime/cache-model IO. It intentionally does not import or own vLLM
-    worker/request objects or qbruntime implementation types.
-    """
-
-    DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS = 16
-
-    def __init__(
-        self,
-        block_size: int,
-        max_finished_cache_snapshots: int | None = None,
-        *,
-        max_batch_size: int = 1,
-        max_finished_snapshots: int | None = None,
-        dump_runtime_cache: RuntimeCacheDumpFn | None = None,
-        load_runtime_cache: RuntimeCacheLoadFn | None = None,
-    ) -> None:
-        if max_finished_snapshots is None:
-            max_finished_snapshots = max_finished_cache_snapshots
-        if max_finished_snapshots is None:
-            max_finished_snapshots = self.DEFAULT_MAX_FINISHED_CACHE_SNAPSHOTS
-
-        self.max_batch_size = max(0, int(max_batch_size))
-        self.block_size = int(block_size)
-        self.max_finished_cache_snapshots = int(max_finished_snapshots)
-        self._dump_runtime_cache_fn = dump_runtime_cache
-        self._load_runtime_cache_fn = load_runtime_cache
-
-        self.snapshots: dict[str, RuntimeCacheSnapshot] = {}
-        self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
-        self.finished_snapshot_lru: OrderedDict[str, None] = OrderedDict()
-        self.loaded_req_id: str | None = None
-        self.req_to_slot: dict[str, int] = {}
-        self.slot_to_req: dict[int, str] = {}
-        self.free_slots: list[int] = []
-        self.reset_slots(max_batch_size=self.max_batch_size)
-
-    @property
-    def cache_snapshots(self) -> dict[str, RuntimeCacheSnapshot]:
-        return self.snapshots
-
-    @cache_snapshots.setter
-    def cache_snapshots(self, value: dict[str, RuntimeCacheSnapshot]) -> None:
-        self.snapshots = value
-
-    @property
-    def loaded_cache_req_id(self) -> str | None:
-        return self.loaded_req_id
-
-    @loaded_cache_req_id.setter
-    def loaded_cache_req_id(self, value: str | None) -> None:
-        self.loaded_req_id = value
-
-    @property
-    def req_to_cache_slot(self) -> dict[str, int]:
-        return self.req_to_slot
-
-    @property
-    def cache_slot_to_req(self) -> dict[int, str]:
-        return self.slot_to_req
-
-    @property
-    def free_cache_slots(self) -> list[int]:
-        return self.free_slots
-
-    @property
-    def max_finished_snapshots(self) -> int:
-        return self.max_finished_cache_snapshots
-
-    @max_finished_snapshots.setter
-    def max_finished_snapshots(self, value: int) -> None:
-        self.max_finished_cache_snapshots = int(value)
-
-    def set_io_adapters(
-        self,
-        *,
-        dump_runtime_cache: RuntimeCacheDumpFn | None = None,
-        load_runtime_cache: RuntimeCacheLoadFn | None = None,
-    ) -> None:
-        if dump_runtime_cache is not None:
-            self._dump_runtime_cache_fn = dump_runtime_cache
-        if load_runtime_cache is not None:
-            self._load_runtime_cache_fn = load_runtime_cache
-
-    def dump_runtime_cache(self, dump_cache: Any, slot_id: int | None = None) -> list[Any] | None:
-        if slot_id is None:
-            return dump_cache()
-        return dump_cache(cache_id=slot_id)
-
-    def load_runtime_cache(self, load_cache: Any, blobs: list[Any], slot_id: int | None = None) -> bool:
-        if slot_id is None:
-            load_cache(blobs)
-        else:
-            load_cache(blobs, cache_id=slot_id)
-        return True
-
-    def reset_slots(self, *, max_batch_size: int | None = None) -> None:
-        if max_batch_size is not None:
-            self.max_batch_size = max(0, int(max_batch_size))
-        self.req_to_slot = {}
-        self.slot_to_req = {}
-        self.free_slots = list(range(self.max_batch_size))
-
-    def get_slot(self, req_id: str) -> int:
-        slot_id = self.req_to_slot.get(req_id)
-        if slot_id is None:
-            raise RuntimeError(f"No accelerator cache slot is assigned for req_id={req_id}.")
-        return slot_id
-
-    def assign_slot(self, req_id: str) -> int:
-        slot_id = self.req_to_slot.get(req_id)
-        if slot_id is not None:
-            return slot_id
-        if not self.free_slots:
-            raise RuntimeError(
-                "No free accelerator cache slots remain for batch execution. "
-                f"req_id={req_id}, max_batch_size={self.max_batch_size}"
-            )
-        slot_id = self.free_slots.pop(0)
-        self.req_to_slot[req_id] = slot_id
-        self.slot_to_req[slot_id] = req_id
-        return slot_id
-
-    def release_slot(self, req_id: str) -> None:
-        slot_id = self.req_to_slot.pop(req_id, None)
-        if slot_id is None:
-            return
-        if self.slot_to_req.get(slot_id) == req_id:
-            self.slot_to_req.pop(slot_id, None)
-        if slot_id not in self.free_slots:
-            self.free_slots.append(slot_id)
-            self.free_slots.sort()
-
-    def live_slot_owner(self, slot_id: int) -> str | None:
-        return self.slot_to_req.get(slot_id)
-
-    def mark_slot_owner(self, slot_id: int, req_id: str) -> None:
-        self.slot_to_req[slot_id] = req_id
-
-    def clear_loaded_request(self, req_id: str | None = None) -> None:
-        if req_id is None or self.loaded_req_id == req_id:
-            self.loaded_req_id = None
-
-    def mark_loaded_request(self, req_id: str) -> None:
-        self.loaded_req_id = req_id
-
-    def get_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
-        return self.snapshots.get(req_id)
-
-    def has_snapshot(self, req_id: str) -> bool:
-        return req_id in self.snapshots
-
-    def snapshot_count(self) -> int:
-        return len(self.snapshots)
-
-    def put_snapshot(
-        self,
-        req_id: str,
-        blobs: list[Any],
-        block_ids: KVBlockIds,
-        num_tokens: int,
-        first_seq_block_ids: tuple[int, ...] | None = None,
-    ) -> RuntimeCacheSnapshot:
-        normalized_block_ids = normalize_block_ids(block_ids)
-        snapshot = RuntimeCacheSnapshot(
-            blobs=blobs,
-            block_ids=normalized_block_ids,
-            first_seq_blocks=first_seq_block_ids if first_seq_block_ids is not None else first_seq_blocks(normalized_block_ids),
-            num_tokens=max(0, int(num_tokens)),
-        )
-        self.finished_snapshot_lru.pop(req_id, None)
-        self.snapshots[req_id] = snapshot
-        self.rebuild_snapshot_index()
-        return snapshot
-
-    def store_snapshot(
-        self,
-        *,
-        req_id: str,
-        blobs: list[Any],
-        block_ids: KVBlockIds,
-        first_seq_blocks: tuple[int, ...],
-        num_tokens: int,
-    ) -> RuntimeCacheSnapshot:
-        return self.put_snapshot(
-            req_id=req_id,
-            blobs=blobs,
-            block_ids=block_ids,
-            first_seq_block_ids=first_seq_blocks,
-            num_tokens=num_tokens,
-        )
-
-    def dump_and_store_snapshot(
-        self,
-        *,
-        req_id: str,
-        block_ids: KVBlockIds,
-        first_seq_blocks: tuple[int, ...],
-        num_tokens: int,
-        slot_id: int | None = None,
-    ) -> RuntimeCacheSnapshot | None:
-        if self._dump_runtime_cache_fn is None:
-            raise RuntimeError("Runtime cache dump adapter is not configured.")
-        blobs = self._dump_runtime_cache_fn(slot_id)
-        if blobs is None:
-            return None
-        return self.store_snapshot(
-            req_id=req_id,
-            blobs=blobs,
-            block_ids=block_ids,
-            first_seq_blocks=first_seq_blocks,
-            num_tokens=num_tokens,
-        )
-
-    def remove_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
-        snapshot = self.snapshots.pop(req_id, None)
-        self.finished_snapshot_lru.pop(req_id, None)
-        if self.loaded_req_id == req_id:
-            self.loaded_req_id = None
-        if snapshot is not None:
-            self.rebuild_snapshot_index()
-        return snapshot
-
-    @staticmethod
-    def _update_snapshot_index_node(
-        node: RuntimeCacheSnapshotIndexNode,
-        req_id: str,
-        num_tokens: int,
-    ) -> None:
-        if num_tokens >= node.best_num_tokens:
-            node.best_req_id = req_id
-            node.best_num_tokens = num_tokens
-
-    def rebuild_snapshot_index(self) -> None:
-        root = RuntimeCacheSnapshotIndexNode()
-        for req_id, snapshot in self.snapshots.items():
-            node = root
-            self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
-            for block_id in snapshot.first_seq_blocks:
-                node = node.children.setdefault(block_id, RuntimeCacheSnapshotIndexNode())
-                self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
-        self.snapshot_index_root = root
-
-    def mark_snapshot_finished(self, req_id: str) -> list[str]:
-        if req_id in self.snapshots:
-            self.touch_finished_snapshot(req_id)
-        return self.evict_old_finished_snapshots()
-
-    def touch_finished_snapshot(self, req_id: str) -> None:
-        if req_id in self.finished_snapshot_lru:
-            self.finished_snapshot_lru.move_to_end(req_id)
-        else:
-            self.finished_snapshot_lru[req_id] = None
-
-    def evict_old_finished_snapshots(self) -> list[str]:
-        evicted_req_ids: list[str] = []
-        while len(self.finished_snapshot_lru) > self.max_finished_cache_snapshots:
-            evicted_req_id, _ = self.finished_snapshot_lru.popitem(last=False)
-            self.snapshots.pop(evicted_req_id, None)
-            if self.loaded_req_id == evicted_req_id:
-                self.loaded_req_id = None
-            evicted_req_ids.append(evicted_req_id)
-        if evicted_req_ids:
-            self.rebuild_snapshot_index()
-        return evicted_req_ids
-
-    def required_blocks(self, num_tokens: int) -> int:
-        return required_blocks(num_tokens, self.block_size)
-
-    def prefix_compatible_tokens(
-        self,
-        target_blocks: tuple[int, ...],
-        target_tokens: int,
-        snapshot_blocks: tuple[int, ...],
-        snapshot_tokens: int,
-    ) -> int:
-        return prefix_compatible_tokens(
-            target_blocks,
-            target_tokens,
-            snapshot_blocks,
-            snapshot_tokens,
-            self.block_size,
-        )
-
-    def compatible_tokens(
-        self,
-        *,
-        target_blocks: tuple[int, ...],
-        target_tokens: int,
-        snapshot_blocks: tuple[int, ...],
-        snapshot_tokens: int,
-    ) -> int:
-        return self.prefix_compatible_tokens(target_blocks, target_tokens, snapshot_blocks, snapshot_tokens)
-
-    def should_dump_snapshot_after_step(self, req_id: str, next_num_tokens: int) -> bool:
-        snapshot = self.snapshots.get(req_id)
-        if snapshot is None:
-            return True
-        if next_num_tokens <= snapshot.num_tokens:
-            return False
-        return self.required_blocks(next_num_tokens) > self.required_blocks(snapshot.num_tokens)
-
-    def choose_prefix_snapshot(
-        self,
-        target_blocks: RuntimeCacheRequest | tuple[int, ...],
-        target_tokens: int | None = None,
-    ) -> RuntimeCacheSnapshotMatch:
-        if isinstance(target_blocks, RuntimeCacheRequest):
-            request = target_blocks
-            target_blocks = request.first_seq_blocks
-            target_tokens = request.num_computed_tokens
-        if target_tokens is None:
-            raise TypeError("target_tokens is required when target_blocks is not a RuntimeCacheRequest")
-        if target_tokens <= 0 or not target_blocks:
-            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
-
-        best_snapshot: RuntimeCacheSnapshot | None = None
-        best_req_id: str | None = None
-        best_tokens = 0
-        node = self.snapshot_index_root
-        for depth, block_id in enumerate(target_blocks, start=1):
-            node = node.children.get(block_id)
-            if node is None or node.best_req_id is None:
-                break
-
-            snapshot = self.snapshots.get(node.best_req_id)
-            if snapshot is None:
-                continue
-
-            matched_tokens = min(snapshot.num_tokens, depth * self.block_size, target_tokens)
-            if matched_tokens > best_tokens:
-                best_tokens = matched_tokens
-                best_snapshot = snapshot
-                best_req_id = node.best_req_id
-
-        return RuntimeCacheSnapshotMatch(snapshot=best_snapshot, matched_tokens=best_tokens, req_id=best_req_id)
-
-    def choose_snapshot(self, request: RuntimeCacheRequest) -> RuntimeCacheSnapshotMatch:
-        target_tokens = request.num_computed_tokens
-        if target_tokens <= 0:
-            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
-
-        own_snapshot = self.snapshots.get(request.req_id)
-        if own_snapshot is not None:
-            matched_tokens = self.prefix_compatible_tokens(
-                target_blocks=request.first_seq_blocks,
-                target_tokens=target_tokens,
-                snapshot_blocks=own_snapshot.first_seq_blocks,
-                snapshot_tokens=own_snapshot.num_tokens,
-            )
-            if matched_tokens >= target_tokens:
-                return RuntimeCacheSnapshotMatch(
-                    snapshot=own_snapshot,
-                    matched_tokens=target_tokens,
-                    req_id=request.req_id,
-                    is_own_snapshot=True,
-                )
-
-        return self.choose_prefix_snapshot(request.first_seq_blocks, target_tokens)
-
-    def load_for_request(self, request: RuntimeCacheRequest) -> RuntimeCacheLoadResult:
-        target_tokens = request.num_computed_tokens
-        if target_tokens <= 0:
-            self.clear_loaded_request()
-            return RuntimeCacheLoadResult(matched_tokens=0, action="skip-empty")
-
-        if self.loaded_req_id == request.req_id:
-            return RuntimeCacheLoadResult(matched_tokens=target_tokens, action="reuse-live", snapshot_req_id=request.req_id)
-
-        match = self.choose_snapshot(request)
-        if match.snapshot is None or match.matched_tokens <= 0:
-            self.clear_loaded_request()
-            return RuntimeCacheLoadResult(matched_tokens=0, action="miss")
-
-        if self._load_runtime_cache_fn is None:
-            raise RuntimeError("Runtime cache load adapter is not configured.")
-        if not self._load_runtime_cache_fn(match.snapshot.blobs, None):
-            self.clear_loaded_request()
-            return RuntimeCacheLoadResult(matched_tokens=0, action="load-failed", snapshot_req_id=match.req_id)
-
-        self.mark_loaded_request(request.req_id)
-        action = "load-own" if match.is_own_snapshot else "load-shared"
-        return RuntimeCacheLoadResult(matched_tokens=match.matched_tokens, action=action, snapshot_req_id=match.req_id)
-
-    def load_for_slot(self, request: RuntimeCacheRequest, slot_id: int) -> RuntimeCacheLoadResult:
-        target_tokens = request.num_computed_tokens
-        if target_tokens <= 0:
-            self.mark_slot_owner(slot_id, request.req_id)
-            return RuntimeCacheLoadResult(matched_tokens=0, action="skip-empty", snapshot_req_id=request.req_id)
-
-        if self.live_slot_owner(slot_id) == request.req_id:
-            return RuntimeCacheLoadResult(matched_tokens=target_tokens, action="reuse-live", snapshot_req_id=request.req_id)
-
-        match = self.choose_snapshot(request)
-        if match.snapshot is not None and match.matched_tokens > 0:
-            if self._load_runtime_cache_fn is None:
-                raise RuntimeError("Runtime cache load adapter is not configured.")
-            if self._load_runtime_cache_fn(match.snapshot.blobs, slot_id):
-                self.mark_slot_owner(slot_id, request.req_id)
-                action = "load-own" if match.is_own_snapshot else "load-shared"
-                return RuntimeCacheLoadResult(
-                    matched_tokens=match.matched_tokens,
-                    action=action,
-                    snapshot_req_id=match.req_id,
-                )
-
-        self.mark_slot_owner(slot_id, request.req_id)
-        return RuntimeCacheLoadResult(matched_tokens=0, action="miss")
-
-    def reset(self) -> None:
-        self.snapshots.clear()
-        self.finished_snapshot_lru.clear()
-        self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
-        self.loaded_req_id = None
-        self.reset_slots()


### PR DESCRIPTION
## Summary

Refactors Mobilint runtime-side KV cache handling out of `MbltWorker` into a dedicated `MbltRuntimeCacheManager` abstraction.

Key changes:
- Adds `vllm_mblt.runtime_cache` with runtime cache dataclasses, block ID helpers, snapshot repository, prefix index, live cache ownership, and batch slot management.
- Updates `MbltWorker` to instantiate `self.runtime_cache` and delegate runtime cache decisions to the manager.
- Keeps qbruntime/cache-model IO in `MbltWorker` through small dump/load adapter methods instead of letting the manager own runtime objects.
- Adds behavior-oriented runtime cache tests and updates worker cache tests to use the new abstraction.
- Adds `CHANGELOG.md` entries for internal breaking changes around old `MbltWorker` cache internals.

## Breaking Changes

This is an internal API refactor for the pre-1.0 package:
- Cache snapshot, live-cache ownership, and accelerator slot handling moved from `MbltWorker` to `vllm_mblt.runtime_cache.MbltRuntimeCacheManager`.
- Old cache-related `MbltWorker` internals are no longer compatibility targets.
- Direct imports of cache implementation details from `vllm_mblt.mblt_worker` should move to `vllm_mblt.runtime_cache`.

## Validation

- `uv run ruff check .`
- `uv run pytest tests -q`

Result:
- Ruff: `All checks passed!`
- Pytest: `97 passed in 3.03s`