### PR TITLE
Fix completion prompt and generated logprobs

### DIFF
--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -635,6 +635,105 @@ class TestMbltWorkerOptimizations:
         assert all(logprob is not None for logprob in completion_logprobs.token_logprobs[1:])
         assert completion_logprobs.token_logprobs[-1] == -0.25
 
+    @pytest.mark.parametrize("prompt_token_ids", ([], [15339]))
+    def test_prompt_logprobs_fallback_returns_none_for_empty_or_one_token_prompt(
+        self, prompt_token_ids: list[int]
+    ) -> None:
+        worker = self._make_worker()
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+
+        def infer_logits(input_embeds, deepstack_embeds, cache_size):
+            raise AssertionError("short prompts have no prompt positions that require fallback replay")
+
+        worker._infer_logits = infer_logits
+
+        fallback_logits = worker._compute_prompt_logprobs_sequence_logits_fallback(
+            req_state=req_state,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors_with_fallback(
+            req_state=req_state,
+            sequence_logits=None,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert fallback_logits is None
+        assert prompt_logprobs_tensors is None
+
+    def test_prompt_logprobs_fallback_returns_none_after_all_prompt_positions_emitted(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        req_state.next_prompt_logprob_pos = len(prompt_token_ids)
+        req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+
+        def infer_logits(input_embeds, deepstack_embeds, cache_size):
+            raise AssertionError("completed prompt logprobs should not trigger fallback replay")
+
+        worker._infer_logits = infer_logits
+
+        fallback_logits = worker._compute_prompt_logprobs_sequence_logits_fallback(
+            req_state=req_state,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors_with_fallback(
+            req_state=req_state,
+            sequence_logits=None,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert fallback_logits is None
+        assert prompt_logprobs_tensors is None
+
+    def test_prompt_logprobs_fallback_preserves_multitoken_rows_for_needed_positions(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+
+        vocab_size = max(prompt_token_ids) + 1
+        calls: list[tuple[int, int]] = []
+
+        def infer_logits(input_embeds, deepstack_embeds, cache_size):
+            assert deepstack_embeds is None
+            calls.append((int(input_embeds.shape[0]), int(cache_size)))
+            prompt_pos = int(input_embeds.shape[0])
+            logits = np.full((1, vocab_size), -10.0, dtype=np.float32)
+            logits[0, prompt_token_ids[prompt_pos]] = 10.0
+            return logits
+
+        worker._infer_logits = infer_logits
+
+        fallback_logits = worker._compute_prompt_logprobs_sequence_logits_fallback(
+            req_state=req_state,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+        assert fallback_logits is not None
+        assert fallback_logits.shape == (len(prompt_token_ids) - 1, vocab_size)
+        assert calls == [(prompt_pos, 0) for prompt_pos in range(1, len(prompt_token_ids))]
+
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=fallback_logits,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+        assert prompt_logprobs_tensors is not None
+        assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+
     def test_prompt_logprobs_unsupported_logits_shape_terminal_during_decode(self) -> None:
         worker = self._make_worker()
         prompt_token_ids = [101, 102, 103]

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -6,7 +6,7 @@ import torch
 from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from vllm.logprobs import Logprob
 from vllm.sampling_params import SamplingParams
-from vllm.v1.engine.logprobs import LogprobsProcessor
+from vllm.v1.engine.logprobs import LogprobsProcessor, create_prompt_logprobs
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.sampler import Sampler
 
@@ -280,6 +280,100 @@ class TestMbltWorkerOptimizations:
         assert completion_logprobs.token_logprobs[0] is None
         assert completion_logprobs.token_logprobs[1] is not None
         assert completion_logprobs.token_logprobs[-1] == -0.5
+
+    @pytest.mark.parametrize("prompt_token_ids", ([15339, 1917], [128000, 15339, 1917]))
+    def test_prompt_logprobs_include_actual_prompt_token_when_not_topk(
+        self, prompt_token_ids: list[int]
+    ) -> None:
+        worker = self._make_worker()
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+
+        top_token_id = 42
+        vocab_size = max(prompt_token_ids + [top_token_id]) + 1
+        sequence_logits = np.full((len(prompt_token_ids), vocab_size), -10.0, dtype=np.float32)
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            sequence_logits[prompt_pos - 1, top_token_id] = 10.0
+            sequence_logits[prompt_pos - 1, token_id] = -5.0
+
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=sequence_logits,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        processor = LogprobsProcessor(
+            tokenizer=None,
+            logprobs=[],
+            prompt_logprobs=[None],
+            cumulative_logprob=0.0,
+            num_logprobs=1,
+            num_prompt_logprobs=1,
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=prompt_logprobs_tensors)
+        )
+
+        assert processor.prompt_logprobs is not None
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            assert processor.prompt_logprobs[prompt_pos] is not None
+            assert token_id in processor.prompt_logprobs[prompt_pos]
+            assert top_token_id in processor.prompt_logprobs[prompt_pos]
+
+        generated_token_id = 43
+        generated_logprobs = {generated_token_id: Logprob(logprob=-0.5, rank=1, decoded_token=None)}
+        completion_logprobs = OpenAIServingCompletion._create_completion_logprobs(
+            OpenAIServingCompletion.__new__(OpenAIServingCompletion),
+            token_ids=[*prompt_token_ids, generated_token_id],
+            top_logprobs=[*processor.prompt_logprobs, generated_logprobs],
+            num_output_top_logprobs=1,
+            tokenizer=SimpleNamespace(decode=lambda token_id: f"token:{token_id}"),
+            return_as_token_id=True,
+        )
+        assert completion_logprobs.token_logprobs[0] is None
+        assert all(logprob is not None for logprob in completion_logprobs.token_logprobs[1:])
+
+    @pytest.mark.parametrize("prompt_token_ids", ([64], [15339], [128000]))
+    def test_echo_logprobs_one_token_prompt_serializer_keeps_first_prompt_logprob_null(
+        self, prompt_token_ids: list[int]
+    ) -> None:
+        worker = self._make_worker()
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=np.empty((0, max(prompt_token_ids) + 1), dtype=np.float32),
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+        assert prompt_logprobs_tensors is not None
+
+        processor = LogprobsProcessor(
+            tokenizer=None,
+            logprobs=[],
+            prompt_logprobs=create_prompt_logprobs(),
+            cumulative_logprob=0.0,
+            num_logprobs=1,
+            num_prompt_logprobs=1,
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=prompt_logprobs_tensors)
+        )
+        assert processor.prompt_logprobs == [None]
+
+        generated_token_id = 42
+        generated_logprobs = {generated_token_id: Logprob(logprob=-0.25, rank=1, decoded_token=None)}
+        completion_logprobs = OpenAIServingCompletion._create_completion_logprobs(
+            OpenAIServingCompletion.__new__(OpenAIServingCompletion),
+            token_ids=[*prompt_token_ids, generated_token_id],
+            top_logprobs=[*processor.prompt_logprobs, generated_logprobs],
+            num_output_top_logprobs=1,
+            tokenizer=SimpleNamespace(decode=lambda token_id: f"token:{token_id}"),
+            return_as_token_id=True,
+        )
+        assert completion_logprobs.token_logprobs == [None, -0.25]
 
     def test_prompt_logprobs_include_chunk_boundary_prompt_token(self) -> None:
         worker = self._make_worker()

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -584,7 +584,7 @@ class TestMbltWorkerOptimizations:
         def infer_logits(input_embeds, deepstack_embeds, cache_size):
             assert deepstack_embeds is None
             calls.append((int(input_embeds.shape[0]), int(cache_size)))
-            prompt_pos = int(input_embeds.shape[0])
+            prompt_pos = int(cache_size) + int(input_embeds.shape[0])
             logits = np.full((1, vocab_size), -10.0, dtype=np.float32)
             logits[0, prompt_token_ids[prompt_pos]] = 10.0
             return logits
@@ -600,7 +600,7 @@ class TestMbltWorkerOptimizations:
 
         assert prompt_logprobs_tensors is not None
         assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
-        assert calls == [(prompt_pos, 0) for prompt_pos in range(1, len(prompt_token_ids))]
+        assert calls == [(1, prompt_pos - 1) for prompt_pos in range(1, len(prompt_token_ids))]
         assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
 
         processor = LogprobsProcessor(
@@ -708,7 +708,7 @@ class TestMbltWorkerOptimizations:
         def infer_logits(input_embeds, deepstack_embeds, cache_size):
             assert deepstack_embeds is None
             calls.append((int(input_embeds.shape[0]), int(cache_size)))
-            prompt_pos = int(input_embeds.shape[0])
+            prompt_pos = int(cache_size) + int(input_embeds.shape[0])
             logits = np.full((1, vocab_size), -10.0, dtype=np.float32)
             logits[0, prompt_token_ids[prompt_pos]] = 10.0
             return logits
@@ -722,7 +722,7 @@ class TestMbltWorkerOptimizations:
         )
         assert fallback_logits is not None
         assert fallback_logits.shape == (len(prompt_token_ids) - 1, vocab_size)
-        assert calls == [(prompt_pos, 0) for prompt_pos in range(1, len(prompt_token_ids))]
+        assert calls == [(1, prompt_pos - 1) for prompt_pos in range(1, len(prompt_token_ids))]
 
         prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
             req_state=req_state,
@@ -733,6 +733,79 @@ class TestMbltWorkerOptimizations:
         assert prompt_logprobs_tensors is not None
         assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
         assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+
+    def test_prompt_logprobs_fallback_replay_work_is_linear_for_long_prompt(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = list(range(101, 133))
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+
+        vocab_size = max(prompt_token_ids) + 1
+        calls: list[tuple[int, int]] = []
+
+        def infer_logits(input_embeds, deepstack_embeds, cache_size):
+            assert deepstack_embeds is None
+            submitted_tokens = int(input_embeds.shape[0])
+            cache_size = int(cache_size)
+            calls.append((submitted_tokens, cache_size))
+            prompt_pos = cache_size + submitted_tokens
+            logits = np.full((1, vocab_size), -10.0, dtype=np.float32)
+            logits[0, prompt_token_ids[prompt_pos]] = 10.0
+            return logits
+
+        worker._infer_logits = infer_logits
+
+        fallback_logits = worker._compute_prompt_logprobs_sequence_logits_fallback(
+            req_state=req_state,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert fallback_logits is not None
+        assert fallback_logits.shape == (len(prompt_token_ids) - 1, vocab_size)
+        assert calls == [(1, prompt_pos - 1) for prompt_pos in range(1, len(prompt_token_ids))]
+        assert sum(submitted_tokens for submitted_tokens, _cache_size in calls) == len(prompt_token_ids) - 1
+        assert sum(submitted_tokens for submitted_tokens, _cache_size in calls) < len(prompt_token_ids) * 2
+        assert sum(submitted_tokens for submitted_tokens, _cache_size in calls) != sum(
+            range(1, len(prompt_token_ids))
+        )
+
+    def test_prompt_logprobs_fallback_uses_incremental_batch_cache_slot(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103, 104]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+
+        vocab_size = max(prompt_token_ids) + 1
+        calls: list[tuple[int, int, int]] = []
+
+        def infer_logits_batch(input_embeds_batch, cache_sizes, cache_ids):
+            assert len(input_embeds_batch) == len(cache_sizes) == len(cache_ids) == 1
+            submitted_tokens = int(input_embeds_batch[0].shape[0])
+            cache_size = int(cache_sizes[0])
+            cache_id = int(cache_ids[0])
+            calls.append((submitted_tokens, cache_size, cache_id))
+            prompt_pos = cache_size + submitted_tokens
+            logits = np.full((vocab_size,), -10.0, dtype=np.float32)
+            logits[prompt_token_ids[prompt_pos]] = 10.0
+            return [logits]
+
+        worker._infer_logits_batch = infer_logits_batch
+
+        fallback_logits = worker._compute_prompt_logprobs_sequence_logits_fallback(
+            req_state=req_state,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+            cache_id=7,
+        )
+
+        assert fallback_logits is not None
+        assert fallback_logits.shape == (len(prompt_token_ids) - 1, vocab_size)
+        assert calls == [(1, prompt_pos - 1, 7) for prompt_pos in range(1, len(prompt_token_ids))]
 
     def test_prompt_logprobs_unsupported_logits_shape_terminal_during_decode(self) -> None:
         worker = self._make_worker()

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -686,6 +686,31 @@ class TestMbltWorkerOptimizations:
         assert not worker._should_sample_after_step(req_state, 3, 3)
         assert not worker._should_sample_after_step(req_state, 4, 0)
 
+    def test_generated_token_logprobs_are_log_softmax_normalized(self) -> None:
+        worker = self._make_worker()
+        sampling_params = SamplingParams.from_optional(temperature=0.0, logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, [1, 2])
+        sampling_metadata = worker._make_sampling_metadata([req_state])
+        logits = torch.tensor([[0.0, 5.0, 1.0]], dtype=torch.float32)
+
+        sampler_output = worker._sample_next_token(logits=logits, sampling_metadata=sampling_metadata)
+        assert sampler_output.logprobs_tensors is not None
+
+        logprobs_tensors = sampler_output.logprobs_tensors
+        expected_logprobs = torch.log_softmax(logits, dim=-1)
+        selected_token_id = int(sampler_output.sampled_token_ids[0, 0].item())
+
+        assert selected_token_id == 1
+        assert torch.all(logprobs_tensors.logprobs <= 0)
+        torch.testing.assert_close(
+            logprobs_tensors.logprobs[0, 0],
+            expected_logprobs[0, selected_token_id],
+        )
+        torch.testing.assert_close(
+            logprobs_tensors.logprobs[0, 1],
+            expected_logprobs[0, 1],
+        )
+
     def test_normalize_multimodal_embeddings_accepts_tensor_outputs(self) -> None:
         embeddings = torch.randn(2, 4)
         assert MbltWorker._normalize_multimodal_embeddings(embeddings) is embeddings

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -476,6 +476,71 @@ class TestMbltWorkerOptimizations:
         assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
         assert not worker._should_recompute_prompt_logprobs_from_start(req_state)
 
+    @pytest.mark.parametrize("prompt_token_ids", ([15339, 1917], [128000, 15339, 1917]))
+    def test_prompt_logprobs_fallback_for_last_token_only_runtime(self, prompt_token_ids: list[int]) -> None:
+        worker = self._make_worker()
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+
+        vocab_size = max(prompt_token_ids + [42]) + 1
+        calls: list[tuple[int, int]] = []
+
+        def infer_logits(input_embeds, deepstack_embeds, cache_size):
+            assert deepstack_embeds is None
+            calls.append((int(input_embeds.shape[0]), int(cache_size)))
+            prompt_pos = int(input_embeds.shape[0])
+            logits = np.full((1, vocab_size), -10.0, dtype=np.float32)
+            logits[0, prompt_token_ids[prompt_pos]] = 10.0
+            return logits
+
+        worker._infer_logits = infer_logits
+
+        prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors_with_fallback(
+            req_state=req_state,
+            sequence_logits=None,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert prompt_logprobs_tensors is not None
+        assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
+        assert calls == [(prompt_pos, 0) for prompt_pos in range(1, len(prompt_token_ids))]
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+
+        processor = LogprobsProcessor(
+            tokenizer=None,
+            logprobs=[],
+            prompt_logprobs=[None],
+            cumulative_logprob=0.0,
+            num_logprobs=1,
+            num_prompt_logprobs=1,
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=prompt_logprobs_tensors)
+        )
+        assert processor.prompt_logprobs is not None
+        assert len(processor.prompt_logprobs) == len(prompt_token_ids)
+        assert processor.prompt_logprobs[0] is None
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            assert processor.prompt_logprobs[prompt_pos] is not None
+            assert token_id in processor.prompt_logprobs[prompt_pos]
+
+        generated_token_id = 42
+        generated_logprobs = {generated_token_id: Logprob(logprob=-0.25, rank=1, decoded_token=None)}
+        completion_logprobs = OpenAIServingCompletion._create_completion_logprobs(
+            OpenAIServingCompletion.__new__(OpenAIServingCompletion),
+            token_ids=[*prompt_token_ids, generated_token_id],
+            top_logprobs=[*processor.prompt_logprobs, generated_logprobs],
+            num_output_top_logprobs=1,
+            tokenizer=SimpleNamespace(decode=lambda token_id: f"token:{token_id}"),
+            return_as_token_id=True,
+        )
+        assert completion_logprobs.token_logprobs[0] is None
+        assert all(logprob is not None for logprob in completion_logprobs.token_logprobs[1:])
+        assert completion_logprobs.token_logprobs[-1] == -0.25
+
     def test_prompt_logprobs_unsupported_logits_shape_terminal_during_decode(self) -> None:
         worker = self._make_worker()
         prompt_token_ids = [101, 102, 103]

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 
 def register():

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1241,6 +1241,19 @@ class MbltWorker(WorkerBase):
             return False
         return scheduled_end >= req_state.prompt_len
 
+    def _sample_next_token(self, logits: torch.Tensor, sampling_metadata: SamplingMetadata):
+        # OpenAI-compatible logprobs must be log-softmax-normalized
+        # probabilities, not raw logits. Keep the sampler's raw-logits default
+        # for generation behavior, but request normalized raw logprobs for the
+        # optional generated-token logprob tensors. The sampler only computes
+        # these when max_num_logprobs is not None, so normal generation without
+        # logprobs does not pay the log_softmax cost.
+        return self.sampler.forward(
+            logits=logits,
+            sampling_metadata=sampling_metadata,
+            logprobs_mode_override="raw_logprobs",
+        )
+
     def _load_snapshot_if_needed(
         self,
         req_id: str,
@@ -1890,7 +1903,7 @@ class MbltWorker(WorkerBase):
         if logits_batch:
             logits = torch.cat(logits_batch, dim=0)
             sampling_metadata = self._make_sampling_metadata(req_states_for_sampling)
-            sampler_output = self.sampler.forward(logits=logits, sampling_metadata=sampling_metadata)
+            sampler_output = self._sample_next_token(logits, sampling_metadata)
             sampled_token_ids_int: list[list[int]] = sampler_output.sampled_token_ids.tolist()
             for i, req_id in enumerate(sampling_req_ids):
                 self.req_states[req_id].output_token_ids.extend(sampled_token_ids_int[i])

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1145,9 +1145,9 @@ class MbltWorker(WorkerBase):
         log P(t_i | t_0...t_{i-1}) for prompt tokens as well as generated
         tokens.  Some MBLT artifacts return only the last-token logits for an
         inference call, so a normal full-prompt prefill cannot directly provide
-        all prompt positions.  This correctness-first fallback replays prompt
-        prefixes from an empty runtime cache and uses each prefix's last-token
-        logits as the distribution for the next prompt token.
+        all prompt positions.  This correctness-first fallback incrementally
+        replays the prompt in an empty/isolated fallback cache and uses each
+        step's last-token logits as the distribution for the next prompt token.
 
         The caller still runs the scheduled prefill/decode afterwards, so the
         generation cache and generated-token logits are kept on the existing
@@ -1177,25 +1177,44 @@ class MbltWorker(WorkerBase):
         # chunk/replay, but we still include their rows so the tensor layout is
         # identical to full-sequence runtime output.  _get_prompt_logprobs_tensors
         # will slice away already-emitted positions using next_prompt_logprob_pos.
+        #
+        # Feed only new embeddings after the first fallback step and advance the
+        # runtime cache size.  This computes log P(t_i | t_0...t_{i-1}) with
+        # O(N) submitted embeddings instead of replaying every full prefix.
         rows: list[np.ndarray] = []
+        fallback_cache_size = 0
         for prompt_pos in range(start_idx + 1, prompt_end):
-            prefix_embeds = req_state.prompt_embeds[:prompt_pos]
-            prefix_deepstack = (
-                req_state.prompt_deepstack_embeds[:, :prompt_pos, :]
+            if fallback_cache_size == 0:
+                # Prime the fallback cache with the prefix that predicts
+                # prompt_token_ids[prompt_pos].  For the common start_idx == 0
+                # case this is exactly one token; for a nonzero start_idx it is
+                # one linear prefix-fill call, not one call per prefix length.
+                input_start = 0
+                input_end = prompt_pos
+            else:
+                # The fallback cache already contains prompt_pos - 1 tokens;
+                # feed only the next new token to obtain logits for prompt_pos.
+                input_start = prompt_pos - 1
+                input_end = prompt_pos
+
+            input_embeds = req_state.prompt_embeds[input_start:input_end]
+            input_deepstack = (
+                req_state.prompt_deepstack_embeds[:, input_start:input_end, :]
                 if req_state.prompt_deepstack_embeds is not None
                 else None
             )
             if cache_id is not None:
-                if prefix_deepstack is not None:
+                if input_deepstack is not None:
                     raise RuntimeError("Batch prompt-logprob fallback does not support deepstack embeddings.")
                 logits = self._infer_logits_batch(
-                    input_embeds_batch=[prefix_embeds],
-                    cache_sizes=[0],
+                    input_embeds_batch=[input_embeds],
+                    cache_sizes=[fallback_cache_size],
                     cache_ids=[cache_id],
                 )[0]
             else:
-                logits = self._infer_logits(prefix_embeds, prefix_deepstack, cache_size=0)
+                logits = self._infer_logits(input_embeds, input_deepstack, cache_size=fallback_cache_size)
             rows.append(np.asarray(self._last_token_logits(logits)).reshape(-1)[None, :][0])
+            fallback_cache_size += int(input_embeds.shape[0])
 
         if not rows:
             return None

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1160,8 +1160,10 @@ class MbltWorker(WorkerBase):
 
         prompt_token_ids = req_state.prompt_token_ids
         num_prompt_tokens = len(prompt_token_ids)
+        if req_state.next_prompt_logprob_pos >= num_prompt_tokens:
+            return None
         if num_prompt_tokens <= 1:
-            return np.empty((0, int(getattr(self.model.config, "vocab_size", 0))), dtype=np.float32)
+            return None
 
         prompt_end = min(scheduled_end + 1, num_prompt_tokens)
         first_prompt_pos = max(1, start_idx + 1, req_state.next_prompt_logprob_pos)

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1169,9 +1169,12 @@ class MbltWorker(WorkerBase):
             return None
 
         # _get_prompt_logprobs_tensors maps prompt position i to row
-        # i - start_idx - 1.  Recompute the full scheduled prefix span so row
-        # indexing stays identical even if some prompt positions were emitted
-        # by an earlier chunk/replay.
+        # i - start_idx - 1.  Therefore the fallback sequence logits must start
+        # at prompt position start_idx + 1, not first_prompt_pos.  Some prompt
+        # positions in that span may already have been emitted by an earlier
+        # chunk/replay, but we still include their rows so the tensor layout is
+        # identical to full-sequence runtime output.  _get_prompt_logprobs_tensors
+        # will slice away already-emitted positions using next_prompt_logprob_pos.
         rows: list[np.ndarray] = []
         for prompt_pos in range(start_idx + 1, prompt_end):
             prefix_embeds = req_state.prompt_embeds[:prompt_pos]

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1090,7 +1090,7 @@ class MbltWorker(WorkerBase):
         if sequence_logits is None:
             logger.warning_once(
                 "Prompt logprobs were requested, but the MBLT runtime returned only last-token logits. "
-                "Prompt token logprobs will be omitted for this request."
+                "Use _get_prompt_logprobs_tensors_with_fallback to compute prompt token logprobs."
             )
             req_state.next_prompt_logprob_pos = num_prompt_tokens
             return None
@@ -1131,6 +1131,102 @@ class MbltWorker(WorkerBase):
         logprobs = self.sampler.compute_logprobs(prompt_logits)
         req_state.next_prompt_logprob_pos = prompt_end
         return self.sampler.gather_logprobs(logprobs, num_prompt_logprobs, target_token_ids)
+
+    def _compute_prompt_logprobs_sequence_logits_fallback(
+        self,
+        req_state: RequestState,
+        start_idx: int,
+        scheduled_end: int,
+        cache_id: Optional[int] = None,
+    ) -> Optional[np.ndarray]:
+        """Compute prompt-position logits when the runtime exposes only last-token logits.
+
+        vLLM/OpenAI completions with ``echo=true`` and ``logprobs=N`` need
+        log P(t_i | t_0...t_{i-1}) for prompt tokens as well as generated
+        tokens.  Some MBLT artifacts return only the last-token logits for an
+        inference call, so a normal full-prompt prefill cannot directly provide
+        all prompt positions.  This correctness-first fallback replays prompt
+        prefixes from an empty runtime cache and uses each prefix's last-token
+        logits as the distribution for the next prompt token.
+
+        The caller still runs the scheduled prefill/decode afterwards, so the
+        generation cache and generated-token logits are kept on the existing
+        fast path.  This method is invoked only for requests that explicitly
+        ask for prompt logprobs and only when full sequence logits are absent.
+        """
+
+        if self._num_prompt_logprobs(req_state.sampling_params) is None:
+            return None
+
+        prompt_token_ids = req_state.prompt_token_ids
+        num_prompt_tokens = len(prompt_token_ids)
+        if num_prompt_tokens <= 1:
+            return np.empty((0, int(getattr(self.model.config, "vocab_size", 0))), dtype=np.float32)
+
+        prompt_end = min(scheduled_end + 1, num_prompt_tokens)
+        first_prompt_pos = max(1, start_idx + 1, req_state.next_prompt_logprob_pos)
+        if prompt_end <= first_prompt_pos:
+            return None
+
+        # _get_prompt_logprobs_tensors maps prompt position i to row
+        # i - start_idx - 1.  Recompute the full scheduled prefix span so row
+        # indexing stays identical even if some prompt positions were emitted
+        # by an earlier chunk/replay.
+        rows: list[np.ndarray] = []
+        for prompt_pos in range(start_idx + 1, prompt_end):
+            prefix_embeds = req_state.prompt_embeds[:prompt_pos]
+            prefix_deepstack = (
+                req_state.prompt_deepstack_embeds[:, :prompt_pos, :]
+                if req_state.prompt_deepstack_embeds is not None
+                else None
+            )
+            if cache_id is not None:
+                if prefix_deepstack is not None:
+                    raise RuntimeError("Batch prompt-logprob fallback does not support deepstack embeddings.")
+                logits = self._infer_logits_batch(
+                    input_embeds_batch=[prefix_embeds],
+                    cache_sizes=[0],
+                    cache_ids=[cache_id],
+                )[0]
+            else:
+                logits = self._infer_logits(prefix_embeds, prefix_deepstack, cache_size=0)
+            rows.append(np.asarray(self._last_token_logits(logits)).reshape(-1)[None, :][0])
+
+        if not rows:
+            return None
+        return np.stack(rows, axis=0)
+
+    def _get_prompt_logprobs_tensors_with_fallback(
+        self,
+        req_state: RequestState,
+        sequence_logits: Optional[np.ndarray],
+        start_idx: int,
+        scheduled_end: int,
+        cache_id: Optional[int] = None,
+    ):
+        if sequence_logits is None:
+            fallback_logits = self._compute_prompt_logprobs_sequence_logits_fallback(
+                req_state=req_state,
+                start_idx=start_idx,
+                scheduled_end=scheduled_end,
+                cache_id=cache_id,
+            )
+            if fallback_logits is None:
+                return None
+            return self._get_prompt_logprobs_tensors(
+                req_state=req_state,
+                sequence_logits=fallback_logits,
+                start_idx=start_idx,
+                scheduled_end=scheduled_end,
+            )
+
+        prompt_logprobs_tensors = self._get_prompt_logprobs_tensors(
+            req_state=req_state,
+            sequence_logits=sequence_logits,
+            start_idx=start_idx,
+            scheduled_end=scheduled_end,
+        )
+        return prompt_logprobs_tensors
 
     @staticmethod
     def _should_sample_after_step(
@@ -1676,12 +1772,25 @@ class MbltWorker(WorkerBase):
 
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
-                prompt_logprobs_tensors = self._get_prompt_logprobs_tensors(
+                prompt_logprobs_tensors = self._get_prompt_logprobs_tensors_with_fallback(
                     req_state=req_state,
                     sequence_logits=batched_logits[i].full_sequence_logits,
                     start_idx=cache_sizes[i],
                     scheduled_end=scheduled_end_positions[i],
+                    cache_id=cache_ids[i],
                 )
+                if batched_logits[i].full_sequence_logits is None and prompt_logprobs_tensors is not None:
+                    # The fallback replays prompt prefixes in this cache slot. Replay the
+                    # scheduled request from the beginning so the slot's live KV state and
+                    # generated-token logits match the actual request before sampling.
+                    input_embeds = self._build_input_embeds(req_state, 0, scheduled_end_positions[i])
+                    batched_logits[i] = self._infer_logits_batch_with_sequence(
+                        input_embeds_batch=[input_embeds],
+                        cache_sizes=[0],
+                        cache_ids=[cache_ids[i]],
+                    )[0]
+                    sequence_lengths[i] = int(input_embeds.shape[0])
+                    next_cache_sizes[i] = sequence_lengths[i]
                 if prompt_logprobs_tensors is not None:
                     prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
                 req_state.num_computed_tokens = next_cache_sizes[i]
@@ -1729,12 +1838,33 @@ class MbltWorker(WorkerBase):
                     deepstack_embeds,
                     cache_size=cache_size,
                 )
-                prompt_logprobs_tensors = self._get_prompt_logprobs_tensors(
+                prompt_logprobs_tensors = self._get_prompt_logprobs_tensors_with_fallback(
                     req_state=req_state,
                     sequence_logits=inference_logits.full_sequence_logits,
                     start_idx=cache_size,
                     scheduled_end=scheduled_end,
                 )
+                if inference_logits.full_sequence_logits is None and prompt_logprobs_tensors is not None:
+                    # Last-token-only prompt-logprob fallback replays prompt prefixes from
+                    # an empty runtime cache.  Re-run this request from the beginning of
+                    # the scheduled prefix afterwards so live KV state and generated-token
+                    # logits correspond to this request even when the original step had
+                    # loaded a prefix snapshot/cache_size > 0.
+                    input_embeds = self._build_input_embeds(req_state, 0, scheduled_end)
+                    deepstack_embeds = self._build_deepstack_input_embeds(
+                        req_state,
+                        0,
+                        scheduled_end,
+                    )
+                    sequence_length = int(input_embeds.shape[0])
+                    next_cache_size = sequence_length
+                    next_cache_sizes[-1] = next_cache_size
+                    sequence_lengths[-1] = sequence_length
+                    inference_logits = self._infer_logits_with_sequence(
+                        input_embeds,
+                        deepstack_embeds,
+                        cache_size=0,
+                    )
                 if prompt_logprobs_tensors is not None:
                     prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
                 # The live accelerator KV now belongs to this request at


### PR DESCRIPTION
## Summary
- Implement prompt logprobs fallback for OpenAI-compatible `/v1/completions` requests with `echo=true` and `logprobs`.
- Prevent token-id `KeyError`-style HTTP 500 failures for prompt logprobs, including BOS/special-token prompts.
- Normalize generated-token logprobs/top_logprobs with `log_softmax` so raw logits are not returned.
- Add regression coverage for completion echo prompt logprobs and generated-token logprob normalization.

## Validation
- Added/updated regression tests for completion echo prompt logprobs.
- Added/updated regression checks ensuring generated-token logprobs are normalized log probabilities.

## Notes
- Normal generation fast path should remain unchanged when logprobs are not requested.
- First prompt token logprob may remain `null` per vLLM/OpenAI-compatible behavior.