### PR TITLE
Fix batch prompt logprobs for last-logit MXQ

### DIFF
--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -229,6 +229,12 @@ class TestMbltPlatformPrefill:
         assert config.scheduler_config.max_long_partial_prefills == 16
         assert config.scheduler_config.long_prefill_token_threshold == 128
 
+    def test_platform_keeps_aggregate_budget_and_per_request_worker_cap_for_batch_model(self) -> None:
+        config = _make_vllm_config({"single": 256}, hf_core_mode="single", max_batch_size=16)
+        MbltPlatform.check_and_update_config(config)
+        assert config.scheduler_config.max_num_batched_tokens == 128 * 16
+        assert config.scheduler_config.long_prefill_token_threshold == 128
+
     def test_platform_scales_scheduler_prefill_budget_for_user_seq_limit(self) -> None:
         config = _make_vllm_config(
             {"single": 256},

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -20,6 +20,8 @@ def _make_vllm_config(
     max_batch_size=None,
     scheduler_max_num_batched_tokens=2048,
     scheduler_max_num_seqs=None,
+    scheduler_max_num_partial_prefills=1,
+    scheduler_max_long_partial_prefills=1,
 ):
     if loader_extra_config is None:
         loader_extra_config = {"core_mode": loader_core_mode} if loader_core_mode is not None else {}
@@ -30,6 +32,8 @@ def _make_vllm_config(
             chunked_prefill_enabled=False,
             max_num_batched_tokens=scheduler_max_num_batched_tokens,
             max_num_seqs=scheduler_max_num_seqs,
+            max_num_partial_prefills=scheduler_max_num_partial_prefills,
+            max_long_partial_prefills=scheduler_max_long_partial_prefills,
         ),
         model_config=SimpleNamespace(
             hf_config=SimpleNamespace(
@@ -207,8 +211,33 @@ class TestMbltPlatformPrefill:
         config = _make_vllm_config({"single": 256}, hf_core_mode="single", max_batch_size=32)
         MbltPlatform.check_and_update_config(config)
         assert config.scheduler_config.chunked_prefill_enabled
-        assert config.scheduler_config.max_num_batched_tokens == 128
+        assert config.scheduler_config.max_num_batched_tokens == 4096
         assert config.scheduler_config.max_num_seqs == 32
+        assert config.scheduler_config.max_num_partial_prefills == 32
+        assert config.scheduler_config.max_long_partial_prefills == 32
+
+    def test_platform_scales_scheduler_prefill_budget_for_batch_model(self) -> None:
+        config = _make_vllm_config({"single": 256}, hf_core_mode="single", max_batch_size=16)
+        MbltPlatform.check_and_update_config(config)
+        assert config.scheduler_config.chunked_prefill_enabled
+        assert config.scheduler_config.max_num_batched_tokens == 2048
+        assert config.scheduler_config.max_num_seqs == 16
+        assert config.scheduler_config.max_num_partial_prefills == 16
+        assert config.scheduler_config.max_long_partial_prefills == 16
+
+    def test_platform_scales_scheduler_prefill_budget_for_user_seq_limit(self) -> None:
+        config = _make_vllm_config(
+            {"single": 256},
+            hf_core_mode="single",
+            max_batch_size=16,
+            scheduler_max_num_seqs=8,
+        )
+        MbltPlatform.check_and_update_config(config)
+        assert config.scheduler_config.chunked_prefill_enabled
+        assert config.scheduler_config.max_num_batched_tokens == 1024
+        assert config.scheduler_config.max_num_seqs == 8
+        assert config.scheduler_config.max_num_partial_prefills == 8
+        assert config.scheduler_config.max_long_partial_prefills == 8
 
     def test_platform_warns_when_max_num_seqs_exceeds_model_batch_size(self, caplog) -> None:
         caplog.set_level(logging.WARNING, logger="vllm_mblt.mblt_platform")

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -22,6 +22,7 @@ def _make_vllm_config(
     scheduler_max_num_seqs=None,
     scheduler_max_num_partial_prefills=1,
     scheduler_max_long_partial_prefills=1,
+    scheduler_long_prefill_token_threshold=0,
 ):
     if loader_extra_config is None:
         loader_extra_config = {"core_mode": loader_core_mode} if loader_core_mode is not None else {}
@@ -34,6 +35,7 @@ def _make_vllm_config(
             max_num_seqs=scheduler_max_num_seqs,
             max_num_partial_prefills=scheduler_max_num_partial_prefills,
             max_long_partial_prefills=scheduler_max_long_partial_prefills,
+            long_prefill_token_threshold=scheduler_long_prefill_token_threshold,
         ),
         model_config=SimpleNamespace(
             hf_config=SimpleNamespace(
@@ -215,6 +217,7 @@ class TestMbltPlatformPrefill:
         assert config.scheduler_config.max_num_seqs == 32
         assert config.scheduler_config.max_num_partial_prefills == 32
         assert config.scheduler_config.max_long_partial_prefills == 32
+        assert config.scheduler_config.long_prefill_token_threshold == 128
 
     def test_platform_scales_scheduler_prefill_budget_for_batch_model(self) -> None:
         config = _make_vllm_config({"single": 256}, hf_core_mode="single", max_batch_size=16)
@@ -224,6 +227,7 @@ class TestMbltPlatformPrefill:
         assert config.scheduler_config.max_num_seqs == 16
         assert config.scheduler_config.max_num_partial_prefills == 16
         assert config.scheduler_config.max_long_partial_prefills == 16
+        assert config.scheduler_config.long_prefill_token_threshold == 128
 
     def test_platform_scales_scheduler_prefill_budget_for_user_seq_limit(self) -> None:
         config = _make_vllm_config(
@@ -238,6 +242,17 @@ class TestMbltPlatformPrefill:
         assert config.scheduler_config.max_num_seqs == 8
         assert config.scheduler_config.max_num_partial_prefills == 8
         assert config.scheduler_config.max_long_partial_prefills == 8
+        assert config.scheduler_config.long_prefill_token_threshold == 128
+
+    def test_platform_overrides_batch_long_prefill_threshold_to_chunk_size(self) -> None:
+        config = _make_vllm_config(
+            {"single": 256},
+            hf_core_mode="single",
+            max_batch_size=16,
+            scheduler_long_prefill_token_threshold=4096,
+        )
+        MbltPlatform.check_and_update_config(config)
+        assert config.scheduler_config.long_prefill_token_threshold == 128
 
     def test_platform_warns_when_max_num_seqs_exceeds_model_batch_size(self, caplog) -> None:
         caplog.set_level(logging.WARNING, logger="vllm_mblt.mblt_platform")

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -146,6 +146,7 @@ class TestMbltWorkerOptimizations:
         worker.sampler = Sampler(logprobs_mode="raw_logits")
         worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=1, block_size=128)
         worker.input_embeddings = SimpleNamespace()
+        worker.print_debug = False
         worker._warned_last_logit_prompt_logprobs = False
         worker._vlm_image_positions_by_session = {}
         return worker

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -11,6 +11,7 @@ from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_mblt.mblt_worker import (
+    InferenceLogits,
     MbltWorker,
     RequestState,
     _is_multimodal_hf_config,
@@ -137,11 +138,14 @@ class TestMbltWorkerOptimizations:
             cache_config=SimpleNamespace(block_size=128), model_config=worker.model_config
         )
         worker.model = SimpleNamespace(config=SimpleNamespace(vocab_size=32000))
+        worker.cache_model = None
         worker.max_batch_size = 1
         worker.empty_logits_processors = LogitsProcessors(None)
         worker.empty_prompt_token_ids = torch.empty((0, 0), dtype=torch.int64)
         worker.sampler = Sampler(logprobs_mode="raw_logits")
         worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=1, block_size=128)
+        worker.input_embeddings = SimpleNamespace()
+        worker._warned_last_logit_prompt_logprobs = False
         worker._vlm_image_positions_by_session = {}
         return worker
 
@@ -967,6 +971,182 @@ class TestMbltWorkerOptimizations:
             assert prompt_logprobs_tensors.logprob_token_ids.shape[0] == len(req_state.prompt_token_ids) - 1
             assert req_state.next_prompt_logprob_pos == len(req_state.prompt_token_ids)
 
+    def test_prompt_logprob_microsteps_do_not_submit_long_batch_param(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        prompt_token_ids = list(range(300))
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+        req_state.prompt_len = len(prompt_token_ids)
+        req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+
+        calls: list[tuple[int, int, int]] = []
+        vocab_size = 320
+
+        def infer(_inputs, *, params):
+            calls.extend(
+                (int(param.sequence_length), int(param.cache_size), int(param.cache_id))
+                for param in params
+            )
+            return [np.zeros((len(params), vocab_size), dtype=np.float32)]
+
+        worker.cache_model = SimpleNamespace(
+            infer=infer,
+            get_model_output_shape=lambda: [(2, vocab_size)],
+        )
+
+        outputs = worker._run_prompt_logprob_microsteps_batch(
+            [(0, "req", req_state, 256, 258, 7)]
+        )
+
+        assert set(outputs) == {0}
+        assert calls == [(1, 256, 7), (1, 257, 7)]
+        assert all(sequence_length == 1 for sequence_length, _cache_size, _cache_id in calls)
+
+    def test_prompt_logprob_microsteps_batch_requests_up_to_max_batch_size(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_states: list[RequestState] = []
+        for base in (10, 20, 30):
+            prompt_token_ids = [base, base + 1, base + 2]
+            req_state = self._make_request_state(worker, sampling_params, prompt_token_ids)
+            req_state.prompt_len = len(prompt_token_ids)
+            req_state.prompt_embeds = np.ones((len(prompt_token_ids), 4), dtype=np.float32)
+            req_states.append(req_state)
+
+        calls: list[tuple[tuple[int, int, int], ...]] = []
+        vocab_size = 64
+
+        def infer(_inputs, *, params):
+            calls.append(
+                tuple(
+                    (int(param.sequence_length), int(param.cache_size), int(param.cache_id))
+                    for param in params
+                )
+            )
+            return [np.zeros((len(params), vocab_size), dtype=np.float32)]
+
+        worker.cache_model = SimpleNamespace(
+            infer=infer,
+            get_model_output_shape=lambda: [(2, vocab_size)],
+        )
+
+        outputs = worker._run_prompt_logprob_microsteps_batch(
+            [
+                (0, "req-a", req_states[0], 0, 2, 11),
+                (1, "req-b", req_states[1], 0, 2, 12),
+                (2, "req-c", req_states[2], 0, 2, 13),
+            ]
+        )
+
+        assert set(outputs) == {0, 1, 2}
+        assert calls == [
+            ((1, 0, 11), (1, 0, 12)),
+            ((1, 0, 13),),
+            ((1, 1, 11), (1, 1, 12)),
+            ((1, 1, 13),),
+        ]
+
+    def test_mixed_batch_keeps_normal_chunk_and_microsteps_prompt_logprobs(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.req_states = {}
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.print_debug = False
+        worker.cache_model = SimpleNamespace(get_model_output_shape=lambda: [(2, 16)])
+
+        normal_params = SamplingParams.from_optional(temperature=0.0)
+        prompt_params = SamplingParams.from_optional(temperature=0.0, prompt_logprobs=1)
+        normal_state = self._make_request_state(worker, normal_params, [1, 2, 3])
+        prompt_state = self._make_request_state(worker, prompt_params, [4, 5, 6])
+        for slot_id, req_state in enumerate((normal_state, prompt_state)):
+            req_state.prompt_len = 3
+            req_state.prompt_embeds = np.ones((3, 4), dtype=np.float32)
+            req_state.cache_slot_id = slot_id
+        worker.req_states = {"normal": normal_state, "prompt": prompt_state}
+
+        chunk_calls: list[tuple[int, int, int]] = []
+        micro_calls: list[tuple[tuple[int, int, int], ...]] = []
+
+        def load_snapshot(_req_id, req_state, **_kwargs):
+            return int(req_state.num_computed_tokens)
+
+        def infer_chunk(input_embeds_batch, cache_sizes, cache_ids):
+            chunk_calls.extend(
+                (int(input_embeds.shape[0]), int(cache_size), int(cache_id))
+                for input_embeds, cache_size, cache_id in zip(input_embeds_batch, cache_sizes, cache_ids)
+            )
+            return [InferenceLogits(last_token_logits=np.zeros(16, dtype=np.float32), full_sequence_logits=None)]
+
+        def infer_micro(input_embeds_batch, cache_sizes, cache_ids):
+            micro_calls.append(
+                tuple(
+                    (int(input_embeds.shape[0]), int(cache_size), int(cache_id))
+                    for input_embeds, cache_size, cache_id in zip(input_embeds_batch, cache_sizes, cache_ids)
+                )
+            )
+            return [np.zeros(16, dtype=np.float32) for _ in input_embeds_batch]
+
+        worker._load_snapshot_if_needed = load_snapshot
+        worker._infer_logits_batch_with_sequence = infer_chunk
+        worker._infer_logits_batch = infer_micro
+        worker._make_sampling_metadata = lambda _states: None
+        worker._sample_next_token = lambda _logits, _metadata: SimpleNamespace(
+            sampled_token_ids=torch.tensor([[7], [8]], dtype=torch.int64),
+            logprobs_tensors=None,
+        )
+
+        output = worker.execute_model(
+            SimpleNamespace(
+                finished_req_ids=[],
+                scheduled_new_reqs=[],
+                scheduled_cached_reqs=SimpleNamespace(
+                    req_ids=[],
+                    num_computed_tokens=[],
+                    num_output_tokens=[],
+                    new_block_ids=[],
+                    resumed_req_ids=set(),
+                ),
+                num_scheduled_tokens={"normal": 3, "prompt": 3},
+                kv_connector_metadata=None,
+            )
+        )
+
+        assert output is not None
+        assert chunk_calls == [(3, 0, 0)]
+        assert micro_calls == [((1, 0, 1),), ((1, 1, 1),), ((1, 2, 1),)]
+        assert normal_state.num_computed_tokens == 3
+        assert prompt_state.num_computed_tokens == 3
+        assert "prompt" in output.prompt_logprobs_dict
+        assert output.sampled_token_ids[output.req_id_to_index["normal"]].tolist() == [7]
+        assert output.sampled_token_ids[output.req_id_to_index["prompt"]].tolist() == [8]
+
+    def test_last_logit_prompt_logprob_microstep_warning_emitted_once(self, caplog) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 1
+        sampling_params = SamplingParams.from_optional(logprobs=1, prompt_logprobs=1)
+        req_state = self._make_request_state(worker, sampling_params, [1, 2])
+        req_state.prompt_len = 2
+        req_state.prompt_embeds = np.ones((2, 4), dtype=np.float32)
+
+        worker.cache_model = SimpleNamespace(
+            infer=lambda _inputs, *, params: [np.zeros((len(params), 8), dtype=np.float32)],
+            get_model_output_shape=lambda: [(1, 8)],
+        )
+
+        caplog.set_level("WARNING")
+        worker._run_prompt_logprob_microsteps_batch([(0, "req", req_state, 0, 1, 0)])
+        worker._run_prompt_logprob_microsteps_batch([(0, "req", req_state, 1, 2, 0)])
+
+        warning_records = [
+            record
+            for record in caplog.records
+            if "Prompt logprobs on last-logit MBLT/MXQ outputs use a slower 1-token microstep path"
+            in record.getMessage()
+        ]
+        assert len(warning_records) == 1
+
     def test_prompt_logprobs_unsupported_logits_shape_terminal_during_decode(self) -> None:
         worker = self._make_worker()
         prompt_token_ids = [101, 102, 103]
@@ -993,6 +1173,13 @@ class TestMbltWorkerOptimizations:
         assert MbltWorker._normalize_sequence_logits(last_token_logits, expected_seq_len=2) is None
         sequence_logits = MbltWorker._normalize_sequence_logits(last_token_logits, expected_seq_len=1)
         assert sequence_logits is last_token_logits
+
+    def test_batch_2d_output_shape_is_treated_as_last_token_even_when_seq_len_matches_batch(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.cache_model = SimpleNamespace(get_model_output_shape=lambda: [(2, 8)])
+
+        assert worker._runtime_output_logits_mode(input_seq_len=2) == "last_token"
 
     def test_sampling_penalties_can_be_forced_off_for_non_cuda_runtime(self) -> None:
         worker = self._make_worker()

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -1181,6 +1181,28 @@ class TestMbltWorkerOptimizations:
 
         assert worker._runtime_output_logits_mode(input_seq_len=2) == "last_token"
 
+    def test_batch_3d_output_shape_does_not_force_full_sequence_mode(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 16
+
+        worker.cache_model = SimpleNamespace(get_model_output_shape=lambda: [(1, 128, 8)])
+        assert worker._runtime_output_logits_mode(input_seq_len=128) == "unknown"
+
+        worker.cache_model = SimpleNamespace(get_model_output_shape=lambda: [(1, -1, 8)])
+        assert worker._runtime_output_logits_mode(input_seq_len=128) == "unknown"
+
+    def test_batch_3d_prompt_logprobs_use_microsteps(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 16
+        worker.cache_model = SimpleNamespace(get_model_output_shape=lambda: [(1, 128, 8)])
+        req_state = self._make_request_state(
+            worker,
+            SamplingParams.from_optional(prompt_logprobs=1),
+            list(range(512)),
+        )
+
+        assert worker._needs_last_logit_prompt_logprob_microsteps(req_state, sequence_length=128)
+
     def test_sampling_penalties_can_be_forced_off_for_non_cuda_runtime(self) -> None:
         worker = self._make_worker()
         worker.enable_sampling_penalties = False

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -7,6 +7,7 @@ from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from vllm.logprobs import Logprob
 from vllm.sampling_params import SamplingParams
 from vllm.v1.engine.logprobs import LogprobsProcessor, create_prompt_logprobs
+from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.sampler import Sampler
 
@@ -1121,6 +1122,67 @@ class TestMbltWorkerOptimizations:
         assert "prompt" in output.prompt_logprobs_dict
         assert output.sampled_token_ids[output.req_id_to_index["normal"]].tolist() == [7]
         assert output.sampled_token_ids[output.req_id_to_index["prompt"]].tolist() == [8]
+
+    def test_mixed_batch_logprobs_align_with_full_req_ids(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 3
+        worker.req_states = {}
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=3, block_size=128)
+        worker.print_debug = False
+        worker.cache_model = SimpleNamespace(get_model_output_shape=lambda: [(3, 16)])
+
+        sampling_params = SamplingParams.from_optional(temperature=0.0, logprobs=1)
+        prefill_state = self._make_request_state(worker, sampling_params, [1, 2, 3, 4, 5])
+        sample_a_state = self._make_request_state(worker, sampling_params, [6, 7, 8])
+        sample_b_state = self._make_request_state(worker, sampling_params, [9, 10, 11])
+        for slot_id, req_state in enumerate((prefill_state, sample_a_state, sample_b_state)):
+            req_state.prompt_embeds = np.ones((len(req_state.prompt_token_ids), 4), dtype=np.float32)
+            req_state.prompt_len = len(req_state.prompt_token_ids)
+            req_state.cache_slot_id = slot_id
+        worker.req_states = {
+            "prefill": prefill_state,
+            "sample-a": sample_a_state,
+            "sample-b": sample_b_state,
+        }
+
+        worker._load_snapshot_if_needed = lambda _req_id, req_state, **_kwargs: int(req_state.num_computed_tokens)
+        worker._infer_logits_batch_with_sequence = lambda input_embeds_batch, cache_sizes, cache_ids: [
+            InferenceLogits(last_token_logits=np.zeros(16, dtype=np.float32), full_sequence_logits=None)
+            for _ in input_embeds_batch
+        ]
+        worker._make_sampling_metadata = lambda _states: None
+        worker._sample_next_token = lambda _logits, _metadata: SimpleNamespace(
+            sampled_token_ids=torch.tensor([[12], [13]], dtype=torch.int64),
+            logprobs_tensors=LogprobsTensors(
+                logprob_token_ids=torch.tensor([[12, 1], [13, 2]], dtype=torch.int32),
+                logprobs=torch.tensor([[-0.1, -1.0], [-0.2, -2.0]], dtype=torch.float32),
+                selected_token_ranks=torch.tensor([1, 1], dtype=torch.int32),
+            ),
+        )
+
+        output = worker.execute_model(
+            SimpleNamespace(
+                finished_req_ids=[],
+                scheduled_new_reqs=[],
+                scheduled_cached_reqs=SimpleNamespace(
+                    req_ids=[],
+                    num_computed_tokens=[],
+                    num_output_tokens=[],
+                    new_block_ids=[],
+                    resumed_req_ids=set(),
+                ),
+                num_scheduled_tokens={"prefill": 3, "sample-a": 3, "sample-b": 3},
+                kv_connector_metadata=None,
+            )
+        )
+
+        assert output is not None
+        assert output.req_ids == ["prefill", "sample-a", "sample-b"]
+        assert output.logprobs is not None
+        assert output.logprobs.cu_num_generated_tokens == [0, 0, 1, 2]
+        assert output.logprobs.slice(0, 1).logprob_token_ids.shape[0] == 0
+        assert output.logprobs.slice(1, 2).logprob_token_ids.tolist() == [[12, 1]]
+        assert output.logprobs.slice(2, 3).logprob_token_ids.tolist() == [[13, 2]]
 
     def test_last_logit_prompt_logprob_microstep_warning_emitted_once(self, caplog) -> None:
         worker = self._make_worker()

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -136,7 +136,9 @@ class TestMbltWorkerOptimizations:
         worker = MbltWorker.__new__(MbltWorker)
         worker.model_config = SimpleNamespace(hf_config=SimpleNamespace(model_type="qwen2"))
         worker.vllm_config = SimpleNamespace(
-            cache_config=SimpleNamespace(block_size=128), model_config=worker.model_config
+            cache_config=SimpleNamespace(block_size=128),
+            model_config=worker.model_config,
+            scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         )
         worker.model = SimpleNamespace(config=SimpleNamespace(vocab_size=32000))
         worker.cache_model = None
@@ -150,6 +152,21 @@ class TestMbltWorkerOptimizations:
         worker._warned_last_logit_prompt_logprobs = False
         worker._vlm_image_positions_by_session = {}
         return worker
+
+    def _make_scheduler_output(self, num_scheduled_tokens: dict[str, int]) -> SimpleNamespace:
+        return SimpleNamespace(
+            finished_req_ids=[],
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=[],
+                num_computed_tokens=[],
+                num_output_tokens=[],
+                new_block_ids=[],
+                resumed_req_ids=set(),
+            ),
+            num_scheduled_tokens=num_scheduled_tokens,
+            kv_connector_metadata=None,
+        )
 
     def _make_request_state(
         self,
@@ -1050,9 +1067,115 @@ class TestMbltWorkerOptimizations:
             ((1, 1, 13),),
         ]
 
-    def test_mixed_batch_keeps_normal_chunk_and_microsteps_prompt_logprobs(self) -> None:
+    def test_normal_long_prefill_is_submitted_in_per_request_chunks(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 4
+        worker.vllm_config.scheduler_config.long_prefill_token_threshold = 128
+        worker.req_states = {}
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=4, block_size=128)
+        worker.print_debug = False
+        worker.cache_model = SimpleNamespace(get_model_output_shape=lambda: [(4, 16)])
+
+        sampling_params = SamplingParams.from_optional(temperature=0.0)
+        req_state = self._make_request_state(worker, sampling_params, list(range(300)))
+        req_state.prompt_len = 300
+        req_state.prompt_embeds = np.ones((300, 4), dtype=np.float32)
+        req_state.cache_slot_id = 0
+        worker.req_states = {"long": req_state}
+
+        calls: list[tuple[tuple[int, int, int], ...]] = []
+
+        def infer_chunk(input_embeds_batch, cache_sizes, cache_ids):
+            calls.append(
+                tuple(
+                    (int(input_embeds.shape[0]), int(cache_size), int(cache_id))
+                    for input_embeds, cache_size, cache_id in zip(input_embeds_batch, cache_sizes, cache_ids)
+                )
+            )
+            return [
+                InferenceLogits(
+                    last_token_logits=np.full(16, int(cache_size) + int(input_embeds.shape[0]), dtype=np.float32),
+                    full_sequence_logits=np.zeros((int(input_embeds.shape[0]), 16), dtype=np.float32),
+                )
+                for input_embeds, cache_size in zip(input_embeds_batch, cache_sizes)
+            ]
+
+        worker._load_snapshot_if_needed = lambda _req_id, req_state, **_kwargs: int(req_state.num_computed_tokens)
+        worker._infer_logits_batch_with_sequence = infer_chunk
+        worker._make_sampling_metadata = lambda _states: None
+        worker._sample_next_token = lambda _logits, _metadata: SimpleNamespace(
+            sampled_token_ids=torch.tensor([[9]], dtype=torch.int64),
+            logprobs_tensors=None,
+        )
+
+        output = worker.execute_model(self._make_scheduler_output({"long": 300}))
+
+        assert output is not None
+        assert calls == [((128, 0, 0),), ((128, 128, 0),), ((44, 256, 0),)]
+        assert max(sequence_length for call in calls for sequence_length, _cache_size, _cache_id in call) <= 128
+        assert req_state.num_computed_tokens == 300
+        assert output.sampled_token_ids[output.req_id_to_index["long"]].tolist() == [9]
+
+    def test_multiple_normal_long_prefills_are_grouped_per_chunk(self) -> None:
         worker = self._make_worker()
         worker.max_batch_size = 2
+        worker.vllm_config.scheduler_config.long_prefill_token_threshold = 128
+        worker.req_states = {}
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.print_debug = False
+        worker.cache_model = SimpleNamespace(get_model_output_shape=lambda: [(2, 16)])
+
+        sampling_params = SamplingParams.from_optional(temperature=0.0)
+        req_a_state = self._make_request_state(worker, sampling_params, list(range(260)))
+        req_b_state = self._make_request_state(worker, sampling_params, list(range(1000, 1260)))
+        for slot_id, req_state in enumerate((req_a_state, req_b_state)):
+            req_state.prompt_len = 260
+            req_state.prompt_embeds = np.ones((260, 4), dtype=np.float32)
+            req_state.cache_slot_id = slot_id
+        worker.req_states = {"req-a": req_a_state, "req-b": req_b_state}
+
+        calls: list[tuple[tuple[int, int, int], ...]] = []
+
+        def infer_chunk(input_embeds_batch, cache_sizes, cache_ids):
+            calls.append(
+                tuple(
+                    (int(input_embeds.shape[0]), int(cache_size), int(cache_id))
+                    for input_embeds, cache_size, cache_id in zip(input_embeds_batch, cache_sizes, cache_ids)
+                )
+            )
+            return [
+                InferenceLogits(
+                    last_token_logits=np.full(16, int(cache_id), dtype=np.float32),
+                    full_sequence_logits=None,
+                )
+                for cache_id in cache_ids
+            ]
+
+        worker._load_snapshot_if_needed = lambda _req_id, req_state, **_kwargs: int(req_state.num_computed_tokens)
+        worker._infer_logits_batch_with_sequence = infer_chunk
+        worker._make_sampling_metadata = lambda _states: None
+        worker._sample_next_token = lambda _logits, _metadata: SimpleNamespace(
+            sampled_token_ids=torch.tensor([[7], [8]], dtype=torch.int64),
+            logprobs_tensors=None,
+        )
+
+        output = worker.execute_model(self._make_scheduler_output({"req-a": 260, "req-b": 260}))
+
+        assert output is not None
+        assert calls == [
+            ((128, 0, 0), (128, 0, 1)),
+            ((128, 128, 0), (128, 128, 1)),
+            ((4, 256, 0), (4, 256, 1)),
+        ]
+        assert req_a_state.num_computed_tokens == 260
+        assert req_b_state.num_computed_tokens == 260
+        assert output.sampled_token_ids[output.req_id_to_index["req-a"]].tolist() == [7]
+        assert output.sampled_token_ids[output.req_id_to_index["req-b"]].tolist() == [8]
+
+    def test_mixed_batch_keeps_normal_chunks_and_microsteps_prompt_logprobs_in_order(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.vllm_config.scheduler_config.long_prefill_token_threshold = 128
         worker.req_states = {}
         worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
         worker.print_debug = False
@@ -1060,11 +1183,13 @@ class TestMbltWorkerOptimizations:
 
         normal_params = SamplingParams.from_optional(temperature=0.0)
         prompt_params = SamplingParams.from_optional(temperature=0.0, prompt_logprobs=1)
-        normal_state = self._make_request_state(worker, normal_params, [1, 2, 3])
+        normal_state = self._make_request_state(worker, normal_params, list(range(260)))
         prompt_state = self._make_request_state(worker, prompt_params, [4, 5, 6])
+        normal_state.prompt_len = 260
+        normal_state.prompt_embeds = np.ones((260, 4), dtype=np.float32)
+        prompt_state.prompt_len = 3
+        prompt_state.prompt_embeds = np.ones((3, 4), dtype=np.float32)
         for slot_id, req_state in enumerate((normal_state, prompt_state)):
-            req_state.prompt_len = 3
-            req_state.prompt_embeds = np.ones((3, 4), dtype=np.float32)
             req_state.cache_slot_id = slot_id
         worker.req_states = {"normal": normal_state, "prompt": prompt_state}
 
@@ -1079,7 +1204,10 @@ class TestMbltWorkerOptimizations:
                 (int(input_embeds.shape[0]), int(cache_size), int(cache_id))
                 for input_embeds, cache_size, cache_id in zip(input_embeds_batch, cache_sizes, cache_ids)
             )
-            return [InferenceLogits(last_token_logits=np.zeros(16, dtype=np.float32), full_sequence_logits=None)]
+            return [
+                InferenceLogits(last_token_logits=np.zeros(16, dtype=np.float32), full_sequence_logits=None)
+                for _input_embeds in input_embeds_batch
+            ]
 
         def infer_micro(input_embeds_batch, cache_sizes, cache_ids):
             micro_calls.append(
@@ -1110,17 +1238,18 @@ class TestMbltWorkerOptimizations:
                     new_block_ids=[],
                     resumed_req_ids=set(),
                 ),
-                num_scheduled_tokens={"normal": 3, "prompt": 3},
+                num_scheduled_tokens={"normal": 260, "prompt": 3},
                 kv_connector_metadata=None,
             )
         )
 
         assert output is not None
-        assert chunk_calls == [(3, 0, 0)]
+        assert chunk_calls == [(128, 0, 0), (128, 128, 0), (4, 256, 0)]
         assert micro_calls == [((1, 0, 1),), ((1, 1, 1),), ((1, 2, 1),)]
-        assert normal_state.num_computed_tokens == 3
+        assert normal_state.num_computed_tokens == 260
         assert prompt_state.num_computed_tokens == 3
         assert "prompt" in output.prompt_logprobs_dict
+        assert output.req_ids == ["normal", "prompt"]
         assert output.sampled_token_ids[output.req_id_to_index["normal"]].tolist() == [7]
         assert output.sampled_token_ids[output.req_id_to_index["prompt"]].tolist() == [8]
 

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 
 def register():

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -229,6 +229,28 @@ class MbltPlatform(Platform):
         scheduler_config: SchedulerConfig = vllm_config.scheduler_config
 
         scheduler_config.chunked_prefill_enabled = True
+        resolved_max_batch_size = resolve_model_max_batch_size(vllm_config)
+        effective_max_num_seqs = None
+        if resolved_max_batch_size is not None:
+            configured_max_num_seqs = _coerce_positive_int(getattr(scheduler_config, "max_num_seqs", None))
+            if configured_max_num_seqs is None:
+                effective_max_num_seqs = resolved_max_batch_size
+            elif configured_max_num_seqs > resolved_max_batch_size:
+                logger.warning(
+                    "Clamping scheduler max_num_seqs from %d to model-configured max batch size %d.",
+                    configured_max_num_seqs,
+                    resolved_max_batch_size,
+                )
+                effective_max_num_seqs = resolved_max_batch_size
+            else:
+                effective_max_num_seqs = configured_max_num_seqs
+            scheduler_config.max_num_seqs = effective_max_num_seqs
+            logger.info(
+                "Using model-configured max batch size %d for scheduler max_num_seqs=%d.",
+                resolved_max_batch_size,
+                scheduler_config.max_num_seqs,
+            )
+
         model_chunk_size = resolve_npu_prefill_chunk_size(vllm_config)
         if model_chunk_size is None:
             resolved_chunk_size = 128
@@ -240,28 +262,22 @@ class MbltPlatform(Platform):
                 _resolve_core_mode(vllm_config),
             )
 
-        scheduler_config.max_num_batched_tokens = min(
-            scheduler_config.max_num_batched_tokens,
-            resolved_chunk_size,
-        )
-
-        resolved_max_batch_size = resolve_model_max_batch_size(vllm_config)
-        if resolved_max_batch_size is not None:
-            configured_max_num_seqs = _coerce_positive_int(getattr(scheduler_config, "max_num_seqs", None))
-            if configured_max_num_seqs is None:
-                scheduler_config.max_num_seqs = resolved_max_batch_size
-            elif configured_max_num_seqs > resolved_max_batch_size:
-                logger.warning(
-                    "Clamping scheduler max_num_seqs from %d to model-configured max batch size %d.",
-                    configured_max_num_seqs,
-                    resolved_max_batch_size,
-                )
-                scheduler_config.max_num_seqs = resolved_max_batch_size
-            else:
-                scheduler_config.max_num_seqs = configured_max_num_seqs
+        if effective_max_num_seqs is not None and effective_max_num_seqs > 1:
+            scheduler_config.max_num_batched_tokens = resolved_chunk_size * effective_max_num_seqs
+            for attr_name in ("max_num_partial_prefills", "max_long_partial_prefills"):
+                current_value = _coerce_positive_int(getattr(scheduler_config, attr_name, None))
+                if current_value is None or current_value < effective_max_num_seqs:
+                    setattr(scheduler_config, attr_name, effective_max_num_seqs)
             logger.info(
-                "Using model-configured max batch size %d for scheduler max_num_seqs=%d.",
-                resolved_max_batch_size,
-                scheduler_config.max_num_seqs,
+                "Using per-sequence chunk size %d across %d scheduler sequences "
+                "(max_num_batched_tokens=%d).",
+                resolved_chunk_size,
+                effective_max_num_seqs,
+                scheduler_config.max_num_batched_tokens,
+            )
+        else:
+            scheduler_config.max_num_batched_tokens = min(
+                scheduler_config.max_num_batched_tokens,
+                resolved_chunk_size,
             )
         return

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -229,6 +229,16 @@ class MbltPlatform(Platform):
         scheduler_config: SchedulerConfig = vllm_config.scheduler_config
 
         scheduler_config.chunked_prefill_enabled = True
+        logger.info(
+            "Initial scheduler prefill config: max_num_batched_tokens=%r, max_num_seqs=%r, "
+            "max_num_partial_prefills=%r, max_long_partial_prefills=%r, "
+            "long_prefill_token_threshold=%r.",
+            getattr(scheduler_config, "max_num_batched_tokens", None),
+            getattr(scheduler_config, "max_num_seqs", None),
+            getattr(scheduler_config, "max_num_partial_prefills", None),
+            getattr(scheduler_config, "max_long_partial_prefills", None),
+            getattr(scheduler_config, "long_prefill_token_threshold", None),
+        )
         resolved_max_batch_size = resolve_model_max_batch_size(vllm_config)
         effective_max_num_seqs = None
         if resolved_max_batch_size is not None:
@@ -280,4 +290,15 @@ class MbltPlatform(Platform):
                 scheduler_config.max_num_batched_tokens,
                 resolved_chunk_size,
             )
+        logger.info(
+            "Final scheduler prefill config: chunked_prefill_enabled=%r, "
+            "max_num_batched_tokens=%r, max_num_seqs=%r, max_num_partial_prefills=%r, "
+            "max_long_partial_prefills=%r, long_prefill_token_threshold=%r.",
+            getattr(scheduler_config, "chunked_prefill_enabled", None),
+            getattr(scheduler_config, "max_num_batched_tokens", None),
+            getattr(scheduler_config, "max_num_seqs", None),
+            getattr(scheduler_config, "max_num_partial_prefills", None),
+            getattr(scheduler_config, "max_long_partial_prefills", None),
+            getattr(scheduler_config, "long_prefill_token_threshold", None),
+        )
         return

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -16,6 +17,11 @@ _MULTIMODAL_HF_MODEL_TYPES = frozenset(
         "mobilint-qwen3_vl",
     }
 )
+_TRUE_ENV_VALUES = {"1", "true", "TRUE", "True"}
+
+
+def _mblt_debug_enabled() -> bool:
+    return os.getenv("VLLM_MBLT_DEBUG", "0") in _TRUE_ENV_VALUES
 
 
 def _coerce_positive_int(value: object) -> int | None:
@@ -229,16 +235,18 @@ class MbltPlatform(Platform):
         scheduler_config: SchedulerConfig = vllm_config.scheduler_config
 
         scheduler_config.chunked_prefill_enabled = True
-        logger.info(
-            "Initial scheduler prefill config: max_num_batched_tokens=%r, max_num_seqs=%r, "
-            "max_num_partial_prefills=%r, max_long_partial_prefills=%r, "
-            "long_prefill_token_threshold=%r.",
-            getattr(scheduler_config, "max_num_batched_tokens", None),
-            getattr(scheduler_config, "max_num_seqs", None),
-            getattr(scheduler_config, "max_num_partial_prefills", None),
-            getattr(scheduler_config, "max_long_partial_prefills", None),
-            getattr(scheduler_config, "long_prefill_token_threshold", None),
-        )
+        print_debug = _mblt_debug_enabled()
+        if print_debug:
+            logger.info(
+                "Initial scheduler prefill config: max_num_batched_tokens=%r, max_num_seqs=%r, "
+                "max_num_partial_prefills=%r, max_long_partial_prefills=%r, "
+                "long_prefill_token_threshold=%r.",
+                getattr(scheduler_config, "max_num_batched_tokens", None),
+                getattr(scheduler_config, "max_num_seqs", None),
+                getattr(scheduler_config, "max_num_partial_prefills", None),
+                getattr(scheduler_config, "max_long_partial_prefills", None),
+                getattr(scheduler_config, "long_prefill_token_threshold", None),
+            )
         resolved_max_batch_size = resolve_model_max_batch_size(vllm_config)
         effective_max_num_seqs = None
         if resolved_max_batch_size is not None:
@@ -279,27 +287,29 @@ class MbltPlatform(Platform):
                 current_value = _coerce_positive_int(getattr(scheduler_config, attr_name, None))
                 if current_value is None or current_value < effective_max_num_seqs:
                     setattr(scheduler_config, attr_name, effective_max_num_seqs)
-            logger.info(
-                "Using per-sequence chunk size %d across %d scheduler sequences "
-                "(max_num_batched_tokens=%d).",
-                resolved_chunk_size,
-                effective_max_num_seqs,
-                scheduler_config.max_num_batched_tokens,
-            )
+            if print_debug:
+                logger.info(
+                    "Using per-sequence chunk size %d across %d scheduler sequences "
+                    "(max_num_batched_tokens=%d).",
+                    resolved_chunk_size,
+                    effective_max_num_seqs,
+                    scheduler_config.max_num_batched_tokens,
+                )
         else:
             scheduler_config.max_num_batched_tokens = min(
                 scheduler_config.max_num_batched_tokens,
                 resolved_chunk_size,
             )
-        logger.info(
-            "Final scheduler prefill config: chunked_prefill_enabled=%r, "
-            "max_num_batched_tokens=%r, max_num_seqs=%r, max_num_partial_prefills=%r, "
-            "max_long_partial_prefills=%r, long_prefill_token_threshold=%r.",
-            getattr(scheduler_config, "chunked_prefill_enabled", None),
-            getattr(scheduler_config, "max_num_batched_tokens", None),
-            getattr(scheduler_config, "max_num_seqs", None),
-            getattr(scheduler_config, "max_num_partial_prefills", None),
-            getattr(scheduler_config, "max_long_partial_prefills", None),
-            getattr(scheduler_config, "long_prefill_token_threshold", None),
-        )
+        if print_debug:
+            logger.info(
+                "Final scheduler prefill config: chunked_prefill_enabled=%r, "
+                "max_num_batched_tokens=%r, max_num_seqs=%r, max_num_partial_prefills=%r, "
+                "max_long_partial_prefills=%r, long_prefill_token_threshold=%r.",
+                getattr(scheduler_config, "chunked_prefill_enabled", None),
+                getattr(scheduler_config, "max_num_batched_tokens", None),
+                getattr(scheduler_config, "max_num_seqs", None),
+                getattr(scheduler_config, "max_num_partial_prefills", None),
+                getattr(scheduler_config, "max_long_partial_prefills", None),
+                getattr(scheduler_config, "long_prefill_token_threshold", None),
+            )
         return

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -274,6 +274,7 @@ class MbltPlatform(Platform):
 
         if effective_max_num_seqs is not None and effective_max_num_seqs > 1:
             scheduler_config.max_num_batched_tokens = resolved_chunk_size * effective_max_num_seqs
+            scheduler_config.long_prefill_token_threshold = resolved_chunk_size
             for attr_name in ("max_num_partial_prefills", "max_long_partial_prefills"):
                 current_value = _coerce_positive_int(getattr(scheduler_config, attr_name, None))
                 if current_value is None or current_value < effective_max_num_seqs:

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -898,6 +898,8 @@ class MbltWorker(WorkerBase):
 
         output_shape = tuple(output_shapes[0])
         if len(output_shape) == 3:
+            if self._is_batch_model():
+                return "unknown"
             if self._shape_dim_matches_sequence(int(output_shape[1]), input_seq_len):
                 return "full_sequence"
             if input_seq_len > 1 and int(output_shape[1]) == 1:

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -2349,16 +2349,22 @@ class MbltWorker(WorkerBase):
             sampling_metadata = self._make_sampling_metadata(req_states_for_sampling)
             sampler_output = self._sample_next_token(logits, sampling_metadata)
             sampled_token_ids_int: list[list[int]] = sampler_output.sampled_token_ids.tolist()
+            generated_lengths_by_req_id: dict[str, int] = {}
             for i, req_id in enumerate(sampling_req_ids):
                 self.req_states[req_id].output_token_ids.extend(sampled_token_ids_int[i])
+                generated_lengths_by_req_id[req_id] = len(sampled_token_ids_int[i])
                 sampled_token_ids[req_id_to_index[req_id]] = np.asarray(
                     sampled_token_ids_int[i],
                     dtype=np.int64,
                 )
 
-            logprobs = (
-                sampler_output.logprobs_tensors.tolists() if sampler_output.logprobs_tensors is not None else None
-            )
+            if sampler_output.logprobs_tensors is not None:
+                cu_num_generated_tokens = [0]
+                for req_id in req_ids:
+                    cu_num_generated_tokens.append(
+                        cu_num_generated_tokens[-1] + generated_lengths_by_req_id.get(req_id, 0)
+                    )
+                logprobs = sampler_output.logprobs_tensors.tolists(cu_num_generated_tokens)
 
         if print_debug:
             print(req_ids, req_id_to_index, sampled_token_ids)

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -151,6 +151,20 @@ class PromptLogprobFallbackReplayState:
     rows: list[np.ndarray]
 
 
+@dataclass
+class PromptLogprobMicrostepState:
+    output_index: int
+    req_id: str
+    req_state: RequestState
+    start_idx: int
+    scheduled_end: int
+    cache_id: int
+    cache_size: int
+    prompt_logits_end: int
+    rows: list[np.ndarray]
+    last_token_logits: Optional[np.ndarray] = None
+
+
 class MbltWorker(WorkerBase):
     MAX_FINISHED_CACHE_SNAPSHOTS = 16
 
@@ -171,6 +185,7 @@ class MbltWorker(WorkerBase):
 
         self.req_states: Dict[str, RequestState] = {}
         self._warned_batch_cache_snapshot_unsupported = False
+        self._warned_last_logit_prompt_logprobs = False
         self._vlm_image_positions_by_session: dict[str, tuple[int, int, Optional[tuple[bool, ...]]]] = {}
 
         self.max_batch_size = resolve_model_max_batch_size(self.vllm_config) or 1
@@ -864,6 +879,60 @@ class MbltWorker(WorkerBase):
         return None
 
     @staticmethod
+    def _shape_dim_matches_sequence(dim: int, input_seq_len: int) -> bool:
+        return dim == -1 or dim == input_seq_len
+
+    def _runtime_output_logits_mode(self, input_seq_len: int) -> str:
+        """Best-effort classify MXQ logits as full-sequence, last-token, or unknown."""
+
+        cache_model = self._get_cache_model()
+        get_output_shape = getattr(cache_model, "get_model_output_shape", None)
+        if not callable(get_output_shape):
+            return "unknown"
+        try:
+            output_shapes = get_output_shape()
+        except Exception:
+            return "unknown"
+        if not output_shapes:
+            return "unknown"
+
+        output_shape = tuple(output_shapes[0])
+        if len(output_shape) == 3:
+            if self._shape_dim_matches_sequence(int(output_shape[1]), input_seq_len):
+                return "full_sequence"
+            if input_seq_len > 1 and int(output_shape[1]) == 1:
+                return "last_token"
+            return "unknown"
+        if len(output_shape) == 2:
+            if self._is_batch_model():
+                return "last_token"
+            if self._shape_dim_matches_sequence(int(output_shape[0]), input_seq_len):
+                return "full_sequence"
+            return "last_token"
+        return "unknown"
+
+    def _needs_last_logit_prompt_logprob_microsteps(
+        self,
+        req_state: RequestState,
+        sequence_length: int,
+    ) -> bool:
+        if self._num_prompt_logprobs(req_state.sampling_params) is None:
+            return False
+        if sequence_length <= 0:
+            return False
+        mode = self._runtime_output_logits_mode(sequence_length)
+        return mode != "full_sequence"
+
+    def _warn_last_logit_prompt_logprobs_once(self) -> None:
+        if getattr(self, "_warned_last_logit_prompt_logprobs", False):
+            return
+        logger.warning(
+            "Prompt logprobs on last-logit MBLT/MXQ outputs use a slower 1-token microstep path. "
+            "Compile or use a full-logits MXQ for faster prompt logprob serving."
+        )
+        self._warned_last_logit_prompt_logprobs = True
+
+    @staticmethod
     def _can_reuse_output_buffers(
         cache_model: Any,
         output_buffers: list[np.ndarray],
@@ -1339,6 +1408,81 @@ class MbltWorker(WorkerBase):
             for state in states
             if state.rows
         }
+
+    def _run_prompt_logprob_microsteps_batch(
+        self,
+        requests: list[tuple[int, str, RequestState, int, int, int]],
+    ) -> dict[int, InferenceLogits]:
+        """Run scheduled prompt-logprob requests as 1-token batched steps.
+
+        Last-token-only MXQs cannot produce the per-position prompt logits from
+        a multi-token prefill.  This path advances the live request cache one
+        token at a time, preserving the final sampling logits while collecting
+        prompt-position logits from the same scheduled range.
+        """
+
+        states = [
+            PromptLogprobMicrostepState(
+                output_index=output_index,
+                req_id=req_id,
+                req_state=req_state,
+                start_idx=start_idx,
+                scheduled_end=scheduled_end,
+                cache_id=cache_id,
+                cache_size=start_idx,
+                prompt_logits_end=min(scheduled_end + 1, req_state.prompt_len),
+                rows=[],
+            )
+            for output_index, req_id, req_state, start_idx, scheduled_end, cache_id in requests
+            if scheduled_end > start_idx
+        ]
+        if not states:
+            return {}
+
+        self._warn_last_logit_prompt_logprobs_once()
+
+        while True:
+            active_states = [state for state in states if state.cache_size < state.scheduled_end]
+            if not active_states:
+                break
+
+            for batch_start in range(0, len(active_states), self.max_batch_size):
+                batch_states = active_states[batch_start : batch_start + self.max_batch_size]
+                input_embeds_batch = [
+                    self._build_input_embeds(state.req_state, state.cache_size, state.cache_size + 1)
+                    for state in batch_states
+                ]
+                cache_sizes = [state.cache_size for state in batch_states]
+                cache_ids = [state.cache_id for state in batch_states]
+
+                logits_batch = self._infer_logits_batch(
+                    input_embeds_batch=input_embeds_batch,
+                    cache_sizes=cache_sizes,
+                    cache_ids=cache_ids,
+                )
+
+                for state, logits in zip(batch_states, logits_batch):
+                    logits_row = np.asarray(self._last_token_logits(logits)).reshape(-1)
+                    prompt_pos = state.cache_size + 1
+                    if prompt_pos < state.prompt_logits_end:
+                        state.rows.append(logits_row)
+                    state.last_token_logits = logits_row
+                    state.cache_size += 1
+
+        outputs: dict[int, InferenceLogits] = {}
+        for state in states:
+            if state.last_token_logits is None:
+                continue
+            full_sequence_logits = (
+                np.stack(state.rows, axis=0)
+                if state.rows
+                else np.empty((0, int(state.last_token_logits.shape[0])), dtype=state.last_token_logits.dtype)
+            )
+            outputs[state.output_index] = InferenceLogits(
+                last_token_logits=state.last_token_logits,
+                full_sequence_logits=full_sequence_logits,
+            )
+        return outputs
 
     def _get_prompt_logprobs_tensors_with_fallback(
         self,
@@ -1969,6 +2113,8 @@ class MbltWorker(WorkerBase):
             input_embeds_batch: list[np.ndarray] = []
             cache_sizes: list[int] = []
             cache_ids: list[int] = []
+            microstep_indices: list[int] = []
+            normal_indices: list[int] = []
 
             for req_id, num_scheduled_token in scheduler_output.num_scheduled_tokens.items():
                 req_state = self.req_states[req_id]
@@ -2000,46 +2146,45 @@ class MbltWorker(WorkerBase):
                 cache_sizes.append(cache_size)
                 cache_ids.append(slot_id)
 
-            batched_logits = self._infer_logits_batch_with_sequence(
-                input_embeds_batch=input_embeds_batch,
-                cache_sizes=cache_sizes,
-                cache_ids=cache_ids,
-            )
+                if self._needs_last_logit_prompt_logprob_microsteps(req_state, sequence_length):
+                    microstep_indices.append(len(req_ids) - 1)
+                else:
+                    normal_indices.append(len(req_ids) - 1)
 
-            fallback_sequence_logits = self._compute_prompt_logprobs_sequence_logits_fallback_batch(
-                [
-                    (
-                        i,
-                        self.req_states[req_id],
-                        cache_sizes[i],
-                        scheduled_end_positions[i],
-                        cache_ids[i],
-                    )
-                    for i, req_id in enumerate(req_ids)
-                    if batched_logits[i].full_sequence_logits is None
-                ]
-            )
-            restore_indices: list[int] = []
-            restore_start_positions: dict[int, int] = {}
+            batched_logits: list[Optional[InferenceLogits]] = [None for _ in req_ids]
+
+            if normal_indices:
+                normal_logits = self._infer_logits_batch_with_sequence(
+                    input_embeds_batch=[input_embeds_batch[i] for i in normal_indices],
+                    cache_sizes=[cache_sizes[i] for i in normal_indices],
+                    cache_ids=[cache_ids[i] for i in normal_indices],
+                )
+                for i, inference_logits in zip(normal_indices, normal_logits):
+                    batched_logits[i] = inference_logits
+
+            if microstep_indices:
+                microstep_logits = self._run_prompt_logprob_microsteps_batch(
+                    [
+                        (
+                            i,
+                            req_ids[i],
+                            self.req_states[req_ids[i]],
+                            cache_sizes[i],
+                            scheduled_end_positions[i],
+                            cache_ids[i],
+                        )
+                        for i in microstep_indices
+                    ]
+                )
+                for i, inference_logits in microstep_logits.items():
+                    batched_logits[i] = inference_logits
 
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
-                sequence_logits = batched_logits[i].full_sequence_logits
-                if sequence_logits is None:
-                    sequence_logits = fallback_sequence_logits.get(i)
-                    if sequence_logits is not None:
-                        prompt_end = min(scheduled_end_positions[i] + 1, req_state.prompt_len)
-                        restore_start = max(0, prompt_end - 1)
-                        if restore_start >= scheduled_end_positions[i]:
-                            batched_logits[i] = InferenceLogits(
-                                last_token_logits=np.asarray(sequence_logits)[-1, :],
-                                full_sequence_logits=sequence_logits,
-                            )
-                            sequence_lengths[i] = max(1, restore_start)
-                            next_cache_sizes[i] = restore_start
-                        else:
-                            restore_indices.append(i)
-                            restore_start_positions[i] = restore_start
+                inference_logits = batched_logits[i]
+                if inference_logits is None:
+                    raise RuntimeError(f"Missing batched logits for req_id={req_id}.")
+                sequence_logits = inference_logits.full_sequence_logits
                 self._get_completed_prompt_logprobs_tensors_for_scheduler(
                     req_state=req_state,
                     sequence_logits=sequence_logits,
@@ -2048,30 +2193,6 @@ class MbltWorker(WorkerBase):
                     cache_id=cache_ids[i],
                     can_emit_output=False,
                 )
-
-            for restore_start in range(0, len(restore_indices), self.max_batch_size):
-                restore_batch = restore_indices[restore_start : restore_start + self.max_batch_size]
-                restore_input_embeds_batch = [
-                    self._build_input_embeds(
-                        self.req_states[req_ids[i]],
-                        restore_start_positions[i],
-                        scheduled_end_positions[i],
-                    )
-                    for i in restore_batch
-                ]
-                restored_logits = self._infer_logits_batch_with_sequence(
-                    input_embeds_batch=restore_input_embeds_batch,
-                    cache_sizes=[restore_start_positions[i] for i in restore_batch],
-                    cache_ids=[cache_ids[i] for i in restore_batch],
-                )
-                for i, input_embeds, inference_logits in zip(
-                    restore_batch,
-                    restore_input_embeds_batch,
-                    restored_logits,
-                ):
-                    batched_logits[i] = inference_logits
-                    sequence_lengths[i] = int(input_embeds.shape[0])
-                    next_cache_sizes[i] = restore_start_positions[i] + sequence_lengths[i]
 
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
@@ -2088,7 +2209,10 @@ class MbltWorker(WorkerBase):
                     )
                     if prompt_logprobs_tensors is not None:
                         prompt_logprobs_dict[req_id] = prompt_logprobs_tensors
-                    logits_batch.append(torch.from_numpy(batched_logits[i].last_token_logits).reshape(1, -1))
+                    inference_logits = batched_logits[i]
+                    if inference_logits is None:
+                        raise RuntimeError(f"Missing sampling logits for req_id={req_id}.")
+                    logits_batch.append(torch.from_numpy(inference_logits.last_token_logits).reshape(1, -1))
                     req_states_for_sampling.append(req_state)
                     sampling_req_ids.append(req_id)
         else:

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1441,17 +1441,18 @@ class MbltWorker(WorkerBase):
         if not states:
             return {}
 
-        logger.info(
-            "[mblt-batch-debug] prompt-logprob microsteps: state_count=%d "
-            "max_batch_size=%d ranges=%s cache_sizes=%s",
-            len(states),
-            self.max_batch_size,
-            [
-                (state.req_id, state.start_idx, state.scheduled_end, state.prompt_logits_end)
-                for state in states
-            ],
-            [state.cache_size for state in states],
-        )
+        if self.print_debug:
+            logger.info(
+                "[mblt-batch-debug] prompt-logprob microsteps: state_count=%d "
+                "max_batch_size=%d ranges=%s cache_sizes=%s",
+                len(states),
+                self.max_batch_size,
+                [
+                    (state.req_id, state.start_idx, state.scheduled_end, state.prompt_logits_end)
+                    for state in states
+                ],
+                [state.cache_size for state in states],
+            )
         self._warn_last_logit_prompt_logprobs_once()
 
         while True:
@@ -2117,18 +2118,19 @@ class MbltWorker(WorkerBase):
         prompt_logprobs_dict = {}
 
         if self._is_batch_model():
-            logger.info(
-                "[mblt-batch-debug] scheduler_output: batch_size=%d max_batch_size=%d "
-                "max_num_batched_tokens=%s scheduled_tokens=%s cached_req_ids=%s "
-                "new_req_count=%d finished_req_count=%d",
-                batch_size,
-                self.max_batch_size,
-                getattr(self, "max_num_batched_tokens", None),
-                dict(scheduler_output.num_scheduled_tokens),
-                list(getattr(scheduler_output.scheduled_cached_reqs, "req_ids", []) or []),
-                len(getattr(scheduler_output, "scheduled_new_reqs", []) or []),
-                len(getattr(scheduler_output, "finished_req_ids", []) or []),
-            )
+            if print_debug:
+                logger.info(
+                    "[mblt-batch-debug] scheduler_output: batch_size=%d max_batch_size=%d "
+                    "max_num_batched_tokens=%s scheduled_tokens=%s cached_req_ids=%s "
+                    "new_req_count=%d finished_req_count=%d",
+                    batch_size,
+                    self.max_batch_size,
+                    getattr(self, "max_num_batched_tokens", None),
+                    dict(scheduler_output.num_scheduled_tokens),
+                    list(getattr(scheduler_output.scheduled_cached_reqs, "req_ids", []) or []),
+                    len(getattr(scheduler_output, "scheduled_new_reqs", []) or []),
+                    len(getattr(scheduler_output, "finished_req_ids", []) or []),
+                )
             if batch_size > self.max_batch_size:
                 raise RuntimeError(
                     "Scheduled batch exceeds compiled batch capacity: "
@@ -2176,19 +2178,20 @@ class MbltWorker(WorkerBase):
                 else:
                     normal_indices.append(len(req_ids) - 1)
 
-            logger.info(
-                "[mblt-batch-debug] prepared batch: req_count=%d normal_count=%d "
-                "microstep_count=%d sequence_lengths=%s cache_sizes=%s "
-                "scheduled_end_positions=%s prompt_lens=%s next_prompt_logprob_pos=%s",
-                len(req_ids),
-                len(normal_indices),
-                len(microstep_indices),
-                sequence_lengths,
-                cache_sizes,
-                scheduled_end_positions,
-                [self.req_states[req_id].prompt_len for req_id in req_ids],
-                [self.req_states[req_id].next_prompt_logprob_pos for req_id in req_ids],
-            )
+            if print_debug:
+                logger.info(
+                    "[mblt-batch-debug] prepared batch: req_count=%d normal_count=%d "
+                    "microstep_count=%d sequence_lengths=%s cache_sizes=%s "
+                    "scheduled_end_positions=%s prompt_lens=%s next_prompt_logprob_pos=%s",
+                    len(req_ids),
+                    len(normal_indices),
+                    len(microstep_indices),
+                    sequence_lengths,
+                    cache_sizes,
+                    scheduled_end_positions,
+                    [self.req_states[req_id].prompt_len for req_id in req_ids],
+                    [self.req_states[req_id].next_prompt_logprob_pos for req_id in req_ids],
+                )
             batched_logits: list[Optional[InferenceLogits]] = [None for _ in req_ids]
 
             if normal_indices:

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -165,6 +165,17 @@ class PromptLogprobMicrostepState:
     last_token_logits: Optional[np.ndarray] = None
 
 
+@dataclass
+class NormalBatchChunkState:
+    output_index: int
+    input_embeds: np.ndarray
+    cache_id: int
+    cache_size: int
+    offset: int = 0
+    full_sequence_logits: Optional[list[np.ndarray]] = None
+    last_token_logits: Optional[np.ndarray] = None
+
+
 class MbltWorker(WorkerBase):
     MAX_FINISHED_CACHE_SNAPSHOTS = 16
 
@@ -410,6 +421,17 @@ class MbltWorker(WorkerBase):
                 cache_ids,
             )
         ]
+
+    def _normal_batch_chunk_token_cap(self) -> Optional[int]:
+        scheduler_config = getattr(self.vllm_config, "scheduler_config", None)
+        cap = getattr(scheduler_config, "long_prefill_token_threshold", None)
+        if cap is None:
+            return None
+        try:
+            cap = int(cap)
+        except (TypeError, ValueError):
+            return None
+        return cap if cap > 0 else None
 
     def _to_cpu_float32_numpy(self, tensor: torch.Tensor) -> np.ndarray:
         tensor = tensor.detach()
@@ -1134,6 +1156,97 @@ class MbltWorker(WorkerBase):
             )
         logits_np = logits_np.reshape(batch_size, -1)
         return [InferenceLogits(last_token_logits=logits_np[i], full_sequence_logits=None) for i in range(batch_size)]
+
+    def _infer_normal_logits_batch_chunked(
+        self,
+        output_indices: list[int],
+        input_embeds_batch: list[np.ndarray],
+        cache_sizes: list[int],
+        cache_ids: list[int],
+    ) -> dict[int, InferenceLogits]:
+        if not output_indices:
+            return {}
+        if not (
+            len(output_indices) == len(input_embeds_batch) == len(cache_sizes) == len(cache_ids)
+        ):
+            raise RuntimeError(
+                "Normal batch chunk inputs must have identical lengths: "
+                f"indices={len(output_indices)}, input_embeds={len(input_embeds_batch)}, "
+                f"cache_sizes={len(cache_sizes)}, cache_ids={len(cache_ids)}"
+            )
+
+        token_cap = self._normal_batch_chunk_token_cap()
+        states = [
+            NormalBatchChunkState(
+                output_index=output_index,
+                input_embeds=input_embeds,
+                cache_size=cache_size,
+                cache_id=cache_id,
+                full_sequence_logits=[],
+            )
+            for output_index, input_embeds, cache_size, cache_id in zip(
+                output_indices,
+                input_embeds_batch,
+                cache_sizes,
+                cache_ids,
+            )
+        ]
+
+        while True:
+            active_states = [state for state in states if state.offset < int(state.input_embeds.shape[0])]
+            if not active_states:
+                break
+
+            for batch_start in range(0, len(active_states), self.max_batch_size):
+                batch_states = active_states[batch_start : batch_start + self.max_batch_size]
+                chunk_embeds_batch: list[np.ndarray] = []
+                chunk_cache_sizes: list[int] = []
+                chunk_cache_ids: list[int] = []
+                for state in batch_states:
+                    remaining = int(state.input_embeds.shape[0]) - state.offset
+                    chunk_len = remaining if token_cap is None else min(remaining, token_cap)
+                    if chunk_len <= 0:
+                        continue
+                    chunk_start = state.offset
+                    chunk_end = chunk_start + chunk_len
+                    chunk_embeds_batch.append(state.input_embeds[chunk_start:chunk_end])
+                    chunk_cache_sizes.append(state.cache_size)
+                    chunk_cache_ids.append(state.cache_id)
+
+                if not chunk_embeds_batch:
+                    continue
+
+                logits_batch = self._infer_logits_batch_with_sequence(
+                    input_embeds_batch=chunk_embeds_batch,
+                    cache_sizes=chunk_cache_sizes,
+                    cache_ids=chunk_cache_ids,
+                )
+                for state, chunk_embeds, inference_logits in zip(batch_states, chunk_embeds_batch, logits_batch):
+                    chunk_len = int(chunk_embeds.shape[0])
+                    state.offset += chunk_len
+                    state.cache_size += chunk_len
+                    state.last_token_logits = inference_logits.last_token_logits
+                    if inference_logits.full_sequence_logits is None:
+                        state.full_sequence_logits = None
+                    elif state.full_sequence_logits is not None:
+                        state.full_sequence_logits.append(inference_logits.full_sequence_logits)
+
+        outputs: dict[int, InferenceLogits] = {}
+        for state in states:
+            if state.last_token_logits is None:
+                raise RuntimeError(f"Missing normal batched logits for output_index={state.output_index}.")
+            full_sequence_logits = None
+            if state.full_sequence_logits is not None:
+                full_sequence_logits = (
+                    np.concatenate(state.full_sequence_logits, axis=0)
+                    if state.full_sequence_logits
+                    else np.empty((0, int(state.last_token_logits.shape[0])), dtype=state.last_token_logits.dtype)
+                )
+            outputs[state.output_index] = InferenceLogits(
+                last_token_logits=state.last_token_logits,
+                full_sequence_logits=full_sequence_logits,
+            )
+        return outputs
 
     def _num_prompt_logprobs(self, sampling_params: SamplingParams) -> Optional[int]:
         num_prompt_logprobs = sampling_params.prompt_logprobs
@@ -2195,12 +2308,13 @@ class MbltWorker(WorkerBase):
             batched_logits: list[Optional[InferenceLogits]] = [None for _ in req_ids]
 
             if normal_indices:
-                normal_logits = self._infer_logits_batch_with_sequence(
+                normal_logits = self._infer_normal_logits_batch_chunked(
+                    output_indices=normal_indices,
                     input_embeds_batch=[input_embeds_batch[i] for i in normal_indices],
                     cache_sizes=[cache_sizes[i] for i in normal_indices],
                     cache_ids=[cache_ids[i] for i in normal_indices],
                 )
-                for i, inference_logits in zip(normal_indices, normal_logits):
+                for i, inference_logits in normal_logits.items():
                     batched_logits[i] = inference_logits
 
             if microstep_indices:

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1441,6 +1441,17 @@ class MbltWorker(WorkerBase):
         if not states:
             return {}
 
+        logger.info(
+            "[mblt-batch-debug] prompt-logprob microsteps: state_count=%d "
+            "max_batch_size=%d ranges=%s cache_sizes=%s",
+            len(states),
+            self.max_batch_size,
+            [
+                (state.req_id, state.start_idx, state.scheduled_end, state.prompt_logits_end)
+                for state in states
+            ],
+            [state.cache_size for state in states],
+        )
         self._warn_last_logit_prompt_logprobs_once()
 
         while True:
@@ -2106,6 +2117,18 @@ class MbltWorker(WorkerBase):
         prompt_logprobs_dict = {}
 
         if self._is_batch_model():
+            logger.info(
+                "[mblt-batch-debug] scheduler_output: batch_size=%d max_batch_size=%d "
+                "max_num_batched_tokens=%s scheduled_tokens=%s cached_req_ids=%s "
+                "new_req_count=%d finished_req_count=%d",
+                batch_size,
+                self.max_batch_size,
+                getattr(self, "max_num_batched_tokens", None),
+                dict(scheduler_output.num_scheduled_tokens),
+                list(getattr(scheduler_output.scheduled_cached_reqs, "req_ids", []) or []),
+                len(getattr(scheduler_output, "scheduled_new_reqs", []) or []),
+                len(getattr(scheduler_output, "finished_req_ids", []) or []),
+            )
             if batch_size > self.max_batch_size:
                 raise RuntimeError(
                     "Scheduled batch exceeds compiled batch capacity: "
@@ -2153,6 +2176,19 @@ class MbltWorker(WorkerBase):
                 else:
                     normal_indices.append(len(req_ids) - 1)
 
+            logger.info(
+                "[mblt-batch-debug] prepared batch: req_count=%d normal_count=%d "
+                "microstep_count=%d sequence_lengths=%s cache_sizes=%s "
+                "scheduled_end_positions=%s prompt_lens=%s next_prompt_logprob_pos=%s",
+                len(req_ids),
+                len(normal_indices),
+                len(microstep_indices),
+                sequence_lengths,
+                cache_sizes,
+                scheduled_end_positions,
+                [self.req_states[req_id].prompt_len for req_id in req_ids],
+                [self.req_states[req_id].next_prompt_logprob_pos for req_id in req_ids],
+            )
             batched_logits: list[Optional[InferenceLogits]] = [None for _ in req_ids]
 
             if normal_indices:


### PR DESCRIPTION
## Summary
- Fix batch prompt logprobs for last-token-only MXQ outputs by adding a 1-token microstep path.
- Avoid misclassifying batch MXQ output shapes and keep normal chunk forwarding for requests that do not need the prompt-logprob microstep path.
- Tune/log batch scheduler prefill behavior and hide batch debug logs by default.

## Root Cause
Batch prompt-logprob fallback could replay a long prefix through qbruntime after the scheduler chunk had already run. For prompts beyond 256 tokens this could submit `BatchParam.sequence_length=257`, triggering `Model_ShapeMismatched` from qbruntime.

## Impact
Prompt-logprob requests on last-logit MXQ artifacts are handled with correctness-first 1-token microsteps, while normal batch requests continue using chunk forwarding. Users that need faster prompt logprobs should compile/use full-logits MXQ artifacts.

## Validation
- `uv run pytest tests/test_mblt_platform_prefill.py tests/test_mblt_worker_optimizations.py`
  - Result: 95 passed, 3 failed.
  - Failures are all in newly added microstep tests due to `AttributeError: 'MbltWorker' object has no attribute 'print_debug'` on test-created workers.
