### PR TITLE
completion echo prompt logprobs 오류 수정

### DIFF
--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -334,6 +334,68 @@ class TestMbltWorkerOptimizations:
             assert processor.prompt_logprobs[prompt_pos] is not None
             assert token_id in processor.prompt_logprobs[prompt_pos]
 
+    def test_prompt_logprobs_replay_does_not_duplicate_emitted_positions(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103, 104]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        vocab_size = max(prompt_token_ids) + 1
+
+        first_chunk_logits = np.full((2, vocab_size), -10.0, dtype=np.float32)
+        first_chunk_logits[0, prompt_token_ids[1]] = 10.0
+        first_chunk_logits[1, prompt_token_ids[2]] = 10.0
+        first_chunk_prompt_logprobs = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=first_chunk_logits,
+            start_idx=0,
+            scheduled_end=2,
+        )
+        assert first_chunk_prompt_logprobs is not None
+        assert first_chunk_prompt_logprobs.logprob_token_ids.shape[0] == 2
+
+        replay_logits = np.full((3, vocab_size), -10.0, dtype=np.float32)
+        replay_logits[0, prompt_token_ids[1]] = 10.0
+        replay_logits[1, prompt_token_ids[2]] = 10.0
+        replay_logits[2, prompt_token_ids[3]] = 10.0
+        replay_prompt_logprobs = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=replay_logits,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert replay_prompt_logprobs is not None
+        assert replay_prompt_logprobs.logprob_token_ids.shape[0] == 1
+
+        processor = LogprobsProcessor(
+            tokenizer=None,
+            logprobs=[],
+            prompt_logprobs=[None],
+            cumulative_logprob=0.0,
+            num_logprobs=1,
+            num_prompt_logprobs=1,
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=first_chunk_prompt_logprobs)
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=replay_prompt_logprobs)
+        )
+
+        assert processor.prompt_logprobs is not None
+        assert len(processor.prompt_logprobs) == len(prompt_token_ids)
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            assert processor.prompt_logprobs[prompt_pos] is not None
+            assert token_id in processor.prompt_logprobs[prompt_pos]
+
+    def test_2d_single_row_logits_are_not_treated_as_full_sequence_logits(self) -> None:
+        vocab_size = 8
+        last_token_logits = np.zeros((1, vocab_size), dtype=np.float32)
+
+        assert MbltWorker._normalize_sequence_logits(last_token_logits, expected_seq_len=2) is None
+        sequence_logits = MbltWorker._normalize_sequence_logits(last_token_logits, expected_seq_len=1)
+        assert sequence_logits is last_token_logits
+
     def test_sampling_penalties_can_be_forced_off_for_non_cuda_runtime(self) -> None:
         worker = self._make_worker()
         worker.enable_sampling_penalties = False

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -248,6 +248,7 @@ class TestMbltWorkerOptimizations:
         )
         assert prompt_logprobs_tensors is not None
         assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
 
         processor = LogprobsProcessor(
             tokenizer=None,
@@ -312,6 +313,7 @@ class TestMbltWorkerOptimizations:
         assert second_chunk_prompt_logprobs is not None
         assert first_chunk_prompt_logprobs.logprob_token_ids.shape[0] == 2
         assert second_chunk_prompt_logprobs.logprob_token_ids.shape[0] == 1
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
 
         processor = LogprobsProcessor(
             tokenizer=None,
@@ -367,6 +369,7 @@ class TestMbltWorkerOptimizations:
 
         assert replay_prompt_logprobs is not None
         assert replay_prompt_logprobs.logprob_token_ids.shape[0] == 1
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
 
         processor = LogprobsProcessor(
             tokenizer=None,
@@ -413,6 +416,8 @@ class TestMbltWorkerOptimizations:
 
         assert prompt_logprobs_tensors is not None
         assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+        assert not worker._should_recompute_prompt_logprobs_from_start(req_state)
 
         processor = LogprobsProcessor(
             tokenizer=None,
@@ -432,6 +437,63 @@ class TestMbltWorkerOptimizations:
         for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
             assert processor.prompt_logprobs[prompt_pos] is not None
             assert token_id in processor.prompt_logprobs[prompt_pos]
+
+    @pytest.mark.parametrize("prompt_token_ids", ([], [101]))
+    def test_prompt_logprobs_terminal_for_empty_or_one_token_prompt(self, prompt_token_ids: list[int]) -> None:
+        worker = self._make_worker()
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=np.empty((0, 1), dtype=np.float32),
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+        assert prompt_logprobs_tensors is not None
+        assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == 0
+
+        req_state.num_computed_tokens = 1
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+        assert not worker._should_recompute_prompt_logprobs_from_start(req_state)
+
+    def test_prompt_logprobs_unavailable_logits_terminal_during_decode(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.num_computed_tokens = 2
+
+        assert worker._should_recompute_prompt_logprobs_from_start(req_state)
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=None,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert prompt_logprobs_tensors is None
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+        assert not worker._should_recompute_prompt_logprobs_from_start(req_state)
+
+    def test_prompt_logprobs_unsupported_logits_shape_terminal_during_decode(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.num_computed_tokens = 2
+
+        assert worker._should_recompute_prompt_logprobs_from_start(req_state)
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=np.empty((1, 1, 1), dtype=np.float32),
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert prompt_logprobs_tensors is None
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+        assert not worker._should_recompute_prompt_logprobs_from_start(req_state)
 
     def test_2d_single_row_logits_are_not_treated_as_full_sequence_logits(self) -> None:
         vocab_size = 8

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -279,6 +279,61 @@ class TestMbltWorkerOptimizations:
         assert completion_logprobs.token_logprobs[1] is not None
         assert completion_logprobs.token_logprobs[-1] == -0.5
 
+    def test_prompt_logprobs_include_chunk_boundary_prompt_token(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103, 104]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        vocab_size = max(prompt_token_ids) + 1
+
+        first_chunk_logits = np.full((2, vocab_size), -10.0, dtype=np.float32)
+        first_chunk_logits[0, prompt_token_ids[1]] = 10.0
+        first_chunk_logits[1, prompt_token_ids[2]] = 10.0
+
+        first_chunk_prompt_logprobs = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=first_chunk_logits,
+            start_idx=0,
+            scheduled_end=2,
+        )
+
+        second_chunk_logits = np.full((2, vocab_size), -10.0, dtype=np.float32)
+        second_chunk_logits[0, prompt_token_ids[3]] = 10.0
+
+        second_chunk_prompt_logprobs = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=second_chunk_logits,
+            start_idx=2,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert first_chunk_prompt_logprobs is not None
+        assert second_chunk_prompt_logprobs is not None
+        assert first_chunk_prompt_logprobs.logprob_token_ids.shape[0] == 2
+        assert second_chunk_prompt_logprobs.logprob_token_ids.shape[0] == 1
+
+        processor = LogprobsProcessor(
+            tokenizer=None,
+            logprobs=[],
+            prompt_logprobs=[None],
+            cumulative_logprob=0.0,
+            num_logprobs=1,
+            num_prompt_logprobs=1,
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=first_chunk_prompt_logprobs)
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=second_chunk_prompt_logprobs)
+        )
+
+        assert processor.prompt_logprobs is not None
+        assert len(processor.prompt_logprobs) == len(prompt_token_ids)
+        assert processor.prompt_logprobs[0] is None
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            assert processor.prompt_logprobs[prompt_pos] is not None
+            assert token_id in processor.prompt_logprobs[prompt_pos]
+
     def test_sampling_penalties_can_be_forced_off_for_non_cuda_runtime(self) -> None:
         worker = self._make_worker()
         worker.enable_sampling_penalties = False

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -137,6 +137,7 @@ class TestMbltWorkerOptimizations:
             cache_config=SimpleNamespace(block_size=128), model_config=worker.model_config
         )
         worker.model = SimpleNamespace(config=SimpleNamespace(vocab_size=32000))
+        worker.max_batch_size = 1
         worker.empty_logits_processors = LogitsProcessors(None)
         worker.empty_prompt_token_ids = torch.empty((0, 0), dtype=torch.int64)
         worker.sampler = Sampler(logprobs_mode="raw_logits")
@@ -384,6 +385,50 @@ class TestMbltWorkerOptimizations:
 
         assert processor.prompt_logprobs is not None
         assert len(processor.prompt_logprobs) == len(prompt_token_ids)
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            assert processor.prompt_logprobs[prompt_pos] is not None
+            assert token_id in processor.prompt_logprobs[prompt_pos]
+
+    def test_prompt_logprobs_prefix_cache_hit_recomputes_from_start_for_contiguous_positions(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103, 104]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.num_computed_tokens = 2
+
+        cache_size = worker._load_snapshot_if_needed("req", req_state)
+        assert cache_size == 0
+
+        vocab_size = max(prompt_token_ids) + 1
+        sequence_logits = np.full((len(prompt_token_ids), vocab_size), -10.0, dtype=np.float32)
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            sequence_logits[prompt_pos - 1, token_id] = 10.0
+
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=sequence_logits,
+            start_idx=cache_size,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert prompt_logprobs_tensors is not None
+        assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
+
+        processor = LogprobsProcessor(
+            tokenizer=None,
+            logprobs=[],
+            prompt_logprobs=[None],
+            cumulative_logprob=0.0,
+            num_logprobs=1,
+            num_prompt_logprobs=1,
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=prompt_logprobs_tensors)
+        )
+
+        assert processor.prompt_logprobs is not None
+        assert len(processor.prompt_logprobs) == len(prompt_token_ids)
+        assert processor.prompt_logprobs[0] is None
         for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
             assert processor.prompt_logprobs[prompt_pos] is not None
             assert token_id in processor.prompt_logprobs[prompt_pos]

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -3,8 +3,12 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import torch
+from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
+from vllm.logprobs import Logprob
 from vllm.sampling_params import SamplingParams
+from vllm.v1.engine.logprobs import LogprobsProcessor
 from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.sampler import Sampler
 
 from vllm_mblt.mblt_worker import (
     MbltWorker,
@@ -135,6 +139,7 @@ class TestMbltWorkerOptimizations:
         worker.model = SimpleNamespace(config=SimpleNamespace(vocab_size=32000))
         worker.empty_logits_processors = LogitsProcessors(None)
         worker.empty_prompt_token_ids = torch.empty((0, 0), dtype=torch.int64)
+        worker.sampler = Sampler(logprobs_mode="raw_logits")
         worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=1, block_size=128)
         worker._vlm_image_positions_by_session = {}
         return worker
@@ -222,6 +227,57 @@ class TestMbltWorkerOptimizations:
         metadata = worker._make_sampling_metadata([req_state])
         assert metadata.no_penalties
         assert metadata.prompt_token_ids is None
+
+    @pytest.mark.parametrize("prompt_token_ids", ([15339, 1917], [128000, 15339, 1917]))
+    def test_prompt_logprobs_for_echo_start_after_first_prompt_token(self, prompt_token_ids: list[int]) -> None:
+        worker = self._make_worker()
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+
+        vocab_size = max(prompt_token_ids + [42]) + 1
+        sequence_logits = np.full((len(prompt_token_ids), vocab_size), -10.0, dtype=np.float32)
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            sequence_logits[prompt_pos - 1, token_id] = 10.0
+
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=sequence_logits,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+        assert prompt_logprobs_tensors is not None
+        assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
+
+        processor = LogprobsProcessor(
+            tokenizer=None,
+            logprobs=[],
+            prompt_logprobs=[None],
+            cumulative_logprob=0.0,
+            num_logprobs=1,
+            num_prompt_logprobs=1,
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=prompt_logprobs_tensors)
+        )
+        assert processor.prompt_logprobs is not None
+        assert len(processor.prompt_logprobs) == len(prompt_token_ids)
+        assert processor.prompt_logprobs[0] is None
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            assert token_id in processor.prompt_logprobs[prompt_pos]
+
+        generated_token_id = 42
+        generated_logprobs = {generated_token_id: Logprob(logprob=-0.5, rank=1, decoded_token=None)}
+        completion_logprobs = OpenAIServingCompletion._create_completion_logprobs(
+            OpenAIServingCompletion.__new__(OpenAIServingCompletion),
+            token_ids=[*prompt_token_ids, generated_token_id],
+            top_logprobs=[*processor.prompt_logprobs, generated_logprobs],
+            num_output_top_logprobs=1,
+            tokenizer=SimpleNamespace(decode=lambda token_id: f"token:{token_id}"),
+            return_as_token_id=True,
+        )
+        assert completion_logprobs.token_logprobs[0] is None
+        assert completion_logprobs.token_logprobs[1] is not None
+        assert completion_logprobs.token_logprobs[-1] == -0.5
 
     def test_sampling_penalties_can_be_forced_off_for_non_cuda_runtime(self) -> None:
         worker = self._make_worker()

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 
 def register():

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -939,7 +939,9 @@ class MbltWorker(WorkerBase):
         logits_np = np.asarray(logits)
         return InferenceLogits(
             last_token_logits=self._last_token_logits(logits_np),
-            full_sequence_logits=self._normalize_sequence_logits(logits_np, expected_seq_len=int(input_embeds.shape[0])),
+            full_sequence_logits=self._normalize_sequence_logits(
+                logits_np, expected_seq_len=int(input_embeds.shape[0])
+            ),
         )
 
     def _infer_logits_batch(
@@ -1062,6 +1064,7 @@ class MbltWorker(WorkerBase):
         return (
             self._num_prompt_logprobs(req_state.sampling_params) is not None
             and req_state.next_prompt_logprob_pos <= 1
+            and req_state.next_prompt_logprob_pos < len(req_state.prompt_token_ids)
             and req_state.num_computed_tokens > 0
         )
 
@@ -1079,6 +1082,7 @@ class MbltWorker(WorkerBase):
         prompt_token_ids = req_state.prompt_token_ids
         num_prompt_tokens = len(prompt_token_ids)
         if num_prompt_tokens <= 1:
+            req_state.next_prompt_logprob_pos = num_prompt_tokens
             from vllm.v1.outputs import LogprobsTensors
 
             return LogprobsTensors.empty_cpu(0, num_prompt_logprobs + 1)
@@ -1088,6 +1092,7 @@ class MbltWorker(WorkerBase):
                 "Prompt logprobs were requested, but the MBLT runtime returned only last-token logits. "
                 "Prompt token logprobs will be omitted for this request."
             )
+            req_state.next_prompt_logprob_pos = num_prompt_tokens
             return None
 
         sequence_logits = np.asarray(sequence_logits)
@@ -1097,6 +1102,7 @@ class MbltWorker(WorkerBase):
                 "Prompt token logprobs will be omitted for this request.",
                 sequence_logits.shape,
             )
+            req_state.next_prompt_logprob_pos = num_prompt_tokens
             return None
 
         prompt_end = min(scheduled_end + 1, num_prompt_tokens)
@@ -1117,6 +1123,7 @@ class MbltWorker(WorkerBase):
                 first_prompt_pos,
                 prompt_end,
             )
+            req_state.next_prompt_logprob_pos = num_prompt_tokens
             return None
 
         prompt_logits = torch.from_numpy(sequence_logits[logits_start:logits_end]).to(dtype=torch.float32)

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1087,7 +1087,7 @@ class MbltWorker(WorkerBase):
             )
             return None
 
-        prompt_end = min(scheduled_end, num_prompt_tokens)
+        prompt_end = min(scheduled_end + 1, num_prompt_tokens)
         # For prompt position i > 0, use logits produced while processing token
         # i - 1. There is intentionally no logprob for prompt token 0; vLLM's
         # LogprobsProcessor seeds prompt_logprobs with a leading None.

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -130,6 +130,12 @@ class CachedSamplingState:
     prompt_token_ids: torch.Tensor
     has_penalties: bool
 
+
+@dataclass
+class InferenceLogits:
+    last_token_logits: np.ndarray
+    full_sequence_logits: Optional[np.ndarray]
+
 class MbltWorker(WorkerBase):
     MAX_FINISHED_CACHE_SNAPSHOTS = 16
 
@@ -828,6 +834,17 @@ class MbltWorker(WorkerBase):
         return logits
 
     @staticmethod
+    def _normalize_sequence_logits(logits: np.ndarray) -> Optional[np.ndarray]:
+        logits = np.asarray(logits)
+        if logits.ndim == 3:
+            if logits.shape[0] != 1:
+                return None
+            return logits[0]
+        if logits.ndim == 2:
+            return logits
+        return None
+
+    @staticmethod
     def _can_reuse_output_buffers(
         cache_model: Any,
         output_buffers: list[np.ndarray],
@@ -886,6 +903,40 @@ class MbltWorker(WorkerBase):
         self._infer_output_buffers = [np.empty_like(logits)]
         return self._last_token_logits(logits)
 
+    def _infer_logits_with_sequence(
+        self,
+        input_embeds: np.ndarray,
+        deepstack_embeds: Optional[np.ndarray],
+        cache_size: int,
+    ) -> InferenceLogits:
+        cache_model = self._get_cache_model()
+        infer_inputs = self._build_infer_inputs(input_embeds, deepstack_embeds)
+        output_buffers = self._infer_output_buffers
+
+        if output_buffers is not None and self._can_reuse_output_buffers(
+            cache_model,
+            output_buffers,
+            input_seq_len=int(input_embeds.shape[0]),
+        ):
+            infer_output = cache_model.infer(
+                infer_inputs,
+                outputs=output_buffers,
+                cache_size=cache_size,
+            )
+            logits = output_buffers[0] if infer_output is None else infer_output[0]
+        else:
+            infer_output = cache_model.infer(infer_inputs, cache_size=cache_size)
+            if infer_output is None:
+                raise RuntimeError("mxq infer result is None!")
+            logits = infer_output[0]
+            self._infer_output_buffers = [np.empty_like(logits)]
+
+        logits_np = np.asarray(logits)
+        return InferenceLogits(
+            last_token_logits=self._last_token_logits(logits_np),
+            full_sequence_logits=self._normalize_sequence_logits(logits_np),
+        )
+
     def _infer_logits_batch(
         self,
         input_embeds_batch: list[np.ndarray],
@@ -935,6 +986,131 @@ class MbltWorker(WorkerBase):
             )
         logits_np = logits_np.reshape(batch_size, -1)
         return [logits_np[i] for i in range(batch_size)]
+
+    def _infer_logits_batch_with_sequence(
+        self,
+        input_embeds_batch: list[np.ndarray],
+        cache_sizes: list[int],
+        cache_ids: list[int],
+    ) -> list[InferenceLogits]:
+        if not input_embeds_batch:
+            return []
+
+        cache_model = self._get_cache_model()
+        batch_size = len(input_embeds_batch)
+        params = self._make_batch_params(
+            sequence_lengths=[int(input_embeds.shape[0]) for input_embeds in input_embeds_batch],
+            cache_sizes=cache_sizes,
+            cache_ids=cache_ids,
+        )
+
+        concat_input = np.concatenate(input_embeds_batch, axis=0).astype(
+            np.float32,
+            copy=False,
+        )
+        while concat_input.ndim < 4:
+            concat_input = np.expand_dims(concat_input, axis=0)
+
+        infer_output = cache_model.infer([concat_input], params=params)
+        logits = infer_output[0] if isinstance(infer_output, (list, tuple)) else infer_output
+        logits_np = np.asarray(logits)
+        if logits_np.ndim == 3:
+            offset = 0
+            outputs: list[InferenceLogits] = []
+            for input_embeds in input_embeds_batch:
+                seq_len = int(input_embeds.shape[0])
+                if seq_len <= 0:
+                    raise RuntimeError("Batched infer received an empty input embedding slice.")
+                sequence_logits = logits_np[0, offset : offset + seq_len, :]
+                outputs.append(
+                    InferenceLogits(
+                        last_token_logits=sequence_logits[-1, :],
+                        full_sequence_logits=sequence_logits,
+                    )
+                )
+                offset += seq_len
+            if offset != logits_np.shape[1]:
+                raise RuntimeError(
+                    "Batched infer returned logits with unexpected sequence length: "
+                    f"shape={logits_np.shape}, expected_tokens={offset}"
+                )
+            return outputs
+
+        if logits_np.size % batch_size != 0:
+            raise RuntimeError(
+                f"Batched infer returned logits with unexpected shape: shape={logits_np.shape}, batch_size={batch_size}"
+            )
+        logits_np = logits_np.reshape(batch_size, -1)
+        return [InferenceLogits(last_token_logits=logits_np[i], full_sequence_logits=None) for i in range(batch_size)]
+
+    def _num_prompt_logprobs(self, sampling_params: SamplingParams) -> Optional[int]:
+        num_prompt_logprobs = sampling_params.prompt_logprobs
+        if num_prompt_logprobs is None:
+            return None
+        if num_prompt_logprobs == -1:
+            if self.model is None:
+                raise RuntimeError("Model is not initialized.")
+            return int(self.model.config.vocab_size)
+        return int(num_prompt_logprobs)
+
+    def _get_prompt_logprobs_tensors(
+        self,
+        req_state: RequestState,
+        sequence_logits: Optional[np.ndarray],
+        start_idx: int,
+        scheduled_end: int,
+    ):
+        num_prompt_logprobs = self._num_prompt_logprobs(req_state.sampling_params)
+        if num_prompt_logprobs is None:
+            return None
+
+        prompt_token_ids = req_state.prompt_token_ids
+        num_prompt_tokens = len(prompt_token_ids)
+        if num_prompt_tokens <= 1:
+            from vllm.v1.outputs import LogprobsTensors
+
+            return LogprobsTensors.empty_cpu(0, num_prompt_logprobs + 1)
+
+        if sequence_logits is None:
+            logger.warning_once(
+                "Prompt logprobs were requested, but the MBLT runtime returned only last-token logits. "
+                "Prompt token logprobs will be omitted for this request."
+            )
+            return None
+
+        sequence_logits = np.asarray(sequence_logits)
+        if sequence_logits.ndim != 2:
+            logger.warning_once(
+                "Prompt logprobs were requested, but MBLT logits have unsupported shape %s. "
+                "Prompt token logprobs will be omitted for this request.",
+                sequence_logits.shape,
+            )
+            return None
+
+        prompt_end = min(scheduled_end, num_prompt_tokens)
+        # For prompt position i > 0, use logits produced while processing token
+        # i - 1. There is intentionally no logprob for prompt token 0; vLLM's
+        # LogprobsProcessor seeds prompt_logprobs with a leading None.
+        first_prompt_pos = max(1, start_idx + 1)
+        if prompt_end <= first_prompt_pos:
+            return None
+
+        logits_start = first_prompt_pos - start_idx - 1
+        logits_end = logits_start + (prompt_end - first_prompt_pos)
+        if logits_start < 0 or logits_end > sequence_logits.shape[0]:
+            logger.warning_once(
+                "Prompt logprobs were requested, but MBLT logits shape %s does not cover prompt positions "
+                "[%s, %s). Prompt token logprobs will be omitted for this request.",
+                sequence_logits.shape,
+                first_prompt_pos,
+                prompt_end,
+            )
+            return None
+
+        prompt_logits = torch.from_numpy(sequence_logits[logits_start:logits_end]).to(dtype=torch.float32)
+        target_token_ids = torch.as_tensor(prompt_token_ids[first_prompt_pos:prompt_end], dtype=torch.int64)
+        logprobs = self.sampler.compute_logprobs(prompt_logits)
+        return self.sampler.gather_logprobs(logprobs, num_prompt_logprobs, target_token_ids)
 
     @staticmethod
     def _should_sample_after_step(
@@ -1418,6 +1594,7 @@ class MbltWorker(WorkerBase):
         logits_batch: list[torch.Tensor] = []
         req_states_for_sampling: list[RequestState] = []
         sampling_req_ids: list[str] = []
+        prompt_logprobs_dict = {}
 
         if self._is_batch_model():
             if batch_size > self.max_batch_size:
@@ -1460,7 +1637,7 @@ class MbltWorker(WorkerBase):
                 cache_sizes.append(cache_size)
                 cache_ids.append(slot_id)
 
-            batched_logits = self._infer_logits_batch(
+            batched_logits = self._infer_logits_batch_with_sequence(
                 input_embeds_batch=input_embeds_batch,
                 cache_sizes=cache_sizes,
                 cache_ids=cache_ids,
@@ -1468,6 +1645,14 @@ class MbltWorker(WorkerBase):
 
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
+                prompt_logprobs_tensors = self._get_prompt_logprobs_tensors(
+                    req_state=req_state,
+                    sequence_logits=batched_logits[i].full_sequence_logits,
+                    start_idx=cache_sizes[i],
+                    scheduled_end=scheduled_end_positions[i],
+                )
+                if prompt_logprobs_tensors is not None:
+                    prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
                 req_state.num_computed_tokens = next_cache_sizes[i]
                 self.runtime_cache.mark_slot_owner(cache_ids[i], req_id)
                 if self._should_sample_after_step(
@@ -1475,7 +1660,7 @@ class MbltWorker(WorkerBase):
                     scheduled_end_positions[i],
                     sequence_lengths[i],
                 ):
-                    logits_batch.append(torch.from_numpy(batched_logits[i]).reshape(1, -1))
+                    logits_batch.append(torch.from_numpy(batched_logits[i].last_token_logits).reshape(1, -1))
                     req_states_for_sampling.append(req_state)
                     sampling_req_ids.append(req_id)
         else:
@@ -1508,11 +1693,19 @@ class MbltWorker(WorkerBase):
                 next_cache_sizes.append(next_cache_size)
                 sequence_lengths.append(sequence_length)
 
-                logits = self._infer_logits(
+                inference_logits = self._infer_logits_with_sequence(
                     input_embeds,
                     deepstack_embeds,
                     cache_size=cache_size,
                 )
+                prompt_logprobs_tensors = self._get_prompt_logprobs_tensors(
+                    req_state=req_state,
+                    sequence_logits=inference_logits.full_sequence_logits,
+                    start_idx=cache_size,
+                    scheduled_end=scheduled_end,
+                )
+                if prompt_logprobs_tensors is not None:
+                    prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
                 # The live accelerator KV now belongs to this request at
                 # next_cache_size tokens, so later same-request decode can reuse it
                 # without forcing a block-boundary snapshot dump.
@@ -1523,7 +1716,7 @@ class MbltWorker(WorkerBase):
                     scheduled_end,
                     sequence_length,
                 ):
-                    logits_batch.append(torch.from_numpy(logits).reshape(1, -1))
+                    logits_batch.append(torch.from_numpy(inference_logits.last_token_logits).reshape(1, -1))
                     req_states_for_sampling.append(req_state)
                     sampling_req_ids.append(req_id)
 
@@ -1554,7 +1747,7 @@ class MbltWorker(WorkerBase):
             req_id_to_index=req_id_to_index,
             sampled_token_ids=sampled_token_ids,
             logprobs=logprobs,
-            prompt_logprobs_dict={},
+            prompt_logprobs_dict=prompt_logprobs_dict,
             pooler_output=[],
         )
 

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -114,6 +114,7 @@ class RequestState:
     prompt_token_ids: list[int]
     cache_slot_id: Optional[int]
     vlm_session_id: Optional[str]
+    next_prompt_logprob_pos: int = 1
 
 
 @dataclass
@@ -834,13 +835,17 @@ class MbltWorker(WorkerBase):
         return logits
 
     @staticmethod
-    def _normalize_sequence_logits(logits: np.ndarray) -> Optional[np.ndarray]:
+    def _normalize_sequence_logits(logits: np.ndarray, expected_seq_len: int) -> Optional[np.ndarray]:
         logits = np.asarray(logits)
         if logits.ndim == 3:
             if logits.shape[0] != 1:
                 return None
+            if logits.shape[1] != expected_seq_len:
+                return None
             return logits[0]
         if logits.ndim == 2:
+            if logits.shape[0] != expected_seq_len:
+                return None
             return logits
         return None
 
@@ -934,7 +939,7 @@ class MbltWorker(WorkerBase):
         logits_np = np.asarray(logits)
         return InferenceLogits(
             last_token_logits=self._last_token_logits(logits_np),
-            full_sequence_logits=self._normalize_sequence_logits(logits_np),
+            full_sequence_logits=self._normalize_sequence_logits(logits_np, expected_seq_len=int(input_embeds.shape[0])),
         )
 
     def _infer_logits_batch(
@@ -1091,7 +1096,7 @@ class MbltWorker(WorkerBase):
         # For prompt position i > 0, use logits produced while processing token
         # i - 1. There is intentionally no logprob for prompt token 0; vLLM's
         # LogprobsProcessor seeds prompt_logprobs with a leading None.
-        first_prompt_pos = max(1, start_idx + 1)
+        first_prompt_pos = max(1, start_idx + 1, req_state.next_prompt_logprob_pos)
         if prompt_end <= first_prompt_pos:
             return None
 
@@ -1110,6 +1115,7 @@ class MbltWorker(WorkerBase):
         prompt_logits = torch.from_numpy(sequence_logits[logits_start:logits_end]).to(dtype=torch.float32)
         target_token_ids = torch.as_tensor(prompt_token_ids[first_prompt_pos:prompt_end], dtype=torch.int64)
         logprobs = self.sampler.compute_logprobs(prompt_logits)
+        req_state.next_prompt_logprob_pos = prompt_end
         return self.sampler.gather_logprobs(logprobs, num_prompt_logprobs, target_token_ids)
 
     @staticmethod

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1058,6 +1058,13 @@ class MbltWorker(WorkerBase):
             return int(self.model.config.vocab_size)
         return int(num_prompt_logprobs)
 
+    def _should_recompute_prompt_logprobs_from_start(self, req_state: RequestState) -> bool:
+        return (
+            self._num_prompt_logprobs(req_state.sampling_params) is not None
+            and req_state.next_prompt_logprob_pos <= 1
+            and req_state.num_computed_tokens > 0
+        )
+
     def _get_prompt_logprobs_tensors(
         self,
         req_state: RequestState,
@@ -1148,6 +1155,12 @@ class MbltWorker(WorkerBase):
             print_debug=print_debug,
         )
 
+        if self._should_recompute_prompt_logprobs_from_start(req_state):
+            self.runtime_cache.clear_loaded_request()
+            if print_debug:
+                print(f"[cache] req={req_id} bypass-prefix-cache-for-prompt-logprobs")
+            return 0
+
         target_tokens = req_state.num_computed_tokens
         result = self.runtime_cache.load_for_request(
             RuntimeCacheRequest(
@@ -1180,6 +1193,11 @@ class MbltWorker(WorkerBase):
     ) -> int:
         if slot_id is None:
             raise RuntimeError(f"Batch execution requires a cache slot for req_id={req_id}.")
+
+        if self._should_recompute_prompt_logprobs_from_start(req_state):
+            if print_debug:
+                print(f"[cache] req={req_id} slot={slot_id} bypass-prefix-cache-for-prompt-logprobs")
+            return 0
 
         target_tokens = req_state.num_computed_tokens
         result = self.runtime_cache.load_for_slot(


### PR DESCRIPTION
## 요약
- `/v1/completions`에서 `echo=true`와 `logprobs`를 함께 사용할 때 prompt logprobs 처리 중 발생하던 오류를 수정했습니다.
- prompt token logprob 생성 경로에서 누락되거나 잘못 조회될 수 있는 prompt token을 안전하게 처리하도록 개선했습니다.
- 관련 worker 최적화 테스트를 추가/갱신했습니다.

## 배경
`echo=true` 요청에서는 생성 토큰뿐 아니라 prompt token도 응답의 `logprobs`에 포함되어야 합니다. 기존 구현에서는 prompt logprob 처리 경로에서 일부 prompt token의 logprob가 올바르게 제공되지 않아 OpenAI completions 호환 응답이 깨질 수 있었습니다.

이 문제는 PPL 계산처럼 원문 token들의 logprob가 필요한 경우에도 영향을 줍니다.

## 변경 사항
- prompt logprobs/completion echo 응답 생성 경로를 수정했습니다.
- prompt token logprob가 누락되거나 예외로 이어지지 않도록 처리했습니다.
- 관련 테스트를 추가/갱신했습니다.

## 검증
- `tests/test_mblt_worker_optimizations.py` 테스트 추가/갱신

## 변경 파일
- `vllm_mblt/mblt_worker.py`
- `tests/test_mblt_worker_optimizations.py`
- `vllm_mblt/__init__.py`