### PR TITLE
Fix concurrent prompt logprobs for MBLT V1

### DIFF
--- a/tests/repro_openai_echo_logprobs_concurrency.py
+++ b/tests/repro_openai_echo_logprobs_concurrency.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Reproduce OpenAI completions echo+logprobs concurrency behavior.
+
+Run against a live server, for example:
+  vllm serve mobilint/Llama-3.2-1B-Instruct-Batch16 --trust-remote-code
+  uv run python tests/repro_openai_echo_logprobs_concurrency.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    body: str
+
+
+def post_completion(base_url: str, model: str, prompt: str, *, echo: bool = True, logprobs: int | None = 1) -> Response:
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "temperature": 0,
+        "max_tokens": 1,
+        "echo": echo,
+    }
+    if logprobs is not None:
+        payload["logprobs"] = logprobs
+
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/v1/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return Response(status=response.status, body=response.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        return Response(status=exc.code, body=exc.read().decode("utf-8", errors="replace"))
+
+
+def run_batch(base_url: str, model: str, prompts: list[str], *, name: str) -> None:
+    with ThreadPoolExecutor(max_workers=len(prompts)) as executor:
+        futures = [executor.submit(post_completion, base_url, model, prompt) for prompt in prompts]
+        responses = [future.result() for future in as_completed(futures)]
+
+    failures = [response for response in responses if response.status >= 500]
+    if failures:
+        sample = failures[0].body[:500]
+        raise RuntimeError(f"{name}: {len(failures)} server errors; first body={sample!r}")
+
+    bad_statuses = [response for response in responses if response.status not in {200, 400, 501}]
+    if bad_statuses:
+        sample = bad_statuses[0]
+        raise RuntimeError(f"{name}: unexpected HTTP {sample.status}; body={sample.body[:500]!r}")
+
+    print(f"{name}: {len(responses)} responses, statuses={sorted({response.status for response in responses})}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", default="mobilint/Llama-3.2-1B-Instruct-Batch16")
+    args = parser.parse_args()
+
+    short_prompts = [f"Short echo logprobs request {i}." for i in range(16)]
+    eval_prompts = [
+        (
+            f"Sample {i:02d}. This calibration sample is designed to exercise echo log probability scoring "
+            "with a moderately sized prompt, similar to perplexity evaluation records. It contains enough "
+            f"ordinary words to exceed sixteen tokenizer tokens. The final sentence index is {i}."
+        )
+        for i in range(32)
+    ]
+
+    run_batch(args.base_url, args.model, [short_prompts[0]], name="single-short-echo-logprobs")
+    run_batch(args.base_url, args.model, short_prompts, name="sixteen-short-echo-logprobs")
+    run_batch(args.base_url, args.model, eval_prompts, name="thirty-two-eval-echo-logprobs")
+
+    normal = post_completion(args.base_url, args.model, "Server should still answer normal completions.", echo=False, logprobs=None)
+    if normal.status != 200:
+        raise RuntimeError(f"normal completion after repro failed: HTTP {normal.status}; body={normal.body[:500]!r}")
+    print("post-repro-normal-completion: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/repro_openai_echo_logprobs_concurrency.py
+++ b/tests/repro_openai_echo_logprobs_concurrency.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
+import math
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -48,22 +48,95 @@ def post_completion(base_url: str, model: str, prompt: str, *, echo: bool = True
         return Response(status=exc.code, body=exc.read().decode("utf-8", errors="replace"))
 
 
+def validate_echo_logprobs_response(response: Response, prompt: str, *, name: str) -> None:
+    if response.status != 200:
+        raise RuntimeError(f"{name}: expected HTTP 200, got {response.status}; body={response.body[:500]!r}")
+
+    try:
+        payload = json.loads(response.body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{name}: response body is not JSON: {exc}; body={response.body[:500]!r}") from exc
+
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise RuntimeError(f"{name}: response missing choices")
+
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        raise RuntimeError(f"{name}: choices[0] is not an object")
+
+    text = choice.get("text")
+    if not isinstance(text, str) or not text.startswith(prompt):
+        raise RuntimeError(f"{name}: echoed text does not start with prompt; text={text!r}")
+
+    logprobs = choice.get("logprobs")
+    if not isinstance(logprobs, dict):
+        raise RuntimeError(f"{name}: choices[0].logprobs is missing or not an object")
+
+    tokens = logprobs.get("tokens")
+    token_logprobs = logprobs.get("token_logprobs")
+    top_logprobs = logprobs.get("top_logprobs")
+    if not isinstance(tokens, list) or not isinstance(token_logprobs, list) or not isinstance(top_logprobs, list):
+        raise RuntimeError(f"{name}: logprobs must include tokens, token_logprobs, and top_logprobs lists")
+
+    token_count = len(tokens)
+    if token_count == 0:
+        raise RuntimeError(f"{name}: logprobs.tokens is empty")
+    for field_name, values in (
+        ("token_logprobs", token_logprobs),
+        ("top_logprobs", top_logprobs),
+        ("text_offset", logprobs.get("text_offset")),
+    ):
+        if values is not None and (not isinstance(values, list) or len(values) != token_count):
+            raise RuntimeError(f"{name}: logprobs.{field_name} length does not match tokens")
+
+    if not all(isinstance(token, str) for token in tokens):
+        raise RuntimeError(f"{name}: logprobs.tokens must contain strings")
+
+    echoed_prompt_token_count = None
+    echoed = ""
+    for index, token in enumerate(tokens, start=1):
+        echoed += token
+        if echoed == prompt:
+            echoed_prompt_token_count = index
+            break
+        if not prompt.startswith(echoed):
+            raise RuntimeError(f"{name}: token text diverges from prompt at token {index}; echoed={echoed!r}")
+    if echoed_prompt_token_count is None:
+        raise RuntimeError(f"{name}: logprobs.tokens do not contain the echoed prompt prefix")
+
+    for index, value in enumerate(token_logprobs):
+        if value is None and index == 0:
+            continue
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(value):
+            raise RuntimeError(f"{name}: token_logprobs[{index}] is not finite: {value!r}")
+
+    for index, value in enumerate(top_logprobs):
+        if value is None and index == 0:
+            continue
+        if not isinstance(value, dict):
+            raise RuntimeError(f"{name}: top_logprobs[{index}] is not an object: {value!r}")
+        for token, logprob in value.items():
+            if not isinstance(token, str):
+                raise RuntimeError(f"{name}: top_logprobs[{index}] contains non-string token: {token!r}")
+            if not isinstance(logprob, (int, float)) or isinstance(logprob, bool) or not math.isfinite(logprob):
+                raise RuntimeError(f"{name}: top_logprobs[{index}][{token!r}] is not finite: {logprob!r}")
+
+
 def run_batch(base_url: str, model: str, prompts: list[str], *, name: str) -> None:
     with ThreadPoolExecutor(max_workers=len(prompts)) as executor:
-        futures = [executor.submit(post_completion, base_url, model, prompt) for prompt in prompts]
-        responses = [future.result() for future in as_completed(futures)]
+        futures = {
+            executor.submit(post_completion, base_url, model, prompt): prompt
+            for prompt in prompts
+        }
+        responses = []
+        for future in as_completed(futures):
+            prompt = futures[future]
+            response = future.result()
+            validate_echo_logprobs_response(response, prompt, name=name)
+            responses.append(response)
 
-    failures = [response for response in responses if response.status >= 500]
-    if failures:
-        sample = failures[0].body[:500]
-        raise RuntimeError(f"{name}: {len(failures)} server errors; first body={sample!r}")
-
-    bad_statuses = [response for response in responses if response.status not in {200, 400, 501}]
-    if bad_statuses:
-        sample = bad_statuses[0]
-        raise RuntimeError(f"{name}: unexpected HTTP {sample.status}; body={sample.body[:500]!r}")
-
-    print(f"{name}: {len(responses)} responses, statuses={sorted({response.status for response in responses})}")
+    print(f"{name}: {len(responses)} validated HTTP 200 echo+logprobs responses")
 
 
 def main() -> int:
@@ -86,7 +159,13 @@ def main() -> int:
     run_batch(args.base_url, args.model, short_prompts, name="sixteen-short-echo-logprobs")
     run_batch(args.base_url, args.model, eval_prompts, name="thirty-two-eval-echo-logprobs")
 
-    normal = post_completion(args.base_url, args.model, "Server should still answer normal completions.", echo=False, logprobs=None)
+    normal = post_completion(
+        args.base_url,
+        args.model,
+        "Server should still answer normal completions.",
+        echo=False,
+        logprobs=None,
+    )
     if normal.status != 200:
         raise RuntimeError(f"normal completion after repro failed: HTTP {normal.status}; body={normal.body[:500]!r}")
     print("post-repro-normal-completion: ok")

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -900,6 +900,73 @@ class TestMbltWorkerOptimizations:
         assert fallback_logits.shape == (len(prompt_token_ids) - 1, vocab_size)
         assert calls == [(1, prompt_pos - 1, 7) for prompt_pos in range(1, len(prompt_token_ids))]
 
+    def test_prompt_logprobs_fallback_batches_replay_across_requests(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        prompt_token_ids_by_cache_id = {
+            11: [101, 102, 103, 104],
+            12: [201, 202, 203],
+            13: [301, 302, 303, 304],
+        }
+        req_states: list[RequestState] = []
+        for prompt_token_ids in prompt_token_ids_by_cache_id.values():
+            req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+            req_state.prompt_len = len(prompt_token_ids)
+            req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+            req_states.append(req_state)
+
+        vocab_size = 400
+        calls: list[tuple[tuple[int, int, int], ...]] = []
+
+        def infer_logits_batch(input_embeds_batch, cache_sizes, cache_ids):
+            calls.append(
+                tuple(
+                    (int(input_embeds.shape[0]), int(cache_size), int(cache_id))
+                    for input_embeds, cache_size, cache_id in zip(input_embeds_batch, cache_sizes, cache_ids)
+                )
+            )
+            logits_batch = []
+            for input_embeds, cache_size, cache_id in zip(input_embeds_batch, cache_sizes, cache_ids):
+                prompt_pos = int(cache_size) + int(input_embeds.shape[0])
+                logits = np.full((vocab_size,), -10.0, dtype=np.float32)
+                logits[prompt_token_ids_by_cache_id[int(cache_id)][prompt_pos]] = 10.0
+                logits_batch.append(logits)
+            return logits_batch
+
+        worker._infer_logits_batch = infer_logits_batch
+
+        fallback_logits = worker._compute_prompt_logprobs_sequence_logits_fallback_batch(
+            [
+                (0, req_states[0], 0, req_states[0].prompt_len, 11),
+                (1, req_states[1], 0, req_states[1].prompt_len, 12),
+                (2, req_states[2], 0, req_states[2].prompt_len, 13),
+            ]
+        )
+
+        assert set(fallback_logits) == {0, 1, 2}
+        assert fallback_logits[0].shape == (3, vocab_size)
+        assert fallback_logits[1].shape == (2, vocab_size)
+        assert fallback_logits[2].shape == (3, vocab_size)
+        assert calls == [
+            ((1, 0, 11), (1, 0, 12)),
+            ((1, 0, 13),),
+            ((1, 1, 11), (1, 1, 12)),
+            ((1, 1, 13),),
+            ((1, 2, 11), (1, 2, 13)),
+        ]
+
+        for output_index, req_state in enumerate(req_states):
+            prompt_logprobs_tensors = worker._get_prompt_logprobs_tensors(
+                req_state=req_state,
+                sequence_logits=fallback_logits[output_index],
+                start_idx=0,
+                scheduled_end=req_state.prompt_len,
+            )
+            assert prompt_logprobs_tensors is not None
+            assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(req_state.prompt_token_ids) - 1
+            assert req_state.next_prompt_logprob_pos == len(req_state.prompt_token_ids)
+
     def test_prompt_logprobs_unsupported_logits_shape_terminal_during_decode(self) -> None:
         worker = self._make_worker()
         prompt_token_ids = [101, 102, 103]

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -488,6 +488,42 @@ class TestMbltWorkerOptimizations:
             assert processor.prompt_logprobs[prompt_pos] is not None
             assert token_id in processor.prompt_logprobs[prompt_pos]
 
+    def test_completed_prompt_logprobs_wait_for_scheduler_emitted_output(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103, 104]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        vocab_size = max(prompt_token_ids) + 1
+
+        logits = np.full((len(prompt_token_ids) - 1, vocab_size), -10.0, dtype=np.float32)
+        for row, token_id in enumerate(prompt_token_ids[1:]):
+            logits[row, token_id] = 10.0
+
+        non_emitting_step_prompt_logprobs = worker._get_completed_prompt_logprobs_tensors_for_scheduler(
+            req_state=req_state,
+            sequence_logits=logits,
+            start_idx=0,
+            scheduled_end=len(prompt_token_ids),
+            can_emit_output=False,
+        )
+
+        assert non_emitting_step_prompt_logprobs is None
+        assert req_state.in_progress_prompt_logprobs is not None
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+
+        emitting_step_prompt_logprobs = worker._get_completed_prompt_logprobs_tensors_for_scheduler(
+            req_state=req_state,
+            sequence_logits=None,
+            start_idx=len(prompt_token_ids),
+            scheduled_end=len(prompt_token_ids) + 1,
+            can_emit_output=True,
+        )
+
+        assert emitting_step_prompt_logprobs is not None
+        assert emitting_step_prompt_logprobs.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
+        assert req_state.in_progress_prompt_logprobs is None
+
     def test_prompt_logprobs_replay_does_not_duplicate_emitted_positions(self) -> None:
         worker = self._make_worker()
         prompt_token_ids = [101, 102, 103, 104]

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -431,6 +431,63 @@ class TestMbltWorkerOptimizations:
             assert processor.prompt_logprobs[prompt_pos] is not None
             assert token_id in processor.prompt_logprobs[prompt_pos]
 
+    def test_prompt_logprobs_are_buffered_until_prefill_completion_for_scheduler(self) -> None:
+        worker = self._make_worker()
+        prompt_token_ids = [101, 102, 103, 104]
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        vocab_size = max(prompt_token_ids) + 1
+
+        first_chunk_logits = np.full((2, vocab_size), -10.0, dtype=np.float32)
+        first_chunk_logits[0, prompt_token_ids[1]] = 10.0
+        first_chunk_logits[1, prompt_token_ids[2]] = 10.0
+
+        first_scheduler_prompt_logprobs = worker._get_completed_prompt_logprobs_tensors_for_scheduler(
+            req_state=req_state,
+            sequence_logits=first_chunk_logits,
+            start_idx=0,
+            scheduled_end=2,
+        )
+
+        assert first_scheduler_prompt_logprobs is None
+        assert req_state.in_progress_prompt_logprobs is not None
+        assert req_state.next_prompt_logprob_pos == 3
+
+        second_chunk_logits = np.full((2, vocab_size), -10.0, dtype=np.float32)
+        second_chunk_logits[0, prompt_token_ids[3]] = 10.0
+
+        completed_prompt_logprobs = worker._get_completed_prompt_logprobs_tensors_for_scheduler(
+            req_state=req_state,
+            sequence_logits=second_chunk_logits,
+            start_idx=2,
+            scheduled_end=len(prompt_token_ids),
+        )
+
+        assert completed_prompt_logprobs is not None
+        assert completed_prompt_logprobs.logprob_token_ids.shape[0] == len(prompt_token_ids) - 1
+        assert req_state.in_progress_prompt_logprobs is None
+        assert req_state.next_prompt_logprob_pos == len(prompt_token_ids)
+
+        processor = LogprobsProcessor(
+            tokenizer=None,
+            logprobs=[],
+            prompt_logprobs=[None],
+            cumulative_logprob=0.0,
+            num_logprobs=1,
+            num_prompt_logprobs=1,
+        )
+        processor.update_from_output(
+            SimpleNamespace(new_logprobs=None, new_prompt_logprobs_tensors=completed_prompt_logprobs)
+        )
+
+        assert processor.prompt_logprobs is not None
+        assert len(processor.prompt_logprobs) == len(prompt_token_ids)
+        assert processor.prompt_logprobs[0] is None
+        for prompt_pos, token_id in enumerate(prompt_token_ids[1:], start=1):
+            assert processor.prompt_logprobs[prompt_pos] is not None
+            assert token_id in processor.prompt_logprobs[prompt_pos]
+
     def test_prompt_logprobs_replay_does_not_duplicate_emitted_positions(self) -> None:
         worker = self._make_worker()
         prompt_token_ids = [101, 102, 103, 104]

--- a/tests/test_repro_openai_echo_logprobs_concurrency.py
+++ b/tests/test_repro_openai_echo_logprobs_concurrency.py
@@ -1,0 +1,73 @@
+import json
+
+import pytest
+
+from tests.repro_openai_echo_logprobs_concurrency import Response, validate_echo_logprobs_response
+
+
+def make_response(*, text: str = "Hello world!") -> Response:
+    return Response(
+        status=200,
+        body=json.dumps(
+            {
+                "choices": [
+                    {
+                        "text": text,
+                        "logprobs": {
+                            "tokens": ["Hello", " world", "!"],
+                            "token_logprobs": [None, -0.2, -0.3],
+                            "top_logprobs": [None, {" world": -0.2}, {"!": -0.3}],
+                            "text_offset": [0, 5, 11],
+                        },
+                    }
+                ]
+            }
+        ),
+    )
+
+
+def test_validate_echo_logprobs_response_accepts_aligned_prompt_logprobs() -> None:
+    validate_echo_logprobs_response(make_response(), "Hello world!", name="test")
+
+
+@pytest.mark.parametrize("status", [400, 501])
+def test_validate_echo_logprobs_response_rejects_unsupported_statuses(status: int) -> None:
+    with pytest.raises(RuntimeError, match="expected HTTP 200"):
+        validate_echo_logprobs_response(Response(status=status, body="{}"), "Hello world!", name="test")
+
+
+def test_validate_echo_logprobs_response_rejects_missing_logprobs() -> None:
+    response = Response(status=200, body=json.dumps({"choices": [{"text": "Hello world!"}]}))
+
+    with pytest.raises(RuntimeError, match="logprobs"):
+        validate_echo_logprobs_response(response, "Hello world!", name="test")
+
+
+def test_validate_echo_logprobs_response_rejects_misaligned_prompt_tokens() -> None:
+    response = make_response(text="Hello world!")
+    payload = json.loads(response.body)
+    payload["choices"][0]["logprobs"]["tokens"] = ["Hello", " there", "!"]
+    response = Response(status=200, body=json.dumps(payload))
+
+    with pytest.raises(RuntimeError, match="diverges from prompt"):
+        validate_echo_logprobs_response(response, "Hello world!", name="test")
+
+
+def test_validate_echo_logprobs_response_rejects_nonfinite_prompt_logprob() -> None:
+    response = make_response()
+    payload = json.loads(response.body)
+    payload["choices"][0]["logprobs"]["token_logprobs"][1] = float("inf")
+    response = Response(status=200, body=json.dumps(payload))
+
+    with pytest.raises(RuntimeError, match="not finite"):
+        validate_echo_logprobs_response(response, "Hello world!", name="test")
+
+
+def test_validate_echo_logprobs_response_rejects_extra_null_token_logprob() -> None:
+    response = make_response()
+    payload = json.loads(response.body)
+    payload["choices"][0]["logprobs"]["token_logprobs"][2] = None
+    response = Response(status=200, body=json.dumps(payload))
+
+    with pytest.raises(RuntimeError, match="not finite"):
+        validate_echo_logprobs_response(response, "Hello world!", name="test")

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1289,6 +1289,7 @@ class MbltWorker(WorkerBase):
         start_idx: int,
         scheduled_end: int,
         cache_id: Optional[int] = None,
+        can_emit_output: bool = True,
     ) -> Optional[LogprobsTensors]:
         num_prompt_logprobs = self._num_prompt_logprobs(req_state.sampling_params)
         if num_prompt_logprobs is None:
@@ -1310,9 +1311,23 @@ class MbltWorker(WorkerBase):
 
         if scheduled_end < req_state.prompt_len:
             return None
+
+        return self._pop_completed_prompt_logprobs_tensors_for_scheduler(
+            req_state=req_state,
+            can_emit_output=can_emit_output,
+        )
+
+    def _pop_completed_prompt_logprobs_tensors_for_scheduler(
+        self,
+        req_state: RequestState,
+        can_emit_output: bool,
+    ) -> Optional[LogprobsTensors]:
+        if not can_emit_output:
+            return None
+        if self._num_prompt_logprobs(req_state.sampling_params) is None:
+            return None
         if req_state.next_prompt_logprob_pos < len(req_state.prompt_token_ids):
             return None
-
         completed_prompt_logprobs = req_state.in_progress_prompt_logprobs
         req_state.in_progress_prompt_logprobs = None
         return completed_prompt_logprobs
@@ -1875,12 +1890,13 @@ class MbltWorker(WorkerBase):
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
                 prompt_logprob_pos_before = req_state.next_prompt_logprob_pos
-                prompt_logprobs_tensors = self._get_completed_prompt_logprobs_tensors_for_scheduler(
+                self._get_completed_prompt_logprobs_tensors_for_scheduler(
                     req_state=req_state,
                     sequence_logits=batched_logits[i].full_sequence_logits,
                     start_idx=cache_sizes[i],
                     scheduled_end=scheduled_end_positions[i],
                     cache_id=cache_ids[i],
+                    can_emit_output=False,
                 )
                 prompt_logprob_fallback_replayed = (
                     batched_logits[i].full_sequence_logits is None
@@ -1898,8 +1914,6 @@ class MbltWorker(WorkerBase):
                     )[0]
                     sequence_lengths[i] = int(input_embeds.shape[0])
                     next_cache_sizes[i] = sequence_lengths[i]
-                if prompt_logprobs_tensors is not None:
-                    prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
                 req_state.num_computed_tokens = next_cache_sizes[i]
                 self.runtime_cache.mark_slot_owner(cache_ids[i], req_id)
                 if self._should_sample_after_step(
@@ -1907,6 +1921,12 @@ class MbltWorker(WorkerBase):
                     scheduled_end_positions[i],
                     sequence_lengths[i],
                 ):
+                    prompt_logprobs_tensors = self._pop_completed_prompt_logprobs_tensors_for_scheduler(
+                        req_state=req_state,
+                        can_emit_output=True,
+                    )
+                    if prompt_logprobs_tensors is not None:
+                        prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
                     logits_batch.append(torch.from_numpy(batched_logits[i].last_token_logits).reshape(1, -1))
                     req_states_for_sampling.append(req_state)
                     sampling_req_ids.append(req_id)
@@ -1946,11 +1966,12 @@ class MbltWorker(WorkerBase):
                     cache_size=cache_size,
                 )
                 prompt_logprob_pos_before = req_state.next_prompt_logprob_pos
-                prompt_logprobs_tensors = self._get_completed_prompt_logprobs_tensors_for_scheduler(
+                self._get_completed_prompt_logprobs_tensors_for_scheduler(
                     req_state=req_state,
                     sequence_logits=inference_logits.full_sequence_logits,
                     start_idx=cache_size,
                     scheduled_end=scheduled_end,
+                    can_emit_output=False,
                 )
                 prompt_logprob_fallback_replayed = (
                     inference_logits.full_sequence_logits is None
@@ -1977,8 +1998,6 @@ class MbltWorker(WorkerBase):
                         deepstack_embeds,
                         cache_size=0,
                     )
-                if prompt_logprobs_tensors is not None:
-                    prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
                 # The live accelerator KV now belongs to this request at
                 # next_cache_size tokens, so later same-request decode can reuse it
                 # without forcing a block-boundary snapshot dump.
@@ -1989,6 +2008,12 @@ class MbltWorker(WorkerBase):
                     scheduled_end,
                     sequence_length,
                 ):
+                    prompt_logprobs_tensors = self._pop_completed_prompt_logprobs_tensors_for_scheduler(
+                        req_state=req_state,
+                        can_emit_output=True,
+                    )
+                    if prompt_logprobs_tensors is not None:
+                        prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
                     logits_batch.append(torch.from_numpy(inference_logits.last_token_logits).reshape(1, -1))
                     req_states_for_sampling.append(req_state)
                     sampling_req_ids.append(req_id)

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -20,7 +20,7 @@ from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec, MLAAttentionSpec
-from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
+from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsTensors, ModelRunnerOutput
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
@@ -115,6 +115,7 @@ class RequestState:
     cache_slot_id: Optional[int]
     vlm_session_id: Optional[str]
     next_prompt_logprob_pos: int = 1
+    in_progress_prompt_logprobs: Optional[LogprobsTensors] = None
 
 
 @dataclass
@@ -1252,6 +1253,70 @@ class MbltWorker(WorkerBase):
         )
         return prompt_logprobs_tensors
 
+    def _accumulate_prompt_logprobs_tensors(
+        self,
+        req_state: RequestState,
+        prompt_logprobs_tensors: Optional[LogprobsTensors],
+        first_prompt_pos: int,
+    ) -> None:
+        if prompt_logprobs_tensors is None:
+            return
+
+        num_prompt_logprobs = self._num_prompt_logprobs(req_state.sampling_params)
+        if num_prompt_logprobs is None:
+            return
+
+        num_rows = int(prompt_logprobs_tensors.logprob_token_ids.shape[0])
+        if req_state.in_progress_prompt_logprobs is None:
+            req_state.in_progress_prompt_logprobs = LogprobsTensors.empty_cpu(
+                max(0, len(req_state.prompt_token_ids) - 1),
+                num_prompt_logprobs + 1,
+            )
+        if num_rows <= 0:
+            return
+
+        dst_start = first_prompt_pos - 1
+        dst_end = dst_start + num_rows
+        in_progress = req_state.in_progress_prompt_logprobs
+        in_progress.logprob_token_ids[dst_start:dst_end].copy_(prompt_logprobs_tensors.logprob_token_ids)
+        in_progress.logprobs[dst_start:dst_end].copy_(prompt_logprobs_tensors.logprobs)
+        in_progress.selected_token_ranks[dst_start:dst_end].copy_(prompt_logprobs_tensors.selected_token_ranks)
+
+    def _get_completed_prompt_logprobs_tensors_for_scheduler(
+        self,
+        req_state: RequestState,
+        sequence_logits: Optional[np.ndarray],
+        start_idx: int,
+        scheduled_end: int,
+        cache_id: Optional[int] = None,
+    ) -> Optional[LogprobsTensors]:
+        num_prompt_logprobs = self._num_prompt_logprobs(req_state.sampling_params)
+        if num_prompt_logprobs is None:
+            return None
+
+        first_prompt_pos = max(1, start_idx + 1, req_state.next_prompt_logprob_pos)
+        prompt_logprobs_tensors = self._get_prompt_logprobs_tensors_with_fallback(
+            req_state=req_state,
+            sequence_logits=sequence_logits,
+            start_idx=start_idx,
+            scheduled_end=scheduled_end,
+            cache_id=cache_id,
+        )
+        self._accumulate_prompt_logprobs_tensors(
+            req_state=req_state,
+            prompt_logprobs_tensors=prompt_logprobs_tensors,
+            first_prompt_pos=first_prompt_pos,
+        )
+
+        if scheduled_end < req_state.prompt_len:
+            return None
+        if req_state.next_prompt_logprob_pos < len(req_state.prompt_token_ids):
+            return None
+
+        completed_prompt_logprobs = req_state.in_progress_prompt_logprobs
+        req_state.in_progress_prompt_logprobs = None
+        return completed_prompt_logprobs
+
     @staticmethod
     def _should_sample_after_step(
         req_state: RequestState,
@@ -1809,14 +1874,19 @@ class MbltWorker(WorkerBase):
 
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
-                prompt_logprobs_tensors = self._get_prompt_logprobs_tensors_with_fallback(
+                prompt_logprob_pos_before = req_state.next_prompt_logprob_pos
+                prompt_logprobs_tensors = self._get_completed_prompt_logprobs_tensors_for_scheduler(
                     req_state=req_state,
                     sequence_logits=batched_logits[i].full_sequence_logits,
                     start_idx=cache_sizes[i],
                     scheduled_end=scheduled_end_positions[i],
                     cache_id=cache_ids[i],
                 )
-                if batched_logits[i].full_sequence_logits is None and prompt_logprobs_tensors is not None:
+                prompt_logprob_fallback_replayed = (
+                    batched_logits[i].full_sequence_logits is None
+                    and req_state.next_prompt_logprob_pos > prompt_logprob_pos_before
+                )
+                if prompt_logprob_fallback_replayed:
                     # The fallback replays prompt prefixes in this cache slot. Replay the
                     # scheduled request from the beginning so the slot's live KV state and
                     # generated-token logits match the actual request before sampling.
@@ -1875,13 +1945,18 @@ class MbltWorker(WorkerBase):
                     deepstack_embeds,
                     cache_size=cache_size,
                 )
-                prompt_logprobs_tensors = self._get_prompt_logprobs_tensors_with_fallback(
+                prompt_logprob_pos_before = req_state.next_prompt_logprob_pos
+                prompt_logprobs_tensors = self._get_completed_prompt_logprobs_tensors_for_scheduler(
                     req_state=req_state,
                     sequence_logits=inference_logits.full_sequence_logits,
                     start_idx=cache_size,
                     scheduled_end=scheduled_end,
                 )
-                if inference_logits.full_sequence_logits is None and prompt_logprobs_tensors is not None:
+                prompt_logprob_fallback_replayed = (
+                    inference_logits.full_sequence_logits is None
+                    and req_state.next_prompt_logprob_pos > prompt_logprob_pos_before
+                )
+                if prompt_logprob_fallback_replayed:
                     # Last-token-only prompt-logprob fallback replays prompt prefixes from
                     # an empty runtime cache.  Re-run this request from the beginning of
                     # the scheduled prefix afterwards so live KV state and generated-token

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -2020,6 +2020,7 @@ class MbltWorker(WorkerBase):
                 ]
             )
             restore_indices: list[int] = []
+            restore_start_positions: dict[int, int] = {}
 
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
@@ -2027,7 +2028,18 @@ class MbltWorker(WorkerBase):
                 if sequence_logits is None:
                     sequence_logits = fallback_sequence_logits.get(i)
                     if sequence_logits is not None:
-                        restore_indices.append(i)
+                        prompt_end = min(scheduled_end_positions[i] + 1, req_state.prompt_len)
+                        restore_start = max(0, prompt_end - 1)
+                        if restore_start >= scheduled_end_positions[i]:
+                            batched_logits[i] = InferenceLogits(
+                                last_token_logits=np.asarray(sequence_logits)[-1, :],
+                                full_sequence_logits=sequence_logits,
+                            )
+                            sequence_lengths[i] = max(1, restore_start)
+                            next_cache_sizes[i] = restore_start
+                        else:
+                            restore_indices.append(i)
+                            restore_start_positions[i] = restore_start
                 self._get_completed_prompt_logprobs_tensors_for_scheduler(
                     req_state=req_state,
                     sequence_logits=sequence_logits,
@@ -2042,14 +2054,14 @@ class MbltWorker(WorkerBase):
                 restore_input_embeds_batch = [
                     self._build_input_embeds(
                         self.req_states[req_ids[i]],
-                        0,
+                        restore_start_positions[i],
                         scheduled_end_positions[i],
                     )
                     for i in restore_batch
                 ]
                 restored_logits = self._infer_logits_batch_with_sequence(
                     input_embeds_batch=restore_input_embeds_batch,
-                    cache_sizes=[0 for _ in restore_batch],
+                    cache_sizes=[restore_start_positions[i] for i in restore_batch],
                     cache_ids=[cache_ids[i] for i in restore_batch],
                 )
                 for i, input_embeds, inference_logits in zip(
@@ -2059,7 +2071,7 @@ class MbltWorker(WorkerBase):
                 ):
                     batched_logits[i] = inference_logits
                     sequence_lengths[i] = int(input_embeds.shape[0])
-                    next_cache_sizes[i] = sequence_lengths[i]
+                    next_cache_sizes[i] = restore_start_positions[i] + sequence_lengths[i]
 
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -138,6 +138,19 @@ class InferenceLogits:
     last_token_logits: np.ndarray
     full_sequence_logits: Optional[np.ndarray]
 
+
+@dataclass
+class PromptLogprobFallbackReplayState:
+    output_index: int
+    req_state: RequestState
+    start_idx: int
+    prompt_end: int
+    cache_id: int
+    current_prompt_pos: int
+    fallback_cache_size: int
+    rows: list[np.ndarray]
+
+
 class MbltWorker(WorkerBase):
     MAX_FINISHED_CACHE_SNAPSHOTS = 16
 
@@ -1221,6 +1234,112 @@ class MbltWorker(WorkerBase):
             return None
         return np.stack(rows, axis=0)
 
+    def _make_prompt_logprobs_fallback_replay_state(
+        self,
+        output_index: int,
+        req_state: RequestState,
+        start_idx: int,
+        scheduled_end: int,
+        cache_id: int,
+    ) -> Optional[PromptLogprobFallbackReplayState]:
+        if self._num_prompt_logprobs(req_state.sampling_params) is None:
+            return None
+
+        prompt_token_ids = req_state.prompt_token_ids
+        num_prompt_tokens = len(prompt_token_ids)
+        if req_state.next_prompt_logprob_pos >= num_prompt_tokens:
+            return None
+        if num_prompt_tokens <= 1:
+            return None
+
+        prompt_end = min(scheduled_end + 1, num_prompt_tokens)
+        first_prompt_pos = max(1, start_idx + 1, req_state.next_prompt_logprob_pos)
+        if prompt_end <= first_prompt_pos:
+            return None
+        if req_state.prompt_deepstack_embeds is not None:
+            raise RuntimeError("Batch prompt-logprob fallback does not support deepstack embeddings.")
+
+        return PromptLogprobFallbackReplayState(
+            output_index=output_index,
+            req_state=req_state,
+            start_idx=start_idx,
+            prompt_end=prompt_end,
+            cache_id=cache_id,
+            current_prompt_pos=start_idx + 1,
+            fallback_cache_size=0,
+            rows=[],
+        )
+
+    def _compute_prompt_logprobs_sequence_logits_fallback_batch(
+        self,
+        requests: list[tuple[int, RequestState, int, int, int]],
+    ) -> dict[int, np.ndarray]:
+        """Batch prompt-logprob fallback replay across requests.
+
+        Each active request owns an isolated qbruntime cache_id.  The replay
+        cache starts empty and advances one prompt position at a time, but the
+        work for different requests is submitted together through BatchParam.
+        """
+
+        states = [
+            state
+            for output_index, req_state, start_idx, scheduled_end, cache_id in requests
+            if (
+                state := self._make_prompt_logprobs_fallback_replay_state(
+                    output_index=output_index,
+                    req_state=req_state,
+                    start_idx=start_idx,
+                    scheduled_end=scheduled_end,
+                    cache_id=cache_id,
+                )
+            )
+            is not None
+        ]
+        if not states:
+            return {}
+
+        while True:
+            active_states = [state for state in states if state.current_prompt_pos < state.prompt_end]
+            if not active_states:
+                break
+
+            for batch_start in range(0, len(active_states), self.max_batch_size):
+                batch_states = active_states[batch_start : batch_start + self.max_batch_size]
+                input_embeds_batch: list[np.ndarray] = []
+                cache_sizes: list[int] = []
+                cache_ids: list[int] = []
+
+                for state in batch_states:
+                    prompt_pos = state.current_prompt_pos
+                    if state.fallback_cache_size == 0:
+                        input_start = 0
+                        input_end = prompt_pos
+                    else:
+                        input_start = prompt_pos - 1
+                        input_end = prompt_pos
+
+                    input_embeds = state.req_state.prompt_embeds[input_start:input_end]
+                    input_embeds_batch.append(input_embeds)
+                    cache_sizes.append(state.fallback_cache_size)
+                    cache_ids.append(state.cache_id)
+
+                logits_batch = self._infer_logits_batch(
+                    input_embeds_batch=input_embeds_batch,
+                    cache_sizes=cache_sizes,
+                    cache_ids=cache_ids,
+                )
+
+                for state, input_embeds, logits in zip(batch_states, input_embeds_batch, logits_batch):
+                    state.rows.append(np.asarray(self._last_token_logits(logits)).reshape(-1))
+                    state.fallback_cache_size += int(input_embeds.shape[0])
+                    state.current_prompt_pos += 1
+
+        return {
+            state.output_index: np.stack(state.rows, axis=0)
+            for state in states
+            if state.rows
+        }
+
     def _get_prompt_logprobs_tensors_with_fallback(
         self,
         req_state: RequestState,
@@ -1887,33 +2006,63 @@ class MbltWorker(WorkerBase):
                 cache_ids=cache_ids,
             )
 
+            fallback_sequence_logits = self._compute_prompt_logprobs_sequence_logits_fallback_batch(
+                [
+                    (
+                        i,
+                        self.req_states[req_id],
+                        cache_sizes[i],
+                        scheduled_end_positions[i],
+                        cache_ids[i],
+                    )
+                    for i, req_id in enumerate(req_ids)
+                    if batched_logits[i].full_sequence_logits is None
+                ]
+            )
+            restore_indices: list[int] = []
+
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
-                prompt_logprob_pos_before = req_state.next_prompt_logprob_pos
+                sequence_logits = batched_logits[i].full_sequence_logits
+                if sequence_logits is None:
+                    sequence_logits = fallback_sequence_logits.get(i)
+                    if sequence_logits is not None:
+                        restore_indices.append(i)
                 self._get_completed_prompt_logprobs_tensors_for_scheduler(
                     req_state=req_state,
-                    sequence_logits=batched_logits[i].full_sequence_logits,
+                    sequence_logits=sequence_logits,
                     start_idx=cache_sizes[i],
                     scheduled_end=scheduled_end_positions[i],
                     cache_id=cache_ids[i],
                     can_emit_output=False,
                 )
-                prompt_logprob_fallback_replayed = (
-                    batched_logits[i].full_sequence_logits is None
-                    and req_state.next_prompt_logprob_pos > prompt_logprob_pos_before
+
+            for restore_start in range(0, len(restore_indices), self.max_batch_size):
+                restore_batch = restore_indices[restore_start : restore_start + self.max_batch_size]
+                restore_input_embeds_batch = [
+                    self._build_input_embeds(
+                        self.req_states[req_ids[i]],
+                        0,
+                        scheduled_end_positions[i],
+                    )
+                    for i in restore_batch
+                ]
+                restored_logits = self._infer_logits_batch_with_sequence(
+                    input_embeds_batch=restore_input_embeds_batch,
+                    cache_sizes=[0 for _ in restore_batch],
+                    cache_ids=[cache_ids[i] for i in restore_batch],
                 )
-                if prompt_logprob_fallback_replayed:
-                    # The fallback replays prompt prefixes in this cache slot. Replay the
-                    # scheduled request from the beginning so the slot's live KV state and
-                    # generated-token logits match the actual request before sampling.
-                    input_embeds = self._build_input_embeds(req_state, 0, scheduled_end_positions[i])
-                    batched_logits[i] = self._infer_logits_batch_with_sequence(
-                        input_embeds_batch=[input_embeds],
-                        cache_sizes=[0],
-                        cache_ids=[cache_ids[i]],
-                    )[0]
+                for i, input_embeds, inference_logits in zip(
+                    restore_batch,
+                    restore_input_embeds_batch,
+                    restored_logits,
+                ):
+                    batched_logits[i] = inference_logits
                     sequence_lengths[i] = int(input_embeds.shape[0])
                     next_cache_sizes[i] = sequence_lengths[i]
+
+            for i, req_id in enumerate(req_ids):
+                req_state = self.req_states[req_id]
                 req_state.num_computed_tokens = next_cache_sizes[i]
                 self.runtime_cache.mark_slot_owner(cache_ids[i], req_id)
                 if self._should_sample_after_step(


### PR DESCRIPTION
Fixes MBLT V1 prompt_logprobs handling for concurrent OpenAI completions echo-logprobs requests.

Summary:
- Prevents EngineCore crashes from prompt_logprobs tensors surfacing in invalid V1 scheduler steps.
- Adds batched prompt-logprobs fallback replay for Batch models instead of fully per-request fallback.
- Optimizes cache restoration after fallback replay.
- Preserves normal generation and non-logprobs behavior.

Validation:
- Batch16 model handled 32 concurrent echo=true, logprobs=1, max_tokens=1 requests without EngineCore crash.
- Responses included prompt logprobs with expected token/logprob structure.
- Server remained alive after stress test and subsequent normal completions returned 200.
- Batch16 measured about 3.5x throughput improvement over non-batch for the tested 53-token prompt workload.