### PR TITLE
VLM prefix caching 범위 정리 및 runtime cache 안정화

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,15 @@ Model artifacts are available through Mobilint model repositories such as the
 - Keep finished-session snapshots for prefix reuse.
 - Evict finished snapshots with an LRU cap of 16 sessions.
 
+VLM prefix caching currently covers the language-model KV cache only. For
+single-request VLM execution (`max_batch_size=1`), the worker may load a
+compatible LM KV prefix snapshot and run only the uncached text/embedding
+suffix. Image/video feature extraction is not cached by this layer: image
+requests still rebuild vision features through the model's multimodal feature
+hooks before the LM prefill/decode step. Batch-compiled VLM execution is not
+supported yet; use VLM models with `max_batch_size=1` until Mobilint batch VLM
+artifacts and worker support are added.
+
 Implementation file: [`vllm_mblt/mblt_worker.py`](vllm_mblt/mblt_worker.py)
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -270,6 +270,25 @@ Model artifacts are available through Mobilint model repositories such as the
 - Reuse live cache for same-request continuous decode.
 - Keep finished-session snapshots for prefix reuse.
 - Evict finished snapshots with an LRU cap of 16 sessions.
+- Load matched snapshots only when the worker-side cost model expects the
+  one-cache-id load to beat recomputing the matched prefix.
+
+The prefix-cache load threshold is enabled by default. During model warmup the
+worker tries to measure optimistic one-cache-id prefill costs for 1, 2, 4, and
+8 KV blocks; for batch MXQs this still submits exactly one active `cache_id`.
+Real snapshot loads and dumps update per-`cache_id` EWMA timings. A snapshot is
+loaded only when `load_ms < prefill_ms * 0.9`; otherwise the snapshot remains
+stored and the prompt is recomputed. The policy can be adjusted with environment
+variables or equivalent model loader extra config keys:
+
+- `VLLM_MBLT_PREFIX_CACHE_AUTO_THRESHOLD` / `prefix_cache_auto_threshold`
+  defaults to enabled. Set `0` to disable measured thresholding.
+- `VLLM_MBLT_PREFIX_CACHE_MIN_HIT_TOKENS` / `prefix_cache_min_hit_tokens`
+  sets a manual minimum matched-token count before any snapshot load.
+- `VLLM_MBLT_PREFIX_CACHE_LOAD_MARGIN` / `prefix_cache_load_margin` defaults
+  to `0.9`.
+- `VLLM_MBLT_PREFIX_CACHE_CALIBRATE` defaults to enabled. Set `0` to skip
+  startup prefill calibration.
 
 VLM prefix caching currently covers the language-model KV cache only. For
 single-request VLM execution (`max_batch_size=1`), the worker may load a

--- a/tests/test_kv_cache_swap_spec.py
+++ b/tests/test_kv_cache_swap_spec.py
@@ -64,6 +64,7 @@ def _make_request_state(
         cached_sampling_state=worker._make_cached_sampling_state(sampling_params, prompt_token_ids),
         block_ids=block_ids,
         first_seq_blocks=tuple(block_ids[0]) if block_ids else (),
+        first_seq_block_hashes=None,
         num_computed_tokens=num_computed_tokens,
         num_output_tokens=0,
         prompt_embeds=np.zeros((prompt_len, 2), dtype=np.float32),

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -414,6 +414,171 @@ class TestMbltWorkerOptimizations:
         assert load_calls == [(["runtime-cache"], None)]
         assert worker.runtime_cache.loaded_req_id == "request"
 
+    def test_explicit_prompt_embeds_with_same_tokens_but_different_content_do_not_load(self) -> None:
+        worker = self._make_worker()
+        old_embeds = np.zeros((128, 4), dtype=np.float32)
+        new_embeds = old_embeds.copy()
+        new_embeds[17, 2] = 1.0
+        old_req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(128)))
+        old_req_state.prompt_embeds = old_embeds
+        old_req_state.prompt_len = 128
+        old_req_state.explicit_prompt_embeds = True
+        worker.runtime_cache.store_snapshot(
+            req_id="shared",
+            blobs=["runtime-cache"],
+            block_ids=([10],),
+            first_seq_blocks=(10,),
+            first_seq_block_hashes=("shared-block",),
+            num_tokens=128,
+            cache_token_ids=tuple(range(128)),
+            prompt_embed_cache_identity=worker._make_prompt_embed_cache_identity(old_req_state),
+        )
+        load_calls = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        worker.prefix_cache_cost_model.observe_prefill(128, 20.0)
+        worker.prefix_cache_cost_model.observe_load(None, 5.0)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(128)))
+        req_state.prompt_embeds = new_embeds
+        req_state.prompt_len = 128
+        req_state.explicit_prompt_embeds = True
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+        req_state.first_seq_block_hashes = ("shared-block",)
+        req_state.num_computed_tokens = 128
+
+        cache_size = worker._load_snapshot_if_needed("request", req_state)
+
+        assert cache_size == 0
+        assert load_calls == []
+        assert worker.runtime_cache.loaded_req_id is None
+
+    def test_explicit_prompt_embeds_with_identical_content_load(self) -> None:
+        worker = self._make_worker()
+        prompt_embeds = np.arange(128 * 4, dtype=np.float32).reshape(128, 4)
+        old_req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(128)))
+        old_req_state.prompt_embeds = prompt_embeds
+        old_req_state.prompt_len = 128
+        old_req_state.explicit_prompt_embeds = True
+        worker.runtime_cache.store_snapshot(
+            req_id="shared",
+            blobs=["runtime-cache"],
+            block_ids=([10],),
+            first_seq_blocks=(10,),
+            first_seq_block_hashes=("shared-block",),
+            num_tokens=128,
+            cache_token_ids=tuple(range(128)),
+            prompt_embed_cache_identity=worker._make_prompt_embed_cache_identity(old_req_state),
+        )
+        load_calls = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        worker.prefix_cache_cost_model.observe_prefill(128, 20.0)
+        worker.prefix_cache_cost_model.observe_load(None, 5.0)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(128)))
+        req_state.prompt_embeds = prompt_embeds.copy()
+        req_state.prompt_len = 128
+        req_state.explicit_prompt_embeds = True
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+        req_state.first_seq_block_hashes = ("shared-block",)
+        req_state.num_computed_tokens = 128
+
+        cache_size = worker._load_snapshot_if_needed("request", req_state)
+
+        assert cache_size == 128
+        assert load_calls == [(["runtime-cache"], None)]
+
+    def test_short_explicit_prompt_embed_hit_skips_fingerprint_when_cost_policy_skips(
+        self,
+        monkeypatch,
+    ) -> None:
+        worker = self._make_worker()
+        calls = []
+
+        def fingerprint(prompt_embeds, num_tokens):
+            calls.append((prompt_embeds.shape, int(num_tokens)))
+            return ("unexpected",)
+
+        monkeypatch.setattr(worker, "_fingerprint_prompt_embed_prefix", fingerprint)
+        old_req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(16)))
+        old_req_state.prompt_embeds = np.zeros((16, 4), dtype=np.float32)
+        old_req_state.prompt_len = 16
+        old_req_state.explicit_prompt_embeds = True
+        worker.runtime_cache.store_snapshot(
+            req_id="shared",
+            blobs=["runtime-cache"],
+            block_ids=([10],),
+            first_seq_blocks=(10,),
+            first_seq_block_hashes=("shared-block",),
+            num_tokens=16,
+            cache_token_ids=tuple(range(16)),
+            prompt_embed_cache_identity=worker._make_prompt_embed_cache_identity(old_req_state),
+        )
+        load_calls = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        worker.prefix_cache_cost_model.observe_prefill(128, 20.0)
+        worker.prefix_cache_cost_model.observe_load(None, 5.0)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(16)))
+        req_state.prompt_embeds = np.zeros((16, 4), dtype=np.float32)
+        req_state.prompt_len = 16
+        req_state.explicit_prompt_embeds = True
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+        req_state.first_seq_block_hashes = ("shared-block",)
+        req_state.num_computed_tokens = 16
+
+        cache_size = worker._load_snapshot_if_needed("request", req_state)
+
+        assert cache_size == 0
+        assert load_calls == []
+        assert calls == []
+
+    def test_explicit_prompt_embed_generated_suffix_reuses_after_prompt_boundary(self) -> None:
+        worker = self._make_worker()
+        prompt_embeds = np.arange(4 * 4, dtype=np.float32).reshape(4, 4)
+        old_req_state = self._make_request_state(
+            worker,
+            SamplingParams.from_optional(),
+            [101, 102, 103, 104],
+            output_token_ids=[201, 202],
+        )
+        old_req_state.prompt_embeds = prompt_embeds
+        old_req_state.prompt_len = 4
+        old_req_state.explicit_prompt_embeds = True
+        worker.runtime_cache.store_snapshot(
+            req_id="shared",
+            blobs=["runtime-cache"],
+            block_ids=([10, 11],),
+            first_seq_blocks=(10, 11),
+            first_seq_block_hashes=("shared-a", "shared-b"),
+            num_tokens=6,
+            cache_token_ids=worker._cache_token_ids(old_req_state, 6),
+            prompt_embed_cache_identity=worker._make_prompt_embed_cache_identity(old_req_state),
+        )
+        load_calls = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(
+            block_size=128,
+            auto_threshold_enabled=False,
+        )
+        req_state = self._make_request_state(
+            worker,
+            SamplingParams.from_optional(),
+            [301, 302, 303, 304],
+            output_token_ids=[201, 202],
+        )
+        req_state.prompt_embeds = prompt_embeds.copy()
+        req_state.prompt_len = 4
+        req_state.explicit_prompt_embeds = True
+        req_state.block_ids = ([10, 11],)
+        req_state.first_seq_blocks = (10, 11)
+        req_state.first_seq_block_hashes = ("shared-a", "shared-b")
+        req_state.num_computed_tokens = 6
+
+        cache_size = worker._load_snapshot_if_needed("request", req_state)
+
+        assert cache_size == 6
+        assert load_calls == [(["runtime-cache"], None)]
+
     def test_batch_prefix_cache_threshold_applies_per_cache_id(self) -> None:
         worker = self._make_worker()
         worker.max_batch_size = 2

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -176,6 +176,7 @@ class TestMbltWorkerOptimizations:
         *,
         num_computed_tokens: int = 0,
         block_ids: tuple[list[int], ...] | None = None,
+        block_hashes: tuple[object, ...] | None = None,
         session_id: str | None = None,
     ) -> SimpleNamespace:
         return SimpleNamespace(
@@ -185,6 +186,7 @@ class TestMbltWorkerOptimizations:
             prompt_embeds=prompt_embeds,
             mm_features=mm_features,
             block_ids=block_ids or ([11],),
+            block_hashes=block_hashes,
             num_computed_tokens=num_computed_tokens,
             session_id=session_id,
         )
@@ -1831,6 +1833,7 @@ class TestMbltWorkerOptimizations:
             blobs=["lm-kv-prefix"],
             block_ids=([11],),
             first_seq_blocks=(11,),
+            first_seq_block_hashes=("shared-text-prefix-block",),
             num_tokens=128,
         )
 
@@ -1872,6 +1875,7 @@ class TestMbltWorkerOptimizations:
             [feature],
             num_computed_tokens=128,
             block_ids=([11, 12],),
+            block_hashes=("shared-text-prefix-block", "vlm-suffix-block"),
             session_id="vlm-session",
         )
         scheduler_output = self._make_scheduler_output({"vlm-hit": 2})

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -14,6 +14,7 @@ from vllm.v1.sample.sampler import Sampler
 from vllm_mblt.mblt_worker import (
     InferenceLogits,
     MbltWorker,
+    PrefixCacheCostModel,
     RequestState,
     _is_multimodal_hf_config,
     _is_qwen3_vl_hf_config,
@@ -147,6 +148,7 @@ class TestMbltWorkerOptimizations:
         worker.empty_prompt_token_ids = torch.empty((0, 0), dtype=torch.int64)
         worker.sampler = Sampler(logprobs_mode="raw_logits")
         worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=1, block_size=128)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
         worker.input_embeddings = SimpleNamespace()
         worker.print_debug = False
         worker._warned_last_logit_prompt_logprobs = False
@@ -284,6 +286,154 @@ class TestMbltWorkerOptimizations:
         assert cache_size == 0
         assert load_calls == []
         assert worker.runtime_cache.loaded_req_id is None
+
+    def test_short_prefix_hit_skips_load_and_keeps_snapshot(self) -> None:
+        worker = self._make_worker()
+        worker.runtime_cache.store_snapshot(
+            req_id="shared",
+            blobs=["runtime-cache"],
+            block_ids=([10],),
+            first_seq_blocks=(10,),
+            first_seq_block_hashes=("shared-block",),
+            num_tokens=16,
+            cache_token_ids=tuple(range(16)),
+        )
+        load_calls = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        worker.prefix_cache_cost_model.observe_prefill(128, 20.0)
+        worker.prefix_cache_cost_model.observe_load(None, 5.0)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(32)))
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+        req_state.first_seq_block_hashes = ("shared-block",)
+        req_state.num_computed_tokens = 16
+
+        cache_size = worker._load_snapshot_if_needed("request", req_state)
+
+        assert cache_size == 0
+        assert load_calls == []
+        assert worker.runtime_cache.get_snapshot("shared") is not None
+        assert worker.runtime_cache.loaded_req_id is None
+
+    def test_long_prefix_hit_loads_and_returns_suffix_start(self) -> None:
+        worker = self._make_worker()
+        worker.runtime_cache.store_snapshot(
+            req_id="shared",
+            blobs=["runtime-cache"],
+            block_ids=([10],),
+            first_seq_blocks=(10,),
+            first_seq_block_hashes=("shared-block",),
+            num_tokens=128,
+            cache_token_ids=tuple(range(128)),
+        )
+        load_calls = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        worker.prefix_cache_cost_model.observe_prefill(128, 20.0)
+        worker.prefix_cache_cost_model.observe_load(None, 5.0)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(160)))
+        req_state.block_ids = ([10, 11],)
+        req_state.first_seq_blocks = (10, 11)
+        req_state.first_seq_block_hashes = ("shared-block", "suffix-block")
+        req_state.num_computed_tokens = 128
+
+        cache_size = worker._load_snapshot_if_needed("request", req_state)
+
+        assert cache_size == 128
+        assert load_calls == [(["runtime-cache"], None)]
+        assert worker.runtime_cache.loaded_req_id == "request"
+
+    def test_batch_prefix_cache_threshold_applies_per_cache_id(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+        worker.runtime_cache.store_snapshot(
+            req_id="shared",
+            blobs=["runtime-cache"],
+            block_ids=([10],),
+            first_seq_blocks=(10,),
+            num_tokens=16,
+            cache_token_ids=tuple(range(16)),
+        )
+        load_calls = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        worker.prefix_cache_cost_model.observe_prefill(128, 20.0)
+        worker.prefix_cache_cost_model.observe_load(1, 5.0)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(32)))
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+        req_state.first_seq_block_hashes = ("shared-block",)
+        req_state.num_computed_tokens = 16
+        req_state.cache_slot_id = 1
+
+        cache_size = worker._load_snapshot_if_needed("request", req_state, slot_id=1)
+
+        assert cache_size == 0
+        assert load_calls == []
+        assert worker.runtime_cache.live_slot_owner(1) == "request"
+        assert worker.runtime_cache.get_snapshot("shared") is not None
+
+    def test_prefix_cache_manual_override_and_auto_disable(self, monkeypatch) -> None:
+        cost_model = PrefixCacheCostModel(
+            block_size=128,
+            auto_threshold_enabled=True,
+            manual_min_hit_tokens=64,
+        )
+        cost_model.observe_prefill(128, 20.0)
+        cost_model.observe_load(None, 1.0)
+        assert not cost_model.should_load(matched_tokens=16)
+        assert cost_model.should_load(matched_tokens=128)
+
+        cost_model = PrefixCacheCostModel(
+            block_size=128,
+            auto_threshold_enabled=False,
+            manual_min_hit_tokens=None,
+        )
+        cost_model.observe_prefill(128, 1.0)
+        cost_model.observe_load(None, 100.0)
+        assert cost_model.should_load(matched_tokens=16)
+
+        config_model = PrefixCacheCostModel.from_config(
+            SimpleNamespace(
+                load_config=SimpleNamespace(
+                    model_loader_extra_config={
+                        "prefix_cache_auto_threshold": "0",
+                        "prefix_cache_min_hit_tokens": "32",
+                        "prefix_cache_load_margin": "0.8",
+                    }
+                ),
+                model_config=SimpleNamespace(model_kwargs={}, hf_overrides={}),
+            ),
+            block_size=128,
+        )
+        assert not config_model.auto_threshold_enabled
+        assert config_model.manual_min_hit_tokens == 32
+        assert config_model.margin == 0.8
+
+        monkeypatch.setenv("VLLM_MBLT_PREFIX_CACHE_MIN_HIT_TOKENS", "96")
+        env_model = PrefixCacheCostModel.from_config(SimpleNamespace(), block_size=128)
+        assert env_model.manual_min_hit_tokens == 96
+
+    def test_prefix_cache_calibration_uses_one_active_batch_cache_id(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 4
+        worker.max_seq_len = 128
+        worker.input_embeddings = torch.nn.Embedding(1, 4)
+        calls = []
+
+        def infer(inputs, *, params):
+            calls.extend((int(param.sequence_length), int(param.cache_size), int(param.cache_id)) for param in params)
+            total_tokens = sum(int(param.sequence_length) for param in params)
+            return [np.zeros((1, total_tokens, 8), dtype=np.float32)]
+
+        worker.cache_model = SimpleNamespace(infer=infer)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+
+        worker._calibrate_prefix_cache_prefill_costs()
+
+        assert calls
+        assert all(call == (128, 0, 1) for call in calls)
+        assert worker.prefix_cache_cost_model.prefill_ms(128) is not None
 
     def test_llm_prefix_cache_dump_saves_prompt_and_generated_token_identity(self) -> None:
         worker = self._make_worker()

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -253,6 +253,54 @@ class TestMbltWorkerOptimizations:
         assert snapshot is short_shared
         assert matched_tokens == 256
 
+    def test_llm_prefix_cache_does_not_load_reused_physical_blocks_for_different_prompt_tokens(self) -> None:
+        worker = self._make_worker()
+        worker.runtime_cache.store_snapshot(
+            req_id="old-content",
+            blobs=["stale-runtime-cache"],
+            block_ids=([10],),
+            first_seq_blocks=(10,),
+            num_tokens=4,
+            cache_token_ids=(101, 102, 103, 104),
+        )
+        load_calls = []
+        worker.runtime_cache.set_io_adapters(
+            load_runtime_cache=lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
+        )
+        req_state = self._make_request_state(
+            worker,
+            SamplingParams.from_optional(),
+            [201, 202, 203, 204],
+        )
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+        req_state.num_computed_tokens = 4
+
+        cache_size = worker._load_snapshot_if_needed("new-content", req_state)
+
+        assert cache_size == 0
+        assert load_calls == []
+        assert worker.runtime_cache.loaded_req_id is None
+
+    def test_llm_prefix_cache_dump_saves_prompt_and_generated_token_identity(self) -> None:
+        worker = self._make_worker()
+        worker.runtime_cache.set_io_adapters(dump_runtime_cache=lambda slot_id: ["runtime-cache"])
+        req_state = self._make_request_state(
+            worker,
+            SamplingParams.from_optional(),
+            [101, 102],
+            output_token_ids=[201, 202],
+        )
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+
+        dumped = worker._dump_snapshot("req", req_state, next_num_tokens=4)
+
+        assert dumped
+        snapshot = worker.runtime_cache.get_snapshot("req")
+        assert snapshot is not None
+        assert snapshot.cache_token_ids == (101, 102, 201, 202)
+
     def test_sampling_metadata_reuses_request_generator_and_enables_penalties(self) -> None:
         worker = self._make_worker()
         sampling_params = SamplingParams.from_optional(seed=123, frequency_penalty=0.5, top_k=20)

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -2221,6 +2221,19 @@ class TestMbltWorkerOptimizations:
             data={"pixel_values": torch.zeros(1, 3), "image_grid_thw": torch.tensor([1, 1, 1])},
             mm_position=SimpleNamespace(offset=4, length=2, is_embed=None),
         )
+        image_embeds = torch.full((2, 4), 9.0)
+        cached_prompt_embeds = base_prompt_embeds.clone()
+        cached_prompt_embeds[4:6] = image_embeds
+        cached_req_state = self._make_request_state(
+            worker,
+            SamplingParams.from_optional(),
+            list(range(130)),
+        )
+        cached_req_state.prompt_embeds = cached_prompt_embeds.numpy()
+        cached_req_state.prompt_len = 130
+        cached_req_state.explicit_prompt_embeds = True
+        cached_prompt_embed_identity = worker._make_prompt_embed_cache_identity(cached_req_state)
+        assert cached_prompt_embed_identity is not None
         worker.runtime_cache.store_snapshot(
             req_id="shared-text-prefix",
             blobs=["lm-kv-prefix"],
@@ -2232,10 +2245,10 @@ class TestMbltWorkerOptimizations:
                 "vlm-session",
                 [feature],
             ),
+            prompt_embed_cache_identity=cached_prompt_embed_identity,
         )
 
         image_feature_calls: list[dict[str, torch.Tensor]] = []
-        image_embeds = torch.full((2, 4), 9.0)
 
         def get_image_features(**kwargs):
             image_feature_calls.append(kwargs)
@@ -2277,6 +2290,12 @@ class TestMbltWorkerOptimizations:
         assert image_feature_calls and tuple(image_feature_calls[0]["image_grid_thw"].shape) == (1, 3)
         assert [(sequence_length, cache_size) for sequence_length, cache_size, _inputs in infer_calls] == [(2, 128)]
         np.testing.assert_array_equal(infer_calls[0][2][0], base_prompt_embeds[128:130].numpy())
+        snapshot = worker.runtime_cache.get_snapshot("shared-text-prefix")
+        assert snapshot is not None
+        request_prompt_embed_identity = worker._make_prompt_embed_cache_identity(worker.req_states["vlm-hit"])
+        assert request_prompt_embed_identity is not None
+        assert snapshot.prompt_embed_cache_identity is not None
+        assert request_prompt_embed_identity.fingerprint(128) == snapshot.prompt_embed_cache_identity.fingerprint(128)
         assert worker.req_states["vlm-hit"].num_computed_tokens == 130
         assert worker.runtime_cache.loaded_req_id == "vlm-hit"
 

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -1983,8 +1983,8 @@ class TestMbltWorkerOptimizations:
             blobs=["lm-kv-prefix"],
             block_ids=([11],),
             first_seq_blocks=(11,),
-            first_seq_block_hashes=("shared-text-prefix-block",),
             num_tokens=128,
+            cache_token_ids=tuple(range(128)),
         )
 
         image_feature_calls: list[dict[str, torch.Tensor]] = []
@@ -2025,7 +2025,6 @@ class TestMbltWorkerOptimizations:
             [feature],
             num_computed_tokens=128,
             block_ids=([11, 12],),
-            block_hashes=("shared-text-prefix-block", "vlm-suffix-block"),
             session_id="vlm-session",
         )
         scheduler_output = self._make_scheduler_output({"vlm-hit": 2})

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -133,6 +133,70 @@ class TestMbltWorkerOptimizations:
         )
         assert getattr(worker, "_vlm_image_positions_by_session", {}) == {}
 
+    def test_vlm_multimodal_cache_identity_includes_image_content_fingerprint(self) -> None:
+        image_a = self._make_mm_feature(
+            "image",
+            offset=1,
+            length=2,
+            data={
+                "pixel_values": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+                "image_grid_thw": torch.tensor([1, 1, 2]),
+            },
+        )
+        image_b = self._make_mm_feature(
+            "image",
+            offset=1,
+            length=2,
+            data={
+                "pixel_values": torch.tensor([[1.0, 2.0], [3.0, 5.0]]),
+                "image_grid_thw": torch.tensor([1, 1, 2]),
+            },
+        )
+
+        identity_a = MbltWorker._build_vlm_multimodal_cache_identity("session-a", [image_a])
+        identity_b = MbltWorker._build_vlm_multimodal_cache_identity("session-a", [image_b])
+
+        assert identity_a != identity_b
+
+    def test_vlm_multimodal_cache_identity_is_stable_for_same_image_content(self) -> None:
+        data = {
+            "pixel_values": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            "image_grid_thw": torch.tensor([1, 1, 2]),
+        }
+
+        identity_a = MbltWorker._build_vlm_multimodal_cache_identity(
+            "session-a",
+            [self._make_mm_feature("image", offset=1, length=2, data=data)],
+        )
+        identity_b = MbltWorker._build_vlm_multimodal_cache_identity(
+            "session-a",
+            [
+                self._make_mm_feature(
+                    "image",
+                    offset=1,
+                    length=2,
+                    data={key: value.clone() for key, value in data.items()},
+                )
+            ],
+        )
+
+        assert identity_a == identity_b
+
+    def test_vlm_multimodal_cache_identity_marks_unfingerprintable_feature_unresolved(self) -> None:
+        identity = MbltWorker._build_vlm_multimodal_cache_identity(
+            "session-a",
+            [
+                self._make_mm_feature(
+                    "image",
+                    offset=1,
+                    length=2,
+                    data={"pixel_values": object(), "image_grid_thw": torch.tensor([1, 1, 2])},
+                )
+            ],
+        )
+
+        assert identity == ("vlm", "session-a", (("image", (1, 2, None), None),))
+
     def _make_worker(self) -> MbltWorker:
         worker = MbltWorker.__new__(MbltWorker)
         worker.model_config = SimpleNamespace(hf_config=SimpleNamespace(model_type="qwen2"))
@@ -221,10 +285,18 @@ class TestMbltWorkerOptimizations:
         )
 
     def _make_mm_feature(
-        self, modality: str = "image", *, offset: int = 1, length: int = 2, is_embed: torch.Tensor | None = None
+        self,
+        modality: str = "image",
+        *,
+        offset: int = 1,
+        length: int = 2,
+        is_embed: torch.Tensor | None = None,
+        data: dict[str, object] | None = None,
     ) -> SimpleNamespace:
         return SimpleNamespace(
-            modality=modality, data={}, mm_position=SimpleNamespace(offset=offset, length=length, is_embed=is_embed)
+            modality=modality,
+            data=data or {},
+            mm_position=SimpleNamespace(offset=offset, length=length, is_embed=is_embed),
         )
 
     def test_snapshot_index_can_prefer_shallower_prefix_with_more_tokens(self) -> None:
@@ -1978,6 +2050,12 @@ class TestMbltWorkerOptimizations:
             dump_runtime_cache=lambda _slot_id: ["unused"],
             load_runtime_cache=lambda blobs, _slot_id: blobs == ["lm-kv-prefix"],
         )
+        base_prompt_embeds = torch.arange(130 * 4, dtype=torch.float32).reshape(130, 4)
+        feature = SimpleNamespace(
+            modality="image",
+            data={"pixel_values": torch.zeros(1, 3), "image_grid_thw": torch.tensor([1, 1, 1])},
+            mm_position=SimpleNamespace(offset=4, length=2, is_embed=None),
+        )
         worker.runtime_cache.store_snapshot(
             req_id="shared-text-prefix",
             blobs=["lm-kv-prefix"],
@@ -1985,6 +2063,10 @@ class TestMbltWorkerOptimizations:
             first_seq_blocks=(11,),
             num_tokens=128,
             cache_token_ids=tuple(range(128)),
+            multimodal_cache_identity=MbltWorker._build_vlm_multimodal_cache_identity(
+                "vlm-session",
+                [feature],
+            ),
         )
 
         image_feature_calls: list[dict[str, torch.Tensor]] = []
@@ -2013,12 +2095,6 @@ class TestMbltWorkerOptimizations:
             logprobs_tensors=None,
         )
 
-        base_prompt_embeds = torch.arange(130 * 4, dtype=torch.float32).reshape(130, 4)
-        feature = SimpleNamespace(
-            modality="image",
-            data={"pixel_values": torch.zeros(1, 3), "image_grid_thw": torch.tensor([1, 1, 1])},
-            mm_position=SimpleNamespace(offset=4, length=2, is_embed=None),
-        )
         new_req = self._make_new_request(
             "vlm-hit",
             base_prompt_embeds,

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -204,6 +204,7 @@ class TestMbltWorkerOptimizations:
             cached_sampling_state=worker._make_cached_sampling_state(sampling_params, prompt_token_ids),
             block_ids=([],),
             first_seq_blocks=(),
+            first_seq_block_hashes=None,
             num_computed_tokens=0,
             num_output_tokens=0,
             prompt_embeds=np.empty((0, 1), dtype=np.float32),

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -168,6 +168,27 @@ class TestMbltWorkerOptimizations:
             kv_connector_metadata=None,
         )
 
+    def _make_new_request(
+        self,
+        req_id: str,
+        prompt_embeds: torch.Tensor,
+        mm_features: list[SimpleNamespace],
+        *,
+        num_computed_tokens: int = 0,
+        block_ids: tuple[list[int], ...] | None = None,
+        session_id: str | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            req_id=req_id,
+            sampling_params=SamplingParams.from_optional(temperature=0.0),
+            prompt_token_ids=list(range(int(prompt_embeds.shape[0]))),
+            prompt_embeds=prompt_embeds,
+            mm_features=mm_features,
+            block_ids=block_ids or ([11],),
+            num_computed_tokens=num_computed_tokens,
+            session_id=session_id,
+        )
+
     def _make_request_state(
         self,
         worker: MbltWorker,
@@ -1745,6 +1766,138 @@ class TestMbltWorkerOptimizations:
         torch.testing.assert_close(merged[1:3], image_embeds)
         torch.testing.assert_close(base_prompt_embeds, torch.arange(20, dtype=torch.float32).reshape(5, 4))
         assert deepstack is None
+
+    def test_single_request_vlm_reuses_lm_kv_prefix_and_runs_suffix_only(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen2_vl")
+        worker.model.config = SimpleNamespace(model_type="mobilint-qwen2_vl", vocab_size=32000)
+        worker.req_states = {}
+        worker._infer_output_buffers = None
+        worker.runtime_cache.set_io_adapters(
+            dump_runtime_cache=lambda _slot_id: ["unused"],
+            load_runtime_cache=lambda blobs, _slot_id: blobs == ["lm-kv-prefix"],
+        )
+        worker.runtime_cache.store_snapshot(
+            req_id="shared-text-prefix",
+            blobs=["lm-kv-prefix"],
+            block_ids=([11],),
+            first_seq_blocks=(11,),
+            num_tokens=128,
+        )
+
+        image_feature_calls: list[dict[str, torch.Tensor]] = []
+        image_embeds = torch.full((2, 4), 9.0)
+
+        def get_image_features(**kwargs):
+            image_feature_calls.append(kwargs)
+            return image_embeds
+
+        infer_calls: list[tuple[int, int, np.ndarray]] = []
+
+        def infer(inputs, *, cache_size, outputs=None):
+            input_embeds = np.asarray(inputs[0] if isinstance(inputs, list) else inputs)
+            infer_calls.append((int(input_embeds.shape[1]), int(cache_size), input_embeds.copy()))
+            return [np.full((1, 16), 1.0, dtype=np.float32)]
+
+        worker.model.get_image_features = get_image_features
+        worker.cache_model = SimpleNamespace(
+            infer=infer,
+            get_model_output_shape=lambda: [(1, 16)],
+            get_num_model_variants=lambda: 0,
+        )
+        worker._make_sampling_metadata = lambda _states: None
+        worker._sample_next_token = lambda _logits, _metadata: SimpleNamespace(
+            sampled_token_ids=torch.tensor([[7]], dtype=torch.int64),
+            logprobs_tensors=None,
+        )
+
+        base_prompt_embeds = torch.arange(130 * 4, dtype=torch.float32).reshape(130, 4)
+        feature = SimpleNamespace(
+            modality="image",
+            data={"pixel_values": torch.zeros(1, 3), "image_grid_thw": torch.tensor([1, 1, 1])},
+            mm_position=SimpleNamespace(offset=4, length=2, is_embed=None),
+        )
+        new_req = self._make_new_request(
+            "vlm-hit",
+            base_prompt_embeds,
+            [feature],
+            num_computed_tokens=128,
+            block_ids=([11, 12],),
+            session_id="vlm-session",
+        )
+        scheduler_output = self._make_scheduler_output({"vlm-hit": 2})
+        scheduler_output.scheduled_new_reqs = [new_req]
+
+        output = worker.execute_model(scheduler_output)
+
+        assert output is not None
+        assert image_feature_calls and tuple(image_feature_calls[0]["image_grid_thw"].shape) == (1, 3)
+        assert [(sequence_length, cache_size) for sequence_length, cache_size, _inputs in infer_calls] == [(2, 128)]
+        np.testing.assert_array_equal(infer_calls[0][2][0], base_prompt_embeds[128:130].numpy())
+        assert worker.req_states["vlm-hit"].num_computed_tokens == 130
+        assert worker.runtime_cache.loaded_req_id == "vlm-hit"
+
+    def test_repeated_image_vlm_requests_still_rebuild_vision_embeddings(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen2_vl")
+        worker.model.config = SimpleNamespace(model_type="mobilint-qwen2_vl", vocab_size=32000)
+        worker.req_states = {}
+        worker._infer_output_buffers = None
+        worker.runtime_cache.set_io_adapters(
+            dump_runtime_cache=lambda _slot_id: ["live-kv"],
+            load_runtime_cache=lambda _blobs, _slot_id: True,
+        )
+
+        image_feature_call_count = 0
+
+        def get_image_features(**_kwargs):
+            nonlocal image_feature_call_count
+            image_feature_call_count += 1
+            return torch.full((2, 4), float(image_feature_call_count))
+
+        infer_inputs: list[np.ndarray] = []
+
+        def infer(inputs, *, cache_size, outputs=None):
+            del cache_size, outputs
+            infer_inputs.append(np.asarray(inputs[0] if isinstance(inputs, list) else inputs).copy())
+            return [np.full((1, 16), 1.0, dtype=np.float32)]
+
+        worker.model.get_image_features = get_image_features
+        worker.cache_model = SimpleNamespace(
+            infer=infer,
+            get_model_output_shape=lambda: [(1, 16)],
+            get_num_model_variants=lambda: 0,
+        )
+        worker._make_sampling_metadata = lambda _states: None
+        worker._sample_next_token = lambda _logits, _metadata: SimpleNamespace(
+            sampled_token_ids=torch.tensor([[7]], dtype=torch.int64),
+            logprobs_tensors=None,
+        )
+
+        for index, req_id in enumerate(("vlm-first", "vlm-second"), start=1):
+            prompt_embeds = torch.zeros(6, 4)
+            feature = SimpleNamespace(
+                modality="image",
+                data={"pixel_values": torch.full((1, 3), float(index)), "image_grid_thw": torch.tensor([1, 1, 1])},
+                mm_position=SimpleNamespace(offset=2, length=2, is_embed=None),
+            )
+            scheduler_output = self._make_scheduler_output({req_id: 6})
+            scheduler_output.scheduled_new_reqs = [
+                self._make_new_request(
+                    req_id,
+                    prompt_embeds,
+                    [feature],
+                    block_ids=([20 + index],),
+                    session_id=f"vlm-session-{index}",
+                )
+            ]
+
+            assert worker.execute_model(scheduler_output) is not None
+
+        assert image_feature_call_count == 2
+        assert len(infer_inputs) == 2
+        np.testing.assert_array_equal(infer_inputs[0][0, 2:4], np.full((2, 4), 1.0, dtype=np.float32))
+        np.testing.assert_array_equal(infer_inputs[1][0, 2:4], np.full((2, 4), 2.0, dtype=np.float32))
 
     def test_build_deepstack_input_embeds_pads_decode_tokens(self) -> None:
         worker = self._make_worker()

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -27,6 +27,7 @@ def _request(
     block_hashes: tuple[object, ...] | None = None,
     cache_slot_id: int | None = None,
     cache_token_ids: tuple[int, ...] | list[int] | None = None,
+    multimodal_cache_identity: object | None = None,
 ) -> RuntimeCacheRequest:
     return RuntimeCacheRequest(
         req_id=req_id,
@@ -36,6 +37,7 @@ def _request(
         first_seq_block_hashes=block_hashes,
         cache_slot_id=cache_slot_id,
         cache_token_ids=tuple(cache_token_ids) if cache_token_ids is not None else None,
+        multimodal_cache_identity=multimodal_cache_identity,
     )
 
 
@@ -48,6 +50,7 @@ def _store_snapshot(
     blobs: list[object] | None = None,
     cache_token_ids: tuple[int, ...] | list[int] | None = None,
     block_hashes: tuple[object, ...] | None = None,
+    multimodal_cache_identity: object | None = None,
 ) -> None:
     block_tuple = tuple(blocks)
     block_ids = (list(block_tuple),)
@@ -59,6 +62,7 @@ def _store_snapshot(
         first_seq_block_hashes=block_hashes,
         num_tokens=tokens,
         cache_token_ids=cache_token_ids,
+        multimodal_cache_identity=multimodal_cache_identity,
     )
 
 
@@ -224,23 +228,25 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert match.snapshot is manager.get_snapshot("right-content")
         assert match.matched_tokens == 8
 
-    def test_hashless_snapshot_invalidates_when_physical_block_owner_changes(self) -> None:
+    def test_hashless_snapshot_is_not_invalidated_before_token_identity_check(self) -> None:
         manager = _make_manager(block_size=4)
-        _store_snapshot(manager, "old", (1, 2), 8)
+        _store_snapshot(manager, "old", (1, 2), 8, cache_token_ids=tuple(range(8)))
 
         evicted = manager.observe_request_blocks("new", ([1, 3],))
 
-        assert evicted == ["old"]
-        assert manager.get_snapshot("old") is None
-        assert manager.choose_snapshot(_request("new", (1, 2), 8)).snapshot is None
+        assert evicted == []
+        assert manager.get_snapshot("old") is not None
+        match = manager.choose_snapshot(_request("new", (1, 2), 8, cache_token_ids=tuple(range(8))))
+        assert match.snapshot is manager.get_snapshot("old")
+        assert match.matched_tokens == 8
 
     def test_hashless_load_invalidates_stale_snapshot_before_restore(self) -> None:
         manager = _make_manager(block_size=4)
-        _store_snapshot(manager, "old", (1, 2), 8)
+        _store_snapshot(manager, "old", (1, 2), 8, cache_token_ids=tuple(range(8)))
         load_calls = []
 
         result = manager.load_snapshot_for_request(
-            _request("new", (1, 2), 8),
+            _request("new", (1, 2), 8, cache_token_ids=tuple(range(100, 108))),
             lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
         )
 
@@ -248,6 +254,112 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert result.matched_tokens == 0
         assert load_calls == []
         assert manager.get_snapshot("old") is None
+
+    def test_real_vllm_0112_hashless_shared_prefix_restores_with_token_identity(self) -> None:
+        manager = _make_manager(block_size=4)
+        token_ids = (10, 11, 12, 13, 14, 15, 16, 17)
+        _store_snapshot(manager, "finished-a", (1, 2), 8, cache_token_ids=token_ids)
+        manager.mark_snapshot_finished("finished-a")
+
+        new_request_data = type(
+            "NewRequestData0112",
+            (),
+            {
+                "__annotations__": {
+                    "req_id": str,
+                    "prompt_token_ids": list[int],
+                    "mm_features": object,
+                    "sampling_params": object,
+                    "pooling_params": object,
+                    "block_ids": object,
+                    "num_computed_tokens": int,
+                    "lora_request": object,
+                    "prompt_embeds": object,
+                }
+            },
+        )()
+        new_request_data.req_id = "new-b"
+        new_request_data.prompt_token_ids = list(token_ids)
+        new_request_data.block_ids = ([1, 2],)
+        new_request_data.num_computed_tokens = 8
+
+        manager.observe_request_blocks(new_request_data.req_id, new_request_data.block_ids)
+        result = manager.load_snapshot_for_request(
+            _request(
+                new_request_data.req_id,
+                tuple(new_request_data.block_ids[0]),
+                new_request_data.num_computed_tokens,
+                cache_token_ids=tuple(new_request_data.prompt_token_ids),
+            ),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.loaded
+        assert result.loaded_snapshot_req_id == "finished-a"
+        assert result.matched_tokens == 8
+
+    def test_real_vllm_0112_cached_request_reused_physical_block_with_different_tokens_is_removed(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(manager, "old-content", (7,), 4, cache_token_ids=(1, 2, 3, 4))
+        cached_request_data = type(
+            "CachedRequestData0112",
+            (),
+            {
+                "__annotations__": {
+                    "req_ids": list[str],
+                    "resumed_req_ids": set[str],
+                    "new_token_ids": list[list[int]],
+                    "all_token_ids": dict[str, list[int]],
+                    "new_block_ids": object,
+                    "num_computed_tokens": list[int],
+                    "num_output_tokens": list[int],
+                }
+            },
+        )()
+        cached_request_data.req_ids = ["new-content"]
+        cached_request_data.all_token_ids = {"new-content": [9, 2, 3, 4]}
+        cached_request_data.new_block_ids = [([7],)]
+        cached_request_data.num_computed_tokens = [4]
+
+        manager.observe_request_blocks(cached_request_data.req_ids[0], cached_request_data.new_block_ids[0])
+        result = manager.load_snapshot_for_request(
+            _request(
+                cached_request_data.req_ids[0],
+                tuple(cached_request_data.new_block_ids[0][0]),
+                cached_request_data.num_computed_tokens[0],
+                cache_token_ids=tuple(cached_request_data.all_token_ids["new-content"]),
+            ),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.cache_miss
+        assert manager.get_snapshot("old-content") is None
+
+    def test_hashless_multimodal_identity_mismatch_is_rejected(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(
+            manager,
+            "vlm-old",
+            (30,),
+            4,
+            cache_token_ids=(1, 2, 3, 4),
+            multimodal_cache_identity=("vlm", "session-a", (1, 2, None)),
+        )
+
+        manager.observe_request_blocks("vlm-new", ([30],))
+        result = manager.load_snapshot_for_request(
+            _request(
+                "vlm-new",
+                (30,),
+                4,
+                cache_token_ids=(1, 2, 3, 4),
+                multimodal_cache_identity=("vlm", "session-b", (1, 2, None)),
+            ),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.cache_miss
+        assert manager.get_snapshot("vlm-old") is None
 
     def test_snapshot_update_and_removal_refresh_prefix_index(self) -> None:
         manager = _make_manager(block_size=4)

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -2,6 +2,7 @@ import pytest
 
 from vllm_mblt.runtime_cache import (
     MbltRuntimeCacheManager,
+    PromptEmbedCacheIdentity,
     RuntimeCacheRequest,
     append_block_ids,
     first_seq_blocks,
@@ -28,6 +29,7 @@ def _request(
     cache_slot_id: int | None = None,
     cache_token_ids: tuple[int, ...] | list[int] | None = None,
     multimodal_cache_identity: object | None = None,
+    prompt_embed_cache_identity: PromptEmbedCacheIdentity | None = None,
 ) -> RuntimeCacheRequest:
     return RuntimeCacheRequest(
         req_id=req_id,
@@ -38,6 +40,7 @@ def _request(
         cache_slot_id=cache_slot_id,
         cache_token_ids=tuple(cache_token_ids) if cache_token_ids is not None else None,
         multimodal_cache_identity=multimodal_cache_identity,
+        prompt_embed_cache_identity=prompt_embed_cache_identity,
     )
 
 
@@ -51,6 +54,7 @@ def _store_snapshot(
     cache_token_ids: tuple[int, ...] | list[int] | None = None,
     block_hashes: tuple[object, ...] | None = None,
     multimodal_cache_identity: object | None = None,
+    prompt_embed_cache_identity: PromptEmbedCacheIdentity | None = None,
 ) -> None:
     block_tuple = tuple(blocks)
     block_ids = (list(block_tuple),)
@@ -63,6 +67,14 @@ def _store_snapshot(
         num_tokens=tokens,
         cache_token_ids=cache_token_ids,
         multimodal_cache_identity=multimodal_cache_identity,
+        prompt_embed_cache_identity=prompt_embed_cache_identity,
+    )
+
+
+def _prompt_embed_identity(prompt_len: int, fingerprints: dict[int, object]) -> PromptEmbedCacheIdentity:
+    return PromptEmbedCacheIdentity(
+        prompt_len=prompt_len,
+        fingerprint_for_prefix=lambda num_tokens: fingerprints.get(int(num_tokens)),
     )
 
 
@@ -307,6 +319,117 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert result.loaded
         assert result.loaded_snapshot_req_id == "finished-a"
         assert result.matched_tokens == 8
+
+    def test_explicit_prompt_embed_identity_rejects_same_tokens_with_different_embeds(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(
+            manager,
+            "old",
+            (1, 2),
+            8,
+            cache_token_ids=tuple(range(8)),
+            prompt_embed_cache_identity=_prompt_embed_identity(8, {8: ("embed", "old")}),
+        )
+
+        loaded = []
+        result = manager.load_snapshot_for_request(
+            _request(
+                "new",
+                (1, 2),
+                8,
+                cache_token_ids=tuple(range(8)),
+                prompt_embed_cache_identity=_prompt_embed_identity(8, {8: ("embed", "new")}),
+            ),
+            lambda blobs, slot_id: loaded.append((blobs, slot_id)) or True,
+        )
+
+        assert result.cache_miss
+        assert loaded == []
+
+    def test_explicit_prompt_embed_identity_allows_identical_embed_prefix(self) -> None:
+        manager = _make_manager(block_size=4)
+        fingerprint = ("embed", "same")
+        _store_snapshot(
+            manager,
+            "old",
+            (1, 2),
+            8,
+            cache_token_ids=tuple(range(8)),
+            prompt_embed_cache_identity=_prompt_embed_identity(8, {8: fingerprint}),
+        )
+
+        loaded = []
+        result = manager.load_snapshot_for_request(
+            _request(
+                "new",
+                (1, 2),
+                8,
+                cache_token_ids=tuple(range(8)),
+                prompt_embed_cache_identity=_prompt_embed_identity(8, {8: fingerprint}),
+            ),
+            lambda blobs, slot_id: loaded.append((blobs, slot_id)) or True,
+        )
+
+        assert result.loaded
+        assert result.loaded_snapshot_req_id == "old"
+        assert result.matched_tokens == 8
+        assert loaded == [(["blob:old"], None)]
+
+    def test_explicit_prompt_embed_generated_suffix_uses_token_ids_after_prompt(self) -> None:
+        manager = _make_manager(block_size=4)
+        fingerprint = ("embed", "same-prompt")
+        _store_snapshot(
+            manager,
+            "old",
+            (1, 2),
+            6,
+            cache_token_ids=(101, 102, 103, 104, 201, 202),
+            prompt_embed_cache_identity=_prompt_embed_identity(4, {4: fingerprint}),
+        )
+
+        loaded = []
+        result = manager.load_snapshot_for_request(
+            _request(
+                "new",
+                (1, 2),
+                6,
+                cache_token_ids=(301, 302, 303, 304, 201, 202),
+                prompt_embed_cache_identity=_prompt_embed_identity(4, {4: fingerprint}),
+            ),
+            lambda blobs, slot_id: loaded.append((blobs, slot_id)) or True,
+        )
+
+        assert result.loaded
+        assert result.matched_tokens == 6
+        assert loaded == [(["blob:old"], None)]
+
+    def test_explicit_prompt_embed_generated_suffix_mismatch_caps_to_prompt(self) -> None:
+        manager = _make_manager(block_size=4)
+        fingerprint = ("embed", "same-prompt")
+        _store_snapshot(
+            manager,
+            "old",
+            (1, 2),
+            6,
+            cache_token_ids=(101, 102, 103, 104, 201, 202),
+            prompt_embed_cache_identity=_prompt_embed_identity(4, {4: fingerprint}),
+        )
+
+        loaded = []
+        result = manager.load_snapshot_for_request(
+            _request(
+                "new",
+                (1, 2),
+                6,
+                cache_token_ids=(301, 302, 303, 304, 201, 999),
+                prompt_embed_cache_identity=_prompt_embed_identity(4, {4: fingerprint}),
+            ),
+            lambda blobs, slot_id: loaded.append((blobs, slot_id)) or True,
+        )
+
+        assert result.loaded
+        assert result.matched_tokens == 5
+        assert loaded == [(["blob:old"], None)]
 
     def test_real_vllm_0112_cached_request_reused_physical_block_with_different_tokens_is_removed(self) -> None:
         manager = _make_manager(block_size=4)

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -66,6 +66,16 @@ def _store_snapshot(
     )
 
 
+def _vlm_identity(
+    session_id: str,
+    *,
+    offset: int = 2,
+    length: int = 2,
+    content: object = "image-a",
+) -> tuple[object, ...]:
+    return ("vlm", session_id, (("image", (offset, length, None), content),))
+
+
 class TestRuntimeCacheBlockHelpers:
     def test_normalize_and_append_block_ids_copy_inputs(self) -> None:
         current = ([1, 2], [10])
@@ -343,7 +353,7 @@ class TestMbltRuntimeCacheManagerSnapshots:
             (30,),
             4,
             cache_token_ids=(1, 2, 3, 4),
-            multimodal_cache_identity=("vlm", "session-a", (1, 2, None)),
+            multimodal_cache_identity=("vlm", "session-a", (0, 2, None)),
         )
 
         manager.observe_request_blocks("vlm-new", ([30],))
@@ -353,13 +363,144 @@ class TestMbltRuntimeCacheManagerSnapshots:
                 (30,),
                 4,
                 cache_token_ids=(1, 2, 3, 4),
-                multimodal_cache_identity=("vlm", "session-b", (1, 2, None)),
+                multimodal_cache_identity=("vlm", "session-b", (0, 2, None)),
             ),
             lambda blobs, slot_id: True,
         )
 
         assert result.cache_miss
         assert manager.get_snapshot("vlm-old") is None
+
+    def test_identityless_snapshot_is_rejected_when_vlm_prefix_overlaps_embedding(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(
+            manager,
+            "vlm-old",
+            (30,),
+            4,
+            cache_token_ids=(1, 2, 3, 4),
+            multimodal_cache_identity=None,
+        )
+
+        manager.observe_request_blocks("vlm-new", ([30],))
+        result = manager.load_snapshot_for_request(
+            _request(
+                "vlm-new",
+                (30,),
+                4,
+                cache_token_ids=(1, 2, 3, 4),
+                multimodal_cache_identity=_vlm_identity("session-a", offset=0, length=2),
+            ),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.cache_miss
+        assert result.matched_tokens == 0
+
+    def test_identityless_snapshot_can_match_text_only_prefix_before_vlm_embedding(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(
+            manager,
+            "vlm-old",
+            (30,),
+            4,
+            cache_token_ids=(1, 2, 3, 4),
+            multimodal_cache_identity=None,
+        )
+
+        match = manager.choose_snapshot(
+            _request(
+                "vlm-new",
+                (30,),
+                4,
+                cache_token_ids=(1, 2, 3, 4),
+                multimodal_cache_identity=_vlm_identity("session-a", offset=4, length=2),
+            )
+        )
+
+        assert match.req_id == "vlm-old"
+        assert match.matched_tokens == 4
+
+    def test_same_vlm_identity_reuses_snapshot(self) -> None:
+        manager = _make_manager(block_size=4)
+        identity = _vlm_identity("session-a", offset=2, length=2, content="same-image")
+        _store_snapshot(
+            manager,
+            "vlm-old",
+            (30,),
+            4,
+            cache_token_ids=(1, 2, 3, 4),
+            multimodal_cache_identity=identity,
+        )
+
+        result = manager.load_snapshot_for_request(
+            _request(
+                "vlm-new",
+                (30,),
+                4,
+                cache_token_ids=(1, 2, 3, 4),
+                multimodal_cache_identity=identity,
+            ),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.loaded
+        assert result.loaded_snapshot_req_id == "vlm-old"
+        assert result.matched_tokens == 4
+
+    def test_same_session_position_with_different_vlm_content_rejects_snapshot(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(
+            manager,
+            "vlm-old",
+            (30,),
+            4,
+            cache_token_ids=(1, 2, 3, 4),
+            multimodal_cache_identity=_vlm_identity("session-a", offset=0, length=2, content="image-a"),
+        )
+
+        manager.observe_request_blocks("vlm-new", ([30],))
+        result = manager.load_snapshot_for_request(
+            _request(
+                "vlm-new",
+                (30,),
+                4,
+                cache_token_ids=(1, 2, 3, 4),
+                multimodal_cache_identity=_vlm_identity("session-a", offset=0, length=2, content="image-b"),
+            ),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.cache_miss
+        assert result.matched_tokens == 0
+        assert manager.get_snapshot("vlm-old") is None
+
+    def test_unresolved_vlm_identity_trims_reuse_before_embedding_overlap(self) -> None:
+        manager = _make_manager(block_size=4)
+        unresolved_identity = _vlm_identity("session-a", offset=2, length=2, content=None)
+        _store_snapshot(
+            manager,
+            "vlm-old",
+            (30,),
+            4,
+            cache_token_ids=(1, 2, 3, 4),
+            multimodal_cache_identity=unresolved_identity,
+        )
+
+        result = manager.load_snapshot_for_request(
+            _request(
+                "vlm-new",
+                (30,),
+                4,
+                cache_token_ids=(1, 2, 3, 4),
+                multimodal_cache_identity=unresolved_identity,
+            ),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.loaded
+        assert result.loaded_snapshot_req_id == "vlm-old"
+        assert result.matched_tokens == 2
 
     def test_snapshot_update_and_removal_refresh_prefix_index(self) -> None:
         manager = _make_manager(block_size=4)

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -24,6 +24,7 @@ def _request(
     blocks: tuple[int, ...],
     tokens: int,
     *,
+    block_hashes: tuple[object, ...] | None = None,
     cache_slot_id: int | None = None,
     cache_token_ids: tuple[int, ...] | list[int] | None = None,
 ) -> RuntimeCacheRequest:
@@ -32,6 +33,7 @@ def _request(
         block_ids=(list(blocks),),
         first_seq_blocks=blocks,
         num_computed_tokens=tokens,
+        first_seq_block_hashes=block_hashes,
         cache_slot_id=cache_slot_id,
         cache_token_ids=tuple(cache_token_ids) if cache_token_ids is not None else None,
     )
@@ -45,6 +47,7 @@ def _store_snapshot(
     *,
     blobs: list[object] | None = None,
     cache_token_ids: tuple[int, ...] | list[int] | None = None,
+    block_hashes: tuple[object, ...] | None = None,
 ) -> None:
     block_tuple = tuple(blocks)
     block_ids = (list(block_tuple),)
@@ -53,6 +56,7 @@ def _store_snapshot(
         blobs=blobs if blobs is not None else [f"blob:{req_id}"],
         block_ids=block_ids,
         first_seq_blocks=first_seq_blocks(block_ids),
+        first_seq_block_hashes=block_hashes,
         num_tokens=tokens,
         cache_token_ids=cache_token_ids,
     )
@@ -180,6 +184,15 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert match.snapshot is None
         assert match.matched_tokens == 0
 
+    def test_hashed_snapshot_does_not_match_reused_physical_block_ids(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(manager, "old", (1, 2), 8, block_hashes=("old-a", "old-b"))
+
+        match = manager.choose_snapshot(_request("new", (1, 2), 8, block_hashes=("new-a", "new-b")))
+
+        assert match.snapshot is None
+        assert match.matched_tokens == 0
+
     def test_prefix_snapshot_selection_skips_incompatible_reused_block_candidate(self) -> None:
         manager = _make_manager(block_size=4)
         shared_blocks = (10, 11)
@@ -210,6 +223,31 @@ class TestMbltRuntimeCacheManagerSnapshots:
         assert match.req_id == "right-content"
         assert match.snapshot is manager.get_snapshot("right-content")
         assert match.matched_tokens == 8
+
+    def test_hashless_snapshot_invalidates_when_physical_block_owner_changes(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(manager, "old", (1, 2), 8)
+
+        evicted = manager.observe_request_blocks("new", ([1, 3],))
+
+        assert evicted == ["old"]
+        assert manager.get_snapshot("old") is None
+        assert manager.choose_snapshot(_request("new", (1, 2), 8)).snapshot is None
+
+    def test_hashless_load_invalidates_stale_snapshot_before_restore(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(manager, "old", (1, 2), 8)
+        load_calls = []
+
+        result = manager.load_snapshot_for_request(
+            _request("new", (1, 2), 8),
+            lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
+        )
+
+        assert result.cache_miss
+        assert result.matched_tokens == 0
+        assert load_calls == []
+        assert manager.get_snapshot("old") is None
 
     def test_snapshot_update_and_removal_refresh_prefix_index(self) -> None:
         manager = _make_manager(block_size=4)
@@ -305,11 +343,11 @@ class TestMbltRuntimeCacheManagerRuntimeDecisions:
 
     def test_single_cache_loads_useful_shared_prefix_snapshot(self) -> None:
         manager = _make_manager(block_size=4)
-        _store_snapshot(manager, "shared", (1, 2, 3), 12)
+        _store_snapshot(manager, "shared", (1, 2, 3), 12, block_hashes=("a", "b", "c"))
         load_calls = []
 
         result = manager.load_snapshot_for_request(
-            _request("req", (1, 2, 9), 10),
+            _request("req", (1, 2, 9), 10, block_hashes=("a", "b", "z")),
             lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
         )
 
@@ -469,9 +507,9 @@ class TestMbltRuntimeCacheManagerSlots:
         assert reused.matched_tokens == 4
         assert load_calls == []
 
-        _store_snapshot(manager, "other", (7, 8), 8)
+        _store_snapshot(manager, "other", (7, 8), 8, block_hashes=("a", "b"))
         loaded = manager.load_snapshot_for_slot(
-            _request("new", (7, 9), 8, cache_slot_id=slot_id),
+            _request("new", (7, 9), 8, block_hashes=("a", "z"), cache_slot_id=slot_id),
             lambda blobs, load_slot_id: load_calls.append((blobs, load_slot_id)) or True,
         )
 

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -25,6 +25,7 @@ def _request(
     tokens: int,
     *,
     cache_slot_id: int | None = None,
+    cache_token_ids: tuple[int, ...] | list[int] | None = None,
 ) -> RuntimeCacheRequest:
     return RuntimeCacheRequest(
         req_id=req_id,
@@ -32,6 +33,7 @@ def _request(
         first_seq_blocks=blocks,
         num_computed_tokens=tokens,
         cache_slot_id=cache_slot_id,
+        cache_token_ids=tuple(cache_token_ids) if cache_token_ids is not None else None,
     )
 
 
@@ -42,6 +44,7 @@ def _store_snapshot(
     tokens: int,
     *,
     blobs: list[object] | None = None,
+    cache_token_ids: tuple[int, ...] | list[int] | None = None,
 ) -> None:
     block_tuple = tuple(blocks)
     block_ids = (list(block_tuple),)
@@ -51,6 +54,7 @@ def _store_snapshot(
         block_ids=block_ids,
         first_seq_blocks=first_seq_blocks(block_ids),
         num_tokens=tokens,
+        cache_token_ids=cache_token_ids,
     )
 
 
@@ -153,6 +157,59 @@ class TestMbltRuntimeCacheManagerSnapshots:
 
         assert snapshot is None
         assert matched_tokens == 0
+
+    def test_prefix_snapshot_rejects_reused_physical_blocks_with_different_tokens(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(
+            manager,
+            "old-content",
+            (10, 11),
+            8,
+            cache_token_ids=(101, 102, 103, 104, 105, 106, 107, 108),
+        )
+
+        match = manager.choose_snapshot(
+            _request(
+                "new-content",
+                (10, 11),
+                8,
+                cache_token_ids=(201, 202, 203, 204, 205, 206, 207, 208),
+            )
+        )
+
+        assert match.snapshot is None
+        assert match.matched_tokens == 0
+
+    def test_prefix_snapshot_selection_skips_incompatible_reused_block_candidate(self) -> None:
+        manager = _make_manager(block_size=4)
+        shared_blocks = (10, 11)
+        _store_snapshot(
+            manager,
+            "wrong-content",
+            shared_blocks,
+            8,
+            cache_token_ids=(101, 102, 103, 104, 105, 106, 107, 108),
+        )
+        _store_snapshot(
+            manager,
+            "right-content",
+            shared_blocks,
+            8,
+            cache_token_ids=(201, 202, 203, 204, 205, 206, 207, 208),
+        )
+
+        match = manager.choose_snapshot(
+            _request(
+                "new-content",
+                shared_blocks,
+                8,
+                cache_token_ids=(201, 202, 203, 204, 205, 206, 207, 208),
+            )
+        )
+
+        assert match.req_id == "right-content"
+        assert match.snapshot is manager.get_snapshot("right-content")
+        assert match.matched_tokens == 8
 
     def test_snapshot_update_and_removal_refresh_prefix_index(self) -> None:
         manager = _make_manager(block_size=4)
@@ -273,6 +330,32 @@ class TestMbltRuntimeCacheManagerRuntimeDecisions:
         assert result.cache_miss
         assert manager.loaded_req_id is None
 
+    def test_single_cache_does_not_load_snapshot_for_reused_blocks_with_different_tokens(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(
+            manager,
+            "old-content",
+            (10, 11),
+            8,
+            blobs=["stale-runtime-cache"],
+            cache_token_ids=(101, 102, 103, 104, 105, 106, 107, 108),
+        )
+        load_calls = []
+
+        result = manager.load_snapshot_for_request(
+            _request(
+                "new-content",
+                (10, 11),
+                8,
+                cache_token_ids=(201, 202, 203, 204, 205, 206, 207, 208),
+            ),
+            lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
+        )
+
+        assert result.cache_miss
+        assert result.matched_tokens == 0
+        assert load_calls == []
+
     def test_dump_snapshot_if_needed_uses_injected_callable_and_block_boundary_policy(self) -> None:
         manager = _make_manager(block_size=4)
         dump_calls = []
@@ -303,6 +386,17 @@ class TestMbltRuntimeCacheManagerRuntimeDecisions:
         assert not not_dumped
         assert dump_calls == [None, None]
         assert manager.get_snapshot("req").blobs == ["blob:req:5"]
+
+    def test_dump_snapshot_if_needed_saves_token_identity_for_reused_block_detection(self) -> None:
+        manager = _make_manager(block_size=4)
+
+        dumped = manager.dump_snapshot_if_needed(
+            _request("req", (10, 11), 8, cache_token_ids=(101, 102, 103, 104, 105, 106, 107, 108)),
+            lambda slot_id: ["blob:req"],
+        )
+
+        assert dumped
+        assert manager.get_snapshot("req").cache_token_ids == (101, 102, 103, 104, 105, 106, 107, 108)
 
     def test_dump_live_request_before_switch_dumps_current_owner_when_needed(self) -> None:
         manager = _make_manager(block_size=4)

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -117,6 +117,7 @@ class RequestState:
     prompt_token_ids: list[int]
     cache_slot_id: Optional[int]
     vlm_session_id: Optional[str]
+    multimodal_cache_identity: Optional[Hashable] = None
     next_prompt_logprob_pos: int = 1
     in_progress_prompt_logprobs: Optional[LogprobsTensors] = None
 
@@ -2142,6 +2143,7 @@ class MbltWorker(WorkerBase):
                 first_seq_block_hashes=req_state.first_seq_block_hashes,
                 cache_slot_id=slot_id,
                 cache_token_ids=self._cache_token_ids(req_state, target_tokens),
+                multimodal_cache_identity=self._cache_multimodal_identity(req_state, target_tokens),
             )
         )
         if print_debug:
@@ -2240,6 +2242,7 @@ class MbltWorker(WorkerBase):
                 first_seq_block_hashes=req_state.first_seq_block_hashes,
                 cache_slot_id=slot_id,
                 cache_token_ids=self._cache_token_ids(req_state, target_tokens),
+                multimodal_cache_identity=self._cache_multimodal_identity(req_state, target_tokens),
             )
         )
         if print_debug:
@@ -2343,6 +2346,7 @@ class MbltWorker(WorkerBase):
             first_seq_block_hashes=req_state.first_seq_block_hashes,
             num_tokens=next_num_tokens,
             cache_token_ids=self._cache_token_ids(req_state, next_num_tokens),
+            multimodal_cache_identity=self._cache_multimodal_identity(req_state, next_num_tokens),
         )
         if print_debug:
             num_blocks = len(req_state.first_seq_blocks)
@@ -2359,6 +2363,16 @@ class MbltWorker(WorkerBase):
         if len(token_ids) < num_tokens:
             return None
         return tuple(token_ids[:num_tokens])
+
+    @staticmethod
+    def _cache_multimodal_identity(req_state: RequestState, num_tokens: int) -> Hashable | None:
+        if not req_state.is_multimodal:
+            return None
+        if req_state.multimodal_cache_identity is None:
+            return None
+        if max(0, int(num_tokens)) <= 0:
+            return None
+        return req_state.multimodal_cache_identity
 
     def _finalize_finished_request(
         self,
@@ -2690,6 +2704,11 @@ class MbltWorker(WorkerBase):
                 prompt_token_ids=new_req.prompt_token_ids or [],
                 cache_slot_id=cache_slot_id,
                 vlm_session_id=vlm_session_id,
+                multimodal_cache_identity=(
+                    ("vlm", vlm_session_id, self._vlm_image_positions_by_session.get(vlm_session_id))
+                    if new_req.mm_features
+                    else None
+                ),
             )
 
         # Continue cached requests

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -2029,9 +2029,12 @@ class MbltWorker(WorkerBase):
         return True
 
     @staticmethod
-    def _cache_token_ids(req_state: RequestState, num_tokens: int) -> tuple[int, ...]:
+    def _cache_token_ids(req_state: RequestState, num_tokens: int) -> tuple[int, ...] | None:
         token_ids = list(req_state.prompt_token_ids) + list(req_state.output_token_ids)
-        return tuple(token_ids[: max(0, int(num_tokens))])
+        num_tokens = max(0, int(num_tokens))
+        if len(token_ids) < num_tokens:
+            return None
+        return tuple(token_ids[:num_tokens])
 
     def _finalize_finished_request(
         self,

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1,5 +1,6 @@
 import math
 import os
+import statistics
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional
@@ -30,6 +31,7 @@ from vllm_mblt.mblt_platform import resolve_model_max_batch_size
 from vllm_mblt.runtime_cache import (
     KVBlockIds,
     MbltRuntimeCacheManager,
+    RuntimeCacheLoadResult,
     RuntimeCacheRequest,
     append_block_ids,
     first_seq_blocks,
@@ -177,6 +179,134 @@ class NormalBatchChunkState:
     last_token_logits: Optional[np.ndarray] = None
 
 
+class PrefixCacheCostModel:
+    """Worker-side policy for deciding if a matched runtime snapshot is worth loading."""
+
+    DEFAULT_MARGIN = 0.9
+    DEFAULT_EWMA_ALPHA = 0.3
+
+    def __init__(
+        self,
+        *,
+        block_size: int,
+        auto_threshold_enabled: bool = True,
+        manual_min_hit_tokens: Optional[int] = None,
+        margin: float = DEFAULT_MARGIN,
+        ewma_alpha: float = DEFAULT_EWMA_ALPHA,
+    ) -> None:
+        self.block_size = max(1, int(block_size))
+        self.auto_threshold_enabled = bool(auto_threshold_enabled)
+        self.manual_min_hit_tokens = (
+            max(0, int(manual_min_hit_tokens)) if manual_min_hit_tokens is not None else None
+        )
+        self.margin = float(margin)
+        if self.margin <= 0:
+            self.margin = self.DEFAULT_MARGIN
+        self.ewma_alpha = min(1.0, max(0.0, float(ewma_alpha)))
+        self.prefill_ms_by_tokens: dict[int, float] = {}
+        self.load_ms_by_cache_id: dict[int | None, float] = {}
+        self.dump_ms_by_cache_id: dict[int | None, float] = {}
+
+    @classmethod
+    def from_config(cls, config: object, *, block_size: int) -> "PrefixCacheCostModel":
+        def _config_value(name: str) -> object:
+            for root in (
+                getattr(getattr(config, "load_config", None), "model_loader_extra_config", None),
+                getattr(config, "model_loader_extra_config", None),
+                getattr(getattr(config, "model_config", None), "model_kwargs", None),
+                getattr(getattr(config, "model_config", None), "hf_overrides", None),
+            ):
+                if isinstance(root, dict) and name in root:
+                    return root[name]
+            return None
+
+        auto_value = os.getenv("VLLM_MBLT_PREFIX_CACHE_AUTO_THRESHOLD")
+        if auto_value is None:
+            auto_value = _config_value("prefix_cache_auto_threshold")
+        auto_enabled = True if auto_value is None else str(auto_value) not in {"0", "false", "FALSE", "False"}
+
+        manual_value = os.getenv("VLLM_MBLT_PREFIX_CACHE_MIN_HIT_TOKENS")
+        if manual_value is None:
+            manual_value = _config_value("prefix_cache_min_hit_tokens")
+        try:
+            manual_min_hit_tokens = None if manual_value in (None, "") else int(manual_value)
+        except (TypeError, ValueError):
+            manual_min_hit_tokens = None
+
+        margin_value = os.getenv("VLLM_MBLT_PREFIX_CACHE_LOAD_MARGIN")
+        if margin_value is None:
+            margin_value = _config_value("prefix_cache_load_margin")
+        try:
+            margin = cls.DEFAULT_MARGIN if margin_value in (None, "") else float(margin_value)
+        except (TypeError, ValueError):
+            margin = cls.DEFAULT_MARGIN
+
+        return cls(
+            block_size=block_size,
+            auto_threshold_enabled=auto_enabled,
+            manual_min_hit_tokens=manual_min_hit_tokens,
+            margin=margin,
+        )
+
+    def observe_prefill(self, num_tokens: int, elapsed_ms: float) -> None:
+        num_tokens = max(1, int(num_tokens))
+        elapsed_ms = max(0.0, float(elapsed_ms))
+        previous = self.prefill_ms_by_tokens.get(num_tokens)
+        if previous is None:
+            self.prefill_ms_by_tokens[num_tokens] = elapsed_ms
+        else:
+            self.prefill_ms_by_tokens[num_tokens] = self._ewma(previous, elapsed_ms)
+
+    def observe_load(self, cache_id: int | None, elapsed_ms: float) -> None:
+        self._observe_cache_io(self.load_ms_by_cache_id, cache_id, elapsed_ms)
+
+    def observe_dump(self, cache_id: int | None, elapsed_ms: float) -> None:
+        self._observe_cache_io(self.dump_ms_by_cache_id, cache_id, elapsed_ms)
+
+    def should_load(self, *, matched_tokens: int, cache_id: int | None = None) -> bool:
+        matched_tokens = max(0, int(matched_tokens))
+        if matched_tokens <= 0:
+            return False
+        if self.manual_min_hit_tokens is not None and matched_tokens < self.manual_min_hit_tokens:
+            return False
+        if not self.auto_threshold_enabled:
+            return True
+
+        load_ms = self.load_ms(cache_id)
+        prefill_ms = self.prefill_ms(matched_tokens)
+        if load_ms is None or prefill_ms is None:
+            return True
+        return load_ms < prefill_ms * self.margin
+
+    def prefill_ms(self, matched_tokens: int) -> Optional[float]:
+        if not self.prefill_ms_by_tokens:
+            return None
+        matched_tokens = max(1, int(matched_tokens))
+        measured = sorted(self.prefill_ms_by_tokens.items())
+        for tokens, elapsed_ms in measured:
+            if matched_tokens <= tokens:
+                return elapsed_ms * (matched_tokens / tokens)
+        tokens, elapsed_ms = measured[-1]
+        return elapsed_ms * (matched_tokens / tokens)
+
+    def load_ms(self, cache_id: int | None = None) -> Optional[float]:
+        if cache_id in self.load_ms_by_cache_id:
+            return self.load_ms_by_cache_id[cache_id]
+        if None in self.load_ms_by_cache_id:
+            return self.load_ms_by_cache_id[None]
+        if not self.load_ms_by_cache_id:
+            return None
+        return statistics.median(self.load_ms_by_cache_id.values())
+
+    def _observe_cache_io(self, values: dict[int | None, float], cache_id: int | None, elapsed_ms: float) -> None:
+        elapsed_ms = max(0.0, float(elapsed_ms))
+        previous = values.get(cache_id)
+        values[cache_id] = elapsed_ms if previous is None else self._ewma(previous, elapsed_ms)
+
+    def _ewma(self, previous: float, sample: float) -> float:
+        return previous * (1.0 - self.ewma_alpha) + sample * self.ewma_alpha
+
+
 class MbltWorker(WorkerBase):
     MAX_FINISHED_CACHE_SNAPSHOTS = 16
 
@@ -208,6 +338,10 @@ class MbltWorker(WorkerBase):
             max_finished_snapshots=self.MAX_FINISHED_CACHE_SNAPSHOTS,
             dump_runtime_cache=self._dump_runtime_cache,
             load_runtime_cache=self._load_runtime_cache,
+        )
+        self.prefix_cache_cost_model = PrefixCacheCostModel.from_config(
+            self.vllm_config,
+            block_size=self._kv_block_size(),
         )
         self.sampler = Sampler(logprobs_mode="raw_logits")
         self.empty_logits_processors = LogitsProcessors(None)
@@ -247,10 +381,23 @@ class MbltWorker(WorkerBase):
         return self.max_batch_size > 1
 
     def _kv_block_size(self) -> int:
-        configured = self.vllm_config.cache_config.block_size
+        configured = getattr(getattr(self.vllm_config, "cache_config", None), "block_size", None)
         if configured is None:
+            runtime_cache = getattr(self, "runtime_cache", None)
+            if runtime_cache is not None:
+                return int(getattr(runtime_cache, "block_size", 128))
             return 128
         return int(configured)
+
+    def _ensure_prefix_cache_cost_model(self) -> PrefixCacheCostModel:
+        cost_model = getattr(self, "prefix_cache_cost_model", None)
+        if cost_model is None:
+            cost_model = PrefixCacheCostModel.from_config(
+                self.vllm_config,
+                block_size=self._kv_block_size(),
+            )
+            self.prefix_cache_cost_model = cost_model
+        return cost_model
 
     def _num_blocks_per_request(self) -> int:
         return max(1, math.ceil(self.max_seq_len / self._kv_block_size()))
@@ -446,6 +593,63 @@ class MbltWorker(WorkerBase):
         else:
             cache_model.load_cache_memory(blobs, cache_id=slot_id)
         return True
+
+    def _timed_load_runtime_cache(self, blobs: list[Any], slot_id: Optional[int] = None) -> bool:
+        load_runtime_cache = getattr(self.runtime_cache, "_load_runtime_cache_fn", None) or self._load_runtime_cache
+        start = time.perf_counter()
+        loaded = load_runtime_cache(blobs, slot_id)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        self._ensure_prefix_cache_cost_model().observe_load(slot_id, elapsed_ms)
+        return loaded
+
+    def _timed_dump_runtime_cache(self, slot_id: Optional[int] = None) -> Optional[list[Any]]:
+        dump_runtime_cache = getattr(self.runtime_cache, "_dump_runtime_cache_fn", None) or self._dump_runtime_cache
+        start = time.perf_counter()
+        blobs = dump_runtime_cache(slot_id)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        self._ensure_prefix_cache_cost_model().observe_dump(slot_id, elapsed_ms)
+        return blobs
+
+    def _calibrate_prefix_cache_prefill_costs(self) -> None:
+        cost_model = self._ensure_prefix_cache_cost_model()
+        if not cost_model.auto_threshold_enabled:
+            return
+        if os.getenv("VLLM_MBLT_PREFIX_CACHE_CALIBRATE", "1") in {"0", "false", "FALSE", "False"}:
+            return
+        if self.input_embeddings is None or self.cache_model is None:
+            return
+        if not callable(getattr(self.input_embeddings, "__call__", None)):
+            return
+
+        block_size = self._kv_block_size()
+        bucket_blocks = (1, 2, 4, 8)
+        bucket_tokens = [
+            tokens
+            for tokens in (block_size * blocks for blocks in bucket_blocks)
+            if tokens <= self.max_seq_len
+        ]
+        if not bucket_tokens:
+            bucket_tokens = [min(block_size, self.max_seq_len)]
+
+        for num_tokens in bucket_tokens:
+            try:
+                embeds = self._embed_token_ids([0] * num_tokens)
+                samples_ms: list[float] = []
+                for sample_index in range(3):
+                    start = time.perf_counter()
+                    if self._is_batch_model():
+                        self._infer_logits_batch([embeds], cache_sizes=[0], cache_ids=[1])
+                    else:
+                        self._infer_logits(embeds, None, cache_size=0)
+                    elapsed_ms = (time.perf_counter() - start) * 1000.0
+                    if sample_index > 0:
+                        samples_ms.append(elapsed_ms)
+                if samples_ms:
+                    cost_model.observe_prefill(num_tokens, statistics.median(samples_ms))
+            except Exception as exc:
+                logger.debug("Skipping Mobilint prefix-cache prefill calibration: %s", exc)
+                break
+        self._infer_output_buffers = None
 
     def _make_batch_params(
         self,
@@ -1929,7 +2133,7 @@ class MbltWorker(WorkerBase):
             return 0
 
         target_tokens = req_state.num_computed_tokens
-        result = self.runtime_cache.load_for_request(
+        result = self._load_snapshot_for_request_with_cost_policy(
             RuntimeCacheRequest(
                 req_id=req_id,
                 block_ids=req_state.block_ids,
@@ -1949,9 +2153,67 @@ class MbltWorker(WorkerBase):
                 print(f"[cache] req={req_id} load-own matched={result.matched_tokens}/{target_tokens}")
             elif result.action == "load-shared":
                 print(f"[cache] req={req_id} load-shared matched={result.matched_tokens}/{target_tokens}")
+            elif result.action == "skip-cost":
+                print(f"[cache] req={req_id} skip-load-cost matched={result.matched_tokens}/{target_tokens}")
             else:
                 print(f"[cache] req={req_id} cache-miss fallback matched=0/{target_tokens}")
         return result.matched_tokens
+
+    def _load_snapshot_for_request_with_cost_policy(
+        self,
+        request: RuntimeCacheRequest,
+    ) -> RuntimeCacheLoadResult:
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            self.runtime_cache.clear_loaded_request()
+            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True, action="skip-empty")
+
+        self.runtime_cache.observe_request_blocks(
+            request.req_id,
+            request.block_ids,
+            first_seq_block_hashes=request.first_seq_block_hashes,
+        )
+
+        if self.runtime_cache.loaded_req_id == request.req_id:
+            return RuntimeCacheLoadResult(
+                matched_tokens=target_tokens,
+                reused_live_cache=True,
+                action="reuse-live",
+                snapshot_req_id=request.req_id,
+            )
+
+        match = self.runtime_cache.choose_snapshot(request)
+        if match.snapshot is None or match.matched_tokens <= 0:
+            self.runtime_cache.clear_loaded_request()
+            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+
+        if not self._ensure_prefix_cache_cost_model().should_load(
+            matched_tokens=match.matched_tokens,
+            cache_id=None,
+        ):
+            self.runtime_cache.clear_loaded_request()
+            return RuntimeCacheLoadResult(
+                matched_tokens=0,
+                cache_miss=True,
+                loaded_snapshot_req_id=match.req_id,
+                is_own_snapshot=match.is_own_snapshot,
+                action="skip-cost",
+                snapshot_req_id=match.req_id,
+            )
+
+        if self._timed_load_runtime_cache(match.snapshot.blobs, None):
+            self.runtime_cache.mark_loaded_request(request.req_id)
+            return RuntimeCacheLoadResult(
+                matched_tokens=match.matched_tokens,
+                loaded=True,
+                loaded_snapshot_req_id=match.req_id,
+                is_own_snapshot=match.is_own_snapshot,
+                action="load-own" if match.is_own_snapshot else "load-shared",
+                snapshot_req_id=match.req_id,
+            )
+
+        self.runtime_cache.clear_loaded_request()
+        return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
 
     def _load_snapshot_for_batch_slot(
         self,
@@ -1969,7 +2231,7 @@ class MbltWorker(WorkerBase):
             return 0
 
         target_tokens = req_state.num_computed_tokens
-        result = self.runtime_cache.load_for_slot(
+        result = self._load_snapshot_for_slot_with_cost_policy(
             RuntimeCacheRequest(
                 req_id=req_id,
                 block_ids=req_state.block_ids,
@@ -1978,8 +2240,7 @@ class MbltWorker(WorkerBase):
                 first_seq_block_hashes=req_state.first_seq_block_hashes,
                 cache_slot_id=slot_id,
                 cache_token_ids=self._cache_token_ids(req_state, target_tokens),
-            ),
-            slot_id=slot_id,
+            )
         )
         if print_debug:
             if result.action == "reuse-live":
@@ -1991,9 +2252,70 @@ class MbltWorker(WorkerBase):
                     f"[cache] req={req_id} slot={slot_id} "
                     f"load-shared matched={result.matched_tokens}/{target_tokens}"
                 )
+            elif result.action == "skip-cost":
+                print(
+                    f"[cache] req={req_id} slot={slot_id} "
+                    f"skip-load-cost matched={result.matched_tokens}/{target_tokens}"
+                )
             else:
                 print(f"[cache] req={req_id} slot={slot_id} cache-miss fallback matched=0/{target_tokens}")
         return result.matched_tokens
+
+    def _load_snapshot_for_slot_with_cost_policy(
+        self,
+        request: RuntimeCacheRequest,
+    ) -> RuntimeCacheLoadResult:
+        slot_id = request.cache_slot_id
+        if slot_id is None:
+            raise RuntimeError(f"Batch execution requires a cache slot for req_id={request.req_id}.")
+
+        target_tokens = request.num_computed_tokens
+        if target_tokens <= 0:
+            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True, action="skip-empty")
+
+        self.runtime_cache.observe_request_blocks(
+            request.req_id,
+            request.block_ids,
+            first_seq_block_hashes=request.first_seq_block_hashes,
+        )
+
+        if self.runtime_cache.live_slot_owner(slot_id) == request.req_id:
+            return RuntimeCacheLoadResult(
+                matched_tokens=target_tokens,
+                reused_live_cache=True,
+                action="reuse-live",
+                snapshot_req_id=request.req_id,
+            )
+
+        match = self.runtime_cache.choose_snapshot(request)
+        if match.snapshot is not None and match.matched_tokens > 0:
+            if not self._ensure_prefix_cache_cost_model().should_load(
+                matched_tokens=match.matched_tokens,
+                cache_id=slot_id,
+            ):
+                self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
+                return RuntimeCacheLoadResult(
+                    matched_tokens=0,
+                    cache_miss=True,
+                    loaded_snapshot_req_id=match.req_id,
+                    is_own_snapshot=match.is_own_snapshot,
+                    action="skip-cost",
+                    snapshot_req_id=match.req_id,
+                )
+
+            if self._timed_load_runtime_cache(match.snapshot.blobs, slot_id):
+                self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
+                return RuntimeCacheLoadResult(
+                    matched_tokens=match.matched_tokens,
+                    loaded=True,
+                    loaded_snapshot_req_id=match.req_id,
+                    is_own_snapshot=match.is_own_snapshot,
+                    action="load-own" if match.is_own_snapshot else "load-shared",
+                    snapshot_req_id=match.req_id,
+                )
+
+        self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
+        return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
 
     def _dump_snapshot(
         self,
@@ -2003,16 +2325,8 @@ class MbltWorker(WorkerBase):
         slot_id: Optional[int] = None,
         print_debug: bool = False,
     ) -> bool:
-        snapshot = self.runtime_cache.dump_and_store_snapshot(
-            req_id=req_id,
-            block_ids=req_state.block_ids,
-            first_seq_blocks=req_state.first_seq_blocks,
-            first_seq_block_hashes=req_state.first_seq_block_hashes,
-            num_tokens=next_num_tokens,
-            slot_id=slot_id,
-            cache_token_ids=self._cache_token_ids(req_state, next_num_tokens),
-        )
-        if snapshot is None:
+        blobs = self._timed_dump_runtime_cache(slot_id)
+        if blobs is None:
             if self._is_batch_model() and not self._warned_batch_cache_snapshot_unsupported:
                 logger.warning(
                     "Batch cache runtime does not expose slot-scoped dump/load APIs. "
@@ -2020,6 +2334,16 @@ class MbltWorker(WorkerBase):
                 )
                 self._warned_batch_cache_snapshot_unsupported = True
             return False
+
+        self.runtime_cache.store_snapshot(
+            req_id=req_id,
+            blobs=blobs,
+            block_ids=req_state.block_ids,
+            first_seq_blocks=req_state.first_seq_blocks,
+            first_seq_block_hashes=req_state.first_seq_block_hashes,
+            num_tokens=next_num_tokens,
+            cache_token_ids=self._cache_token_ids(req_state, next_num_tokens),
+        )
         if print_debug:
             num_blocks = len(req_state.first_seq_blocks)
             print(
@@ -2157,6 +2481,7 @@ class MbltWorker(WorkerBase):
         )
         self._reset_cache_slots()
         self._infer_output_buffers = None
+        self._calibrate_prefix_cache_prefill_costs()
         self._log_init_stage("load_model:done")
         return
 

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -2,7 +2,7 @@ import math
 import os
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional
 
 import numpy as np
 import torch
@@ -105,6 +105,7 @@ class RequestState:
     cached_sampling_state: "CachedSamplingState"
     block_ids: KVBlockIds
     first_seq_blocks: tuple[int, ...]
+    first_seq_block_hashes: Optional[tuple[Hashable, ...]]
     num_computed_tokens: int
     num_output_tokens: int
     prompt_embeds: np.ndarray
@@ -266,6 +267,56 @@ class MbltWorker(WorkerBase):
 
     def _first_seq_blocks(self, block_ids: KVBlockIds) -> tuple[int, ...]:
         return first_seq_blocks(block_ids)
+
+    def _extract_first_seq_block_hashes(
+        self,
+        source: object,
+        *,
+        candidates: tuple[str, ...] = ("block_hashes", "kv_block_hashes", "block_hash_ids"),
+    ) -> Optional[tuple[Hashable, ...]]:
+        for attr in candidates:
+            block_hashes = getattr(source, attr, None)
+            if block_hashes is None:
+                continue
+            if not block_hashes:
+                return ()
+            if isinstance(block_hashes[0], list):
+                return tuple(block_hashes[0])
+            return tuple(block_hashes)
+        return None
+
+    def _extract_indexed_first_seq_block_hashes(
+        self,
+        source: object,
+        index: int,
+        *,
+        candidates: tuple[str, ...],
+    ) -> Optional[tuple[Hashable, ...]]:
+        for attr in candidates:
+            block_hashes_by_req = getattr(source, attr, None)
+            if block_hashes_by_req is None:
+                continue
+            if not block_hashes_by_req:
+                return ()
+            try:
+                block_hashes = block_hashes_by_req[index]
+            except IndexError:
+                return None
+            if not block_hashes:
+                return ()
+            if isinstance(block_hashes[0], list):
+                return tuple(block_hashes[0])
+            return tuple(block_hashes)
+        return None
+
+    def _append_first_seq_block_hashes(
+        self,
+        current_hashes: Optional[tuple[Hashable, ...]],
+        new_hashes: Optional[tuple[Hashable, ...]],
+    ) -> Optional[tuple[Hashable, ...]]:
+        if current_hashes is None or new_hashes is None:
+            return None
+        return current_hashes + new_hashes
 
     def _get_cache_model(self) -> Any:
         if self.cache_model is None:
@@ -1884,6 +1935,7 @@ class MbltWorker(WorkerBase):
                 block_ids=req_state.block_ids,
                 first_seq_blocks=req_state.first_seq_blocks,
                 num_computed_tokens=target_tokens,
+                first_seq_block_hashes=req_state.first_seq_block_hashes,
                 cache_slot_id=slot_id,
                 cache_token_ids=self._cache_token_ids(req_state, target_tokens),
             )
@@ -1923,6 +1975,7 @@ class MbltWorker(WorkerBase):
                 block_ids=req_state.block_ids,
                 first_seq_blocks=req_state.first_seq_blocks,
                 num_computed_tokens=target_tokens,
+                first_seq_block_hashes=req_state.first_seq_block_hashes,
                 cache_slot_id=slot_id,
                 cache_token_ids=self._cache_token_ids(req_state, target_tokens),
             ),
@@ -1954,6 +2007,7 @@ class MbltWorker(WorkerBase):
             req_id=req_id,
             block_ids=req_state.block_ids,
             first_seq_blocks=req_state.first_seq_blocks,
+            first_seq_block_hashes=req_state.first_seq_block_hashes,
             num_tokens=next_num_tokens,
             slot_id=slot_id,
             cache_token_ids=self._cache_token_ids(req_state, next_num_tokens),
@@ -2276,6 +2330,12 @@ class MbltWorker(WorkerBase):
             )
 
             normalized_block_ids = self._normalize_block_ids(new_req.block_ids)
+            first_seq_block_hashes = self._extract_first_seq_block_hashes(new_req)
+            self.runtime_cache.observe_request_blocks(
+                new_req.req_id,
+                normalized_block_ids,
+                first_seq_block_hashes=first_seq_block_hashes,
+            )
             prompt_embeds_np = self._to_cpu_float32_numpy(prompt_embeds)
             prompt_deepstack_embeds_np = (
                 self._to_cpu_float32_numpy(prompt_deepstack_embeds) if prompt_deepstack_embeds is not None else None
@@ -2292,6 +2352,7 @@ class MbltWorker(WorkerBase):
                 ),
                 block_ids=normalized_block_ids,
                 first_seq_blocks=self._first_seq_blocks(normalized_block_ids),
+                first_seq_block_hashes=first_seq_block_hashes,
                 num_computed_tokens=new_req.num_computed_tokens,
                 num_output_tokens=0,
                 prompt_embeds=prompt_embeds_np,
@@ -2313,14 +2374,29 @@ class MbltWorker(WorkerBase):
 
             new_block_ids = scheduler_output.scheduled_cached_reqs.new_block_ids[i]
             if new_block_ids is not None:
+                new_block_hashes = self._extract_indexed_first_seq_block_hashes(
+                    scheduler_output.scheduled_cached_reqs,
+                    i,
+                    candidates=("new_block_hashes", "new_kv_block_hashes", "new_block_hash_ids"),
+                )
                 if req_id in scheduler_output.scheduled_cached_reqs.resumed_req_ids:
                     cached_request_state.block_ids = self._normalize_block_ids(new_block_ids)
+                    cached_request_state.first_seq_block_hashes = new_block_hashes
                 else:
                     cached_request_state.block_ids = self._append_block_ids(
                         cached_request_state.block_ids,
                         new_block_ids,
                     )
+                    cached_request_state.first_seq_block_hashes = self._append_first_seq_block_hashes(
+                        cached_request_state.first_seq_block_hashes,
+                        new_block_hashes,
+                    )
                 cached_request_state.first_seq_blocks = self._first_seq_blocks(cached_request_state.block_ids)
+                self.runtime_cache.observe_request_blocks(
+                    req_id,
+                    cached_request_state.block_ids,
+                    first_seq_block_hashes=cached_request_state.first_seq_block_hashes,
+                )
 
         batch_size = len(scheduler_output.num_scheduled_tokens)
 

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1,3 +1,4 @@
+import hashlib
 import math
 import os
 import statistics
@@ -571,6 +572,69 @@ class MbltWorker(WorkerBase):
             )
 
         positions_by_session[session_id] = position
+
+    @staticmethod
+    def _fingerprint_multimodal_value(value: object) -> tuple[str, tuple[int, ...], str, str] | None:
+        if value is None:
+            return None
+        value = getattr(value, "data", value)
+        try:
+            if isinstance(value, torch.Tensor):
+                tensor = value.detach().cpu()
+                if not tensor.is_contiguous():
+                    tensor = tensor.contiguous()
+                array = tensor.numpy()
+            else:
+                array = np.asarray(value)
+        except (TypeError, ValueError, RuntimeError):
+            return None
+
+        if array.dtype == object:
+            return None
+        if not array.flags.c_contiguous:
+            array = np.ascontiguousarray(array)
+
+        digest = hashlib.sha256()
+        digest.update(str(array.dtype).encode("utf-8"))
+        digest.update(repr(tuple(int(dim) for dim in array.shape)).encode("utf-8"))
+        digest.update(array.tobytes())
+        return ("sha256", tuple(int(dim) for dim in array.shape), str(array.dtype), digest.hexdigest())
+
+    @classmethod
+    def _multimodal_feature_content_fingerprint(cls, feature: MultiModalFeatureSpec) -> Hashable | None:
+        modality = str(getattr(feature, "modality", ""))
+        if modality.startswith("image"):
+            value_keys = ("pixel_values", "image_grid_thw")
+        elif modality.startswith("video"):
+            value_keys = ("pixel_values_videos", "video_grid_thw")
+        else:
+            return None
+
+        fingerprints: list[tuple[str, tuple[str, tuple[int, ...], str, str] | None]] = []
+        for key in value_keys:
+            value = cls._extract_multimodal_value(feature, key)
+            fingerprint = cls._fingerprint_multimodal_value(value)
+            if fingerprint is None:
+                return None
+            fingerprints.append((key, fingerprint))
+
+        return (modality, tuple(fingerprints))
+
+    @classmethod
+    def _build_vlm_multimodal_cache_identity(
+        cls,
+        session_id: str,
+        mm_features: Optional[list[MultiModalFeatureSpec]],
+    ) -> Hashable | None:
+        if not mm_features:
+            return None
+
+        entries = []
+        for feature in mm_features:
+            position = cls._multimodal_position_signature(feature.mm_position)
+            fingerprint = cls._multimodal_feature_content_fingerprint(feature)
+            entries.append((str(getattr(feature, "modality", "")), position, fingerprint))
+        return ("vlm", str(session_id), tuple(entries))
 
     def _get_cache_slot(self, req_id: str) -> int:
         return self.runtime_cache.get_slot(req_id)
@@ -2704,10 +2768,9 @@ class MbltWorker(WorkerBase):
                 prompt_token_ids=new_req.prompt_token_ids or [],
                 cache_slot_id=cache_slot_id,
                 vlm_session_id=vlm_session_id,
-                multimodal_cache_identity=(
-                    ("vlm", vlm_session_id, self._vlm_image_positions_by_session.get(vlm_session_id))
-                    if new_req.mm_features
-                    else None
+                multimodal_cache_identity=self._build_vlm_multimodal_cache_identity(
+                    vlm_session_id,
+                    new_req.mm_features,
                 ),
             )
 

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1885,6 +1885,7 @@ class MbltWorker(WorkerBase):
                 first_seq_blocks=req_state.first_seq_blocks,
                 num_computed_tokens=target_tokens,
                 cache_slot_id=slot_id,
+                cache_token_ids=self._cache_token_ids(req_state, target_tokens),
             )
         )
         if print_debug:
@@ -1923,6 +1924,7 @@ class MbltWorker(WorkerBase):
                 first_seq_blocks=req_state.first_seq_blocks,
                 num_computed_tokens=target_tokens,
                 cache_slot_id=slot_id,
+                cache_token_ids=self._cache_token_ids(req_state, target_tokens),
             ),
             slot_id=slot_id,
         )
@@ -1954,6 +1956,7 @@ class MbltWorker(WorkerBase):
             first_seq_blocks=req_state.first_seq_blocks,
             num_tokens=next_num_tokens,
             slot_id=slot_id,
+            cache_token_ids=self._cache_token_ids(req_state, next_num_tokens),
         )
         if snapshot is None:
             if self._is_batch_model() and not self._warned_batch_cache_snapshot_unsupported:
@@ -1970,6 +1973,11 @@ class MbltWorker(WorkerBase):
                 f"blocks={num_blocks} snapshots={self.runtime_cache.snapshot_count()}"
             )
         return True
+
+    @staticmethod
+    def _cache_token_ids(req_state: RequestState, num_tokens: int) -> tuple[int, ...]:
+        token_ids = list(req_state.prompt_token_ids) + list(req_state.output_token_ids)
+        return tuple(token_ids[: max(0, int(num_tokens))])
 
     def _finalize_finished_request(
         self,

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -32,6 +32,7 @@ from vllm_mblt.mblt_platform import resolve_model_max_batch_size
 from vllm_mblt.runtime_cache import (
     KVBlockIds,
     MbltRuntimeCacheManager,
+    PromptEmbedCacheIdentity,
     RuntimeCacheLoadResult,
     RuntimeCacheRequest,
     append_block_ids,
@@ -119,6 +120,7 @@ class RequestState:
     cache_slot_id: Optional[int]
     vlm_session_id: Optional[str]
     multimodal_cache_identity: Optional[Hashable] = None
+    explicit_prompt_embeds: bool = False
     next_prompt_logprob_pos: int = 1
     in_progress_prompt_logprobs: Optional[LogprobsTensors] = None
 
@@ -2208,6 +2210,7 @@ class MbltWorker(WorkerBase):
                 cache_slot_id=slot_id,
                 cache_token_ids=self._cache_token_ids(req_state, target_tokens),
                 multimodal_cache_identity=self._cache_multimodal_identity(req_state, target_tokens),
+                prompt_embed_cache_identity=self._make_prompt_embed_cache_identity(req_state),
             )
         )
         if print_debug:
@@ -2267,6 +2270,24 @@ class MbltWorker(WorkerBase):
                 snapshot_req_id=match.req_id,
             )
 
+        match = self.runtime_cache.verify_prompt_embed_match(request, match)
+        if match.snapshot is None or match.matched_tokens <= 0:
+            self.runtime_cache.clear_loaded_request()
+            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+        if not self._ensure_prefix_cache_cost_model().should_load(
+            matched_tokens=match.matched_tokens,
+            cache_id=None,
+        ):
+            self.runtime_cache.clear_loaded_request()
+            return RuntimeCacheLoadResult(
+                matched_tokens=0,
+                cache_miss=True,
+                loaded_snapshot_req_id=match.req_id,
+                is_own_snapshot=match.is_own_snapshot,
+                action="skip-cost",
+                snapshot_req_id=match.req_id,
+            )
+
         if self._timed_load_runtime_cache(match.snapshot.blobs, None):
             self.runtime_cache.mark_loaded_request(request.req_id)
             return RuntimeCacheLoadResult(
@@ -2307,6 +2328,7 @@ class MbltWorker(WorkerBase):
                 cache_slot_id=slot_id,
                 cache_token_ids=self._cache_token_ids(req_state, target_tokens),
                 multimodal_cache_identity=self._cache_multimodal_identity(req_state, target_tokens),
+                prompt_embed_cache_identity=self._make_prompt_embed_cache_identity(req_state),
             )
         )
         if print_debug:
@@ -2370,6 +2392,24 @@ class MbltWorker(WorkerBase):
                     snapshot_req_id=match.req_id,
                 )
 
+            match = self.runtime_cache.verify_prompt_embed_match(request, match)
+            if match.snapshot is None or match.matched_tokens <= 0:
+                self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
+                return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+            if not self._ensure_prefix_cache_cost_model().should_load(
+                matched_tokens=match.matched_tokens,
+                cache_id=slot_id,
+            ):
+                self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
+                return RuntimeCacheLoadResult(
+                    matched_tokens=0,
+                    cache_miss=True,
+                    loaded_snapshot_req_id=match.req_id,
+                    is_own_snapshot=match.is_own_snapshot,
+                    action="skip-cost",
+                    snapshot_req_id=match.req_id,
+                )
+
             if self._timed_load_runtime_cache(match.snapshot.blobs, slot_id):
                 self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
                 return RuntimeCacheLoadResult(
@@ -2411,6 +2451,7 @@ class MbltWorker(WorkerBase):
             num_tokens=next_num_tokens,
             cache_token_ids=self._cache_token_ids(req_state, next_num_tokens),
             multimodal_cache_identity=self._cache_multimodal_identity(req_state, next_num_tokens),
+            prompt_embed_cache_identity=self._make_prompt_embed_cache_identity(req_state),
         )
         if print_debug:
             num_blocks = len(req_state.first_seq_blocks)
@@ -2437,6 +2478,48 @@ class MbltWorker(WorkerBase):
         if max(0, int(num_tokens)) <= 0:
             return None
         return req_state.multimodal_cache_identity
+
+    @staticmethod
+    def _fingerprint_prompt_embed_prefix(
+        prompt_embeds: np.ndarray,
+        num_tokens: int,
+    ) -> Hashable | None:
+        num_tokens = max(0, int(num_tokens))
+        if num_tokens <= 0 or num_tokens > int(prompt_embeds.shape[0]):
+            return None
+        prefix = prompt_embeds[:num_tokens]
+        if prefix.dtype == object:
+            return None
+        if not prefix.flags.c_contiguous:
+            prefix = np.ascontiguousarray(prefix)
+        digest = hashlib.sha256()
+        digest.update(str(prefix.dtype).encode("utf-8"))
+        digest.update(repr(tuple(int(dim) for dim in prefix.shape)).encode("utf-8"))
+        digest.update(prefix.tobytes())
+        return ("sha256", tuple(int(dim) for dim in prefix.shape), str(prefix.dtype), digest.hexdigest())
+
+    def _make_prompt_embed_cache_identity(
+        self,
+        req_state: RequestState,
+    ) -> PromptEmbedCacheIdentity | None:
+        if not req_state.explicit_prompt_embeds:
+            return None
+        prompt_len = max(0, int(req_state.prompt_len))
+        if prompt_len <= 0:
+            return None
+        prompt_embeds = req_state.prompt_embeds
+        fingerprints: dict[int, Hashable | None] = {}
+
+        def fingerprint_for_prefix(num_tokens: int) -> Hashable | None:
+            num_tokens = max(0, int(num_tokens))
+            if num_tokens not in fingerprints:
+                fingerprints[num_tokens] = self._fingerprint_prompt_embed_prefix(prompt_embeds, num_tokens)
+            return fingerprints[num_tokens]
+
+        return PromptEmbedCacheIdentity(
+            prompt_len=prompt_len,
+            fingerprint_for_prefix=fingerprint_for_prefix,
+        )
 
     def _finalize_finished_request(
         self,
@@ -2772,6 +2855,7 @@ class MbltWorker(WorkerBase):
                     vlm_session_id,
                     new_req.mm_features,
                 ),
+                explicit_prompt_embeds=new_req.prompt_embeds is not None,
             )
 
         # Continue cached requests

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -2,7 +2,7 @@ import math
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Hashable
 
 KVBlockIds = tuple[list[int], ...]
 RuntimeCacheDumpFn = Callable[[int | None], list[Any] | None]
@@ -18,6 +18,7 @@ class RuntimeCacheSnapshot:
     first_seq_blocks: tuple[int, ...]
     num_tokens: int
     cache_token_ids: tuple[int, ...] | None = None
+    first_seq_block_hashes: tuple[Hashable, ...] | None = None
 
 
 @dataclass
@@ -28,11 +29,12 @@ class RuntimeCacheRequest:
     num_computed_tokens: int
     cache_slot_id: int | None = None
     cache_token_ids: tuple[int, ...] | None = None
+    first_seq_block_hashes: tuple[Hashable, ...] | None = None
 
 
 @dataclass
 class RuntimeCacheSnapshotIndexNode:
-    children: dict[int, "RuntimeCacheSnapshotIndexNode"] = field(default_factory=dict)
+    children: dict[Hashable, "RuntimeCacheSnapshotIndexNode"] = field(default_factory=dict)
     best_req_id: str | None = None
     best_num_tokens: int = 0
     req_ids: list[str] = field(default_factory=list)
@@ -97,6 +99,7 @@ class MbltRuntimeCacheManager:
         self.snapshots: dict[str, RuntimeCacheSnapshot] = {}
         self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
         self.finished_snapshot_lru: OrderedDict[str, None] = OrderedDict()
+        self.physical_block_owner: dict[int, str] = {}
 
         # Single-cache runtime owner.
         self.loaded_req_id: str | None = None
@@ -144,6 +147,52 @@ class MbltRuntimeCacheManager:
         self.slot_to_req = {}
         self.slot_live_req = {}
         self.free_slots = list(range(self.max_batch_size))
+
+    def _request_index_blocks(self, request: RuntimeCacheRequest) -> tuple[Hashable, ...]:
+        if request.first_seq_block_hashes is not None:
+            return tuple(("hash", block_hash) for block_hash in request.first_seq_block_hashes)
+        return tuple(("physical", block_id) for block_id in request.first_seq_blocks)
+
+    def _snapshot_index_blocks(self, snapshot: RuntimeCacheSnapshot) -> tuple[Hashable, ...]:
+        if snapshot.first_seq_block_hashes is not None:
+            return tuple(("hash", block_hash) for block_hash in snapshot.first_seq_block_hashes)
+        return tuple(("physical", block_id) for block_id in snapshot.first_seq_blocks)
+
+    def observe_request_blocks(
+        self,
+        req_id: str,
+        block_ids: KVBlockIds,
+        *,
+        first_seq_block_hashes: tuple[Hashable, ...] | None = None,
+    ) -> list[str]:
+        """Invalidate ID-keyed snapshots when vLLM reuses physical KV blocks.
+
+        Content-hashed requests/snapshots are safe to match across physical block
+        reuse. Hashless snapshots are only safe while their physical blocks have
+        not been observed under another request.
+        """
+        if first_seq_block_hashes is not None:
+            return []
+
+        stale_req_ids: set[str] = set()
+        for block_id in first_seq_blocks(block_ids):
+            owner = self.physical_block_owner.get(block_id)
+            if owner is None or owner == req_id:
+                continue
+            for snapshot_req_id, snapshot in self.snapshots.items():
+                if snapshot_req_id == req_id or snapshot.first_seq_block_hashes is not None:
+                    continue
+                if block_id in snapshot.first_seq_blocks:
+                    stale_req_ids.add(snapshot_req_id)
+
+        removed: list[str] = []
+        for stale_req_id in sorted(stale_req_ids):
+            if self.remove_snapshot(stale_req_id) is not None:
+                removed.append(stale_req_id)
+
+        for block_id in first_seq_blocks(block_ids):
+            self.physical_block_owner[block_id] = req_id
+        return removed
 
     def get_slot(self, req_id: str) -> int:
         slot_id = self.req_to_slot.get(req_id)
@@ -224,6 +273,7 @@ class MbltRuntimeCacheManager:
         blobs: list[Any],
         block_ids: KVBlockIds,
         first_seq_blocks: tuple[int, ...],
+        first_seq_block_hashes: tuple[Hashable, ...] | None = None,
         num_tokens: int,
         cache_token_ids: tuple[int, ...] | list[int] | None = None,
     ) -> RuntimeCacheSnapshot:
@@ -232,10 +282,14 @@ class MbltRuntimeCacheManager:
             blobs=blobs,
             block_ids=normalize_block_ids(block_ids),
             first_seq_blocks=tuple(first_seq_blocks),
+            first_seq_block_hashes=tuple(first_seq_block_hashes) if first_seq_block_hashes is not None else None,
             num_tokens=max(0, int(num_tokens)),
             cache_token_ids=tuple(cache_token_ids) if cache_token_ids is not None else None,
         )
         self.snapshots[req_id] = snapshot
+        if snapshot.first_seq_block_hashes is None:
+            for block_id in snapshot.first_seq_blocks:
+                self.physical_block_owner[block_id] = req_id
         self.rebuild_snapshot_index()
         return snapshot
 
@@ -263,8 +317,8 @@ class MbltRuntimeCacheManager:
         for req_id, snapshot in self.snapshots.items():
             node = root
             self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
-            for block_id in snapshot.first_seq_blocks:
-                node = node.children.setdefault(block_id, RuntimeCacheSnapshotIndexNode())
+            for block_key in self._snapshot_index_blocks(snapshot):
+                node = node.children.setdefault(block_key, RuntimeCacheSnapshotIndexNode())
                 self._update_snapshot_index_node(node, req_id, snapshot.num_tokens)
         self.snapshot_index_root = root
 
@@ -305,6 +359,7 @@ class MbltRuntimeCacheManager:
         req_id: str,
         block_ids: KVBlockIds,
         first_seq_blocks: tuple[int, ...],
+        first_seq_block_hashes: tuple[Hashable, ...] | None = None,
         num_tokens: int,
         slot_id: int | None = None,
         cache_token_ids: tuple[int, ...] | list[int] | None = None,
@@ -319,6 +374,7 @@ class MbltRuntimeCacheManager:
             blobs=blobs,
             block_ids=block_ids,
             first_seq_blocks=first_seq_blocks,
+            first_seq_block_hashes=first_seq_block_hashes,
             num_tokens=num_tokens,
             cache_token_ids=cache_token_ids,
         )
@@ -330,8 +386,10 @@ class MbltRuntimeCacheManager:
     ) -> RuntimeCacheSnapshotMatch:
         request = target_blocks if isinstance(target_blocks, RuntimeCacheRequest) else None
         if request is not None:
-            target_blocks = request.first_seq_blocks
+            target_blocks = self._request_index_blocks(request)
             target_tokens = request.num_computed_tokens
+        else:
+            target_blocks = tuple(("physical", block_id) for block_id in target_blocks)
         if target_tokens is None:
             raise TypeError("target_tokens is required when target_blocks is not a RuntimeCacheRequest")
         if target_tokens <= 0 or not target_blocks:
@@ -371,9 +429,9 @@ class MbltRuntimeCacheManager:
         own_snapshot = self.snapshots.get(request.req_id)
         if own_snapshot is not None:
             matched_tokens = self.compatible_tokens(
-                target_blocks=request.first_seq_blocks,
+                target_blocks=self._request_index_blocks(request),
                 target_tokens=target_tokens,
-                snapshot_blocks=own_snapshot.first_seq_blocks,
+                snapshot_blocks=self._snapshot_index_blocks(own_snapshot),
                 snapshot_tokens=own_snapshot.num_tokens,
                 target_token_ids=request.cache_token_ids,
                 snapshot_token_ids=own_snapshot.cache_token_ids,
@@ -391,9 +449,9 @@ class MbltRuntimeCacheManager:
     def compatible_tokens(
         self,
         *,
-        target_blocks: tuple[int, ...],
+        target_blocks: tuple[Hashable, ...],
         target_tokens: int,
-        snapshot_blocks: tuple[int, ...],
+        snapshot_blocks: tuple[Hashable, ...],
         snapshot_tokens: int,
         target_token_ids: tuple[int, ...] | None = None,
         snapshot_token_ids: tuple[int, ...] | None = None,
@@ -436,6 +494,7 @@ class MbltRuntimeCacheManager:
             blobs=blobs,
             block_ids=request.block_ids,
             first_seq_blocks=request.first_seq_blocks,
+            first_seq_block_hashes=request.first_seq_block_hashes,
             num_tokens=request.num_computed_tokens,
             cache_token_ids=request.cache_token_ids,
         )
@@ -463,6 +522,12 @@ class MbltRuntimeCacheManager:
         if target_tokens <= 0:
             self.clear_loaded_request()
             return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True, action="skip-empty")
+
+        self.observe_request_blocks(
+            request.req_id,
+            request.block_ids,
+            first_seq_block_hashes=request.first_seq_block_hashes,
+        )
 
         if self.loaded_req_id == request.req_id:
             return RuntimeCacheLoadResult(
@@ -510,6 +575,12 @@ class MbltRuntimeCacheManager:
         if target_tokens <= 0:
             return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True, action="skip-empty")
 
+        self.observe_request_blocks(
+            request.req_id,
+            request.block_ids,
+            first_seq_block_hashes=request.first_seq_block_hashes,
+        )
+
         if self.live_slot_owner(slot_id) == request.req_id:
             return RuntimeCacheLoadResult(
                 matched_tokens=target_tokens,
@@ -544,6 +615,7 @@ class MbltRuntimeCacheManager:
                 block_ids=request.block_ids,
                 first_seq_blocks=request.first_seq_blocks,
                 num_computed_tokens=request.num_computed_tokens,
+                first_seq_block_hashes=request.first_seq_block_hashes,
                 cache_slot_id=slot_id,
             )
         return self.load_snapshot_for_slot(request)
@@ -573,6 +645,7 @@ class MbltRuntimeCacheManager:
         self.snapshots.clear()
         self.finished_snapshot_lru.clear()
         self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
+        self.physical_block_owner.clear()
         self.loaded_req_id = None
         self.reset_slots()
 

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -774,11 +774,124 @@ def multimodal_compatible_tokens(
 ) -> int:
     if matched_tokens <= 0:
         return 0
-    if snapshot_multimodal_identity is None:
+    if target_multimodal_identity is None and snapshot_multimodal_identity is None:
         return matched_tokens
-    if target_multimodal_identity == snapshot_multimodal_identity:
+
+    if (
+        target_multimodal_identity is not None
+        and snapshot_multimodal_identity is not None
+        and _is_resolved_multimodal_identity(target_multimodal_identity)
+        and _is_resolved_multimodal_identity(snapshot_multimodal_identity)
+        and target_multimodal_identity == snapshot_multimodal_identity
+    ):
         return matched_tokens
-    return 0
+
+    text_only_limit = _known_text_only_prefix_limit(
+        target_multimodal_identity,
+        snapshot_multimodal_identity,
+    )
+    if text_only_limit is None:
+        return 0
+    return min(matched_tokens, text_only_limit)
+
+
+def _known_text_only_prefix_limit(
+    target_multimodal_identity: Hashable | None,
+    snapshot_multimodal_identity: Hashable | None,
+) -> int | None:
+    starts: list[int] = []
+    for identity in (target_multimodal_identity, snapshot_multimodal_identity):
+        spans = _multimodal_identity_spans(identity)
+        if spans is None:
+            if identity is not None:
+                return None
+            continue
+        starts.extend(start for start, _end in spans)
+
+    if not starts:
+        return None
+    return max(0, min(starts))
+
+
+def _is_resolved_multimodal_identity(identity: Hashable) -> bool:
+    if not isinstance(identity, tuple) or not identity:
+        return True
+    if identity[0] != "vlm":
+        return True
+
+    entries = _vlm_identity_entries(identity)
+    if entries is None:
+        return False
+    return all(_vlm_entry_content_fingerprint(entry) is not None for entry in entries)
+
+
+def _multimodal_identity_spans(identity: Hashable | None) -> tuple[tuple[int, int], ...] | None:
+    if identity is None:
+        return None
+    if not isinstance(identity, tuple) or not identity:
+        return None
+    if identity[0] != "vlm":
+        return None
+
+    entries = _vlm_identity_entries(identity)
+    if entries is None:
+        return None
+
+    spans: list[tuple[int, int]] = []
+    for entry in entries:
+        position = _vlm_entry_position_signature(entry)
+        if position is None:
+            return None
+        offset, length, _embed_signature = position
+        spans.append((offset, offset + length))
+    return tuple(spans)
+
+
+def _vlm_identity_entries(identity: tuple[object, ...]) -> tuple[object, ...] | None:
+    if len(identity) < 3:
+        return None
+
+    payload = identity[2]
+    if _is_position_signature(payload):
+        # Legacy identity shape: ("vlm", session_id, position_signature). It
+        # proves the text-only prefix boundary but not multimodal content.
+        return (("legacy", payload, None),)
+
+    if isinstance(payload, tuple) and all(_is_vlm_identity_entry(entry) for entry in payload):
+        return payload
+
+    return None
+
+
+def _is_vlm_identity_entry(entry: object) -> bool:
+    return isinstance(entry, tuple) and len(entry) >= 3 and _is_position_signature(entry[1])
+
+
+def _vlm_entry_position_signature(entry: object) -> tuple[int, int, object] | None:
+    if not isinstance(entry, tuple):
+        return None
+    if _is_position_signature(entry):
+        position = entry
+    elif len(entry) >= 2 and _is_position_signature(entry[1]):
+        position = entry[1]
+    else:
+        return None
+    return (int(position[0]), int(position[1]), position[2])
+
+
+def _vlm_entry_content_fingerprint(entry: object) -> object | None:
+    if not isinstance(entry, tuple):
+        return None
+    if len(entry) >= 3:
+        return entry[2]
+    return None
+
+
+def _is_position_signature(value: object) -> bool:
+    if not isinstance(value, tuple) or len(value) != 3:
+        return False
+    offset, length, _embed_signature = value
+    return isinstance(offset, int) and isinstance(length, int)
 
 
 def physical_prefix_overlaps(

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -12,6 +12,20 @@ LoadRuntimeCache = RuntimeCacheLoadFn
 
 
 @dataclass
+class PromptEmbedCacheIdentity:
+    prompt_len: int
+    fingerprint_for_prefix: Callable[[int], Hashable | None]
+
+    def fingerprint(self, num_tokens: int) -> Hashable | None:
+        num_tokens = max(0, int(num_tokens))
+        if num_tokens <= 0:
+            return None
+        if num_tokens > self.prompt_len:
+            return None
+        return self.fingerprint_for_prefix(num_tokens)
+
+
+@dataclass
 class RuntimeCacheSnapshot:
     blobs: list[Any]
     block_ids: KVBlockIds
@@ -20,6 +34,7 @@ class RuntimeCacheSnapshot:
     cache_token_ids: tuple[int, ...] | None = None
     multimodal_cache_identity: Hashable | None = None
     first_seq_block_hashes: tuple[Hashable, ...] | None = None
+    prompt_embed_cache_identity: PromptEmbedCacheIdentity | None = None
 
 
 @dataclass
@@ -32,6 +47,7 @@ class RuntimeCacheRequest:
     cache_token_ids: tuple[int, ...] | None = None
     multimodal_cache_identity: Hashable | None = None
     first_seq_block_hashes: tuple[Hashable, ...] | None = None
+    prompt_embed_cache_identity: PromptEmbedCacheIdentity | None = None
 
 
 @dataclass
@@ -243,6 +259,7 @@ class MbltRuntimeCacheManager:
         first_seq_block_ids: tuple[int, ...] | None = None,
         cache_token_ids: tuple[int, ...] | list[int] | None = None,
         multimodal_cache_identity: Hashable | None = None,
+        prompt_embed_cache_identity: PromptEmbedCacheIdentity | None = None,
     ) -> RuntimeCacheSnapshot:
         return self.store_snapshot(
             req_id=req_id,
@@ -252,6 +269,7 @@ class MbltRuntimeCacheManager:
             num_tokens=num_tokens,
             cache_token_ids=cache_token_ids,
             multimodal_cache_identity=multimodal_cache_identity,
+            prompt_embed_cache_identity=prompt_embed_cache_identity,
         )
 
     def store_snapshot(
@@ -265,6 +283,7 @@ class MbltRuntimeCacheManager:
         num_tokens: int,
         cache_token_ids: tuple[int, ...] | list[int] | None = None,
         multimodal_cache_identity: Hashable | None = None,
+        prompt_embed_cache_identity: PromptEmbedCacheIdentity | None = None,
     ) -> RuntimeCacheSnapshot:
         self.finished_snapshot_lru.pop(req_id, None)
         snapshot = RuntimeCacheSnapshot(
@@ -275,6 +294,7 @@ class MbltRuntimeCacheManager:
             num_tokens=max(0, int(num_tokens)),
             cache_token_ids=tuple(cache_token_ids) if cache_token_ids is not None else None,
             multimodal_cache_identity=multimodal_cache_identity,
+            prompt_embed_cache_identity=prompt_embed_cache_identity,
         )
         self.snapshots[req_id] = snapshot
         if snapshot.first_seq_block_hashes is None:
@@ -354,6 +374,7 @@ class MbltRuntimeCacheManager:
         slot_id: int | None = None,
         cache_token_ids: tuple[int, ...] | list[int] | None = None,
         multimodal_cache_identity: Hashable | None = None,
+        prompt_embed_cache_identity: PromptEmbedCacheIdentity | None = None,
     ) -> RuntimeCacheSnapshot | None:
         if self._dump_runtime_cache_fn is None:
             raise RuntimeError("Runtime cache dump adapter is not configured.")
@@ -369,6 +390,7 @@ class MbltRuntimeCacheManager:
             num_tokens=num_tokens,
             cache_token_ids=cache_token_ids,
             multimodal_cache_identity=multimodal_cache_identity,
+            prompt_embed_cache_identity=prompt_embed_cache_identity,
         )
 
     def choose_prefix_snapshot(
@@ -418,10 +440,12 @@ class MbltRuntimeCacheManager:
                 ):
                     stale_req_ids.add(req_id)
                     continue
-                token_matched_tokens = token_compatible_tokens(
+                token_matched_tokens = token_compatible_tokens_for_prompt_embeds(
                     matched_tokens,
                     request.cache_token_ids if request is not None else None,
                     snapshot.cache_token_ids,
+                    request.prompt_embed_cache_identity if request is not None else None,
+                    snapshot.prompt_embed_cache_identity,
                 )
                 matched_tokens = multimodal_compatible_tokens(
                     token_matched_tokens,
@@ -468,6 +492,8 @@ class MbltRuntimeCacheManager:
                 snapshot_token_ids=own_snapshot.cache_token_ids,
                 target_multimodal_identity=request.multimodal_cache_identity,
                 snapshot_multimodal_identity=own_snapshot.multimodal_cache_identity,
+                target_prompt_embed_identity=request.prompt_embed_cache_identity,
+                snapshot_prompt_embed_identity=own_snapshot.prompt_embed_cache_identity,
             )
             if matched_tokens >= target_tokens:
                 return RuntimeCacheSnapshotMatch(
@@ -478,6 +504,32 @@ class MbltRuntimeCacheManager:
                 )
 
         return self.choose_prefix_snapshot(request)
+
+    def verify_prompt_embed_match(
+        self,
+        request: RuntimeCacheRequest,
+        match: RuntimeCacheSnapshotMatch,
+    ) -> RuntimeCacheSnapshotMatch:
+        if match.snapshot is None or match.matched_tokens <= 0:
+            return match
+
+        matched_tokens = prompt_embed_compatible_tokens(
+            match.matched_tokens,
+            request.prompt_embed_cache_identity,
+            match.snapshot.prompt_embed_cache_identity,
+            request.cache_token_ids,
+            match.snapshot.cache_token_ids,
+        )
+        if matched_tokens <= 0:
+            return RuntimeCacheSnapshotMatch(snapshot=None, matched_tokens=0)
+        if matched_tokens == match.matched_tokens:
+            return match
+        return RuntimeCacheSnapshotMatch(
+            snapshot=match.snapshot,
+            matched_tokens=matched_tokens,
+            req_id=match.req_id,
+            is_own_snapshot=match.is_own_snapshot,
+        )
 
     def compatible_tokens(
         self,
@@ -490,6 +542,8 @@ class MbltRuntimeCacheManager:
         snapshot_token_ids: tuple[int, ...] | None = None,
         target_multimodal_identity: Hashable | None = None,
         snapshot_multimodal_identity: Hashable | None = None,
+        target_prompt_embed_identity: PromptEmbedCacheIdentity | None = None,
+        snapshot_prompt_embed_identity: PromptEmbedCacheIdentity | None = None,
     ) -> int:
         matched_tokens = prefix_compatible_tokens(
             target_blocks,
@@ -498,7 +552,13 @@ class MbltRuntimeCacheManager:
             snapshot_tokens,
             self.block_size,
         )
-        matched_tokens = token_compatible_tokens(matched_tokens, target_token_ids, snapshot_token_ids)
+        matched_tokens = token_compatible_tokens_for_prompt_embeds(
+            matched_tokens,
+            target_token_ids,
+            snapshot_token_ids,
+            target_prompt_embed_identity,
+            snapshot_prompt_embed_identity,
+        )
         return multimodal_compatible_tokens(matched_tokens, target_multimodal_identity, snapshot_multimodal_identity)
 
     def required_blocks(self, num_tokens: int) -> int:
@@ -534,6 +594,7 @@ class MbltRuntimeCacheManager:
             num_tokens=request.num_computed_tokens,
             cache_token_ids=request.cache_token_ids,
             multimodal_cache_identity=request.multimodal_cache_identity,
+            prompt_embed_cache_identity=request.prompt_embed_cache_identity,
         )
         return True
 
@@ -575,6 +636,7 @@ class MbltRuntimeCacheManager:
             )
 
         match = self.choose_snapshot(request)
+        match = self.verify_prompt_embed_match(request, match)
         if match.snapshot is None or match.matched_tokens <= 0:
             self.clear_loaded_request()
             return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
@@ -627,6 +689,7 @@ class MbltRuntimeCacheManager:
             )
 
         match = self.choose_snapshot(request)
+        match = self.verify_prompt_embed_match(request, match)
         if match.snapshot is not None and match.matched_tokens > 0:
             load_runtime_cache = load_runtime_cache or self._load_runtime_cache_fn
             if load_runtime_cache is None:
@@ -656,6 +719,7 @@ class MbltRuntimeCacheManager:
                 cache_token_ids=request.cache_token_ids,
                 multimodal_cache_identity=request.multimodal_cache_identity,
                 cache_slot_id=slot_id,
+                prompt_embed_cache_identity=request.prompt_embed_cache_identity,
             )
         return self.load_snapshot_for_slot(request)
 
@@ -760,6 +824,94 @@ def token_compatible_tokens(
     common_tokens = 0
     for target_token_id, snapshot_token_id in zip(target_token_ids, snapshot_token_ids):
         if target_token_id != snapshot_token_id:
+            break
+        common_tokens += 1
+        if common_tokens >= matched_tokens:
+            break
+    return min(matched_tokens, common_tokens)
+
+
+def token_compatible_tokens_for_prompt_embeds(
+    matched_tokens: int,
+    target_token_ids: tuple[int, ...] | None,
+    snapshot_token_ids: tuple[int, ...] | None,
+    target_identity: PromptEmbedCacheIdentity | None,
+    snapshot_identity: PromptEmbedCacheIdentity | None,
+) -> int:
+    if target_identity is None and snapshot_identity is None:
+        return token_compatible_tokens(matched_tokens, target_token_ids, snapshot_token_ids)
+    if matched_tokens <= 0:
+        return 0
+    if target_identity is None or snapshot_identity is None:
+        return 0
+
+    target_prompt_len = max(0, int(target_identity.prompt_len))
+    snapshot_prompt_len = max(0, int(snapshot_identity.prompt_len))
+    embed_limit = min(target_prompt_len, snapshot_prompt_len)
+    if embed_limit <= 0:
+        return 0
+    if matched_tokens <= embed_limit:
+        return matched_tokens
+    if target_prompt_len != snapshot_prompt_len:
+        return embed_limit
+    if target_token_ids is None or snapshot_token_ids is None:
+        return embed_limit
+
+    common_tokens = target_prompt_len
+    for idx in range(target_prompt_len, min(matched_tokens, len(target_token_ids), len(snapshot_token_ids))):
+        if target_token_ids[idx] != snapshot_token_ids[idx]:
+            break
+        common_tokens += 1
+        if common_tokens >= matched_tokens:
+            break
+    return min(matched_tokens, common_tokens)
+
+
+def prompt_embed_compatible_tokens(
+    matched_tokens: int,
+    target_identity: PromptEmbedCacheIdentity | None,
+    snapshot_identity: PromptEmbedCacheIdentity | None,
+    target_token_ids: tuple[int, ...] | None,
+    snapshot_token_ids: tuple[int, ...] | None,
+) -> int:
+    if matched_tokens <= 0:
+        return 0
+    if target_identity is None and snapshot_identity is None:
+        return token_compatible_tokens(matched_tokens, target_token_ids, snapshot_token_ids)
+
+    # Explicit prompt embeddings replace token embeddings from position 0, so
+    # any cross-request reuse touching that prefix must prove byte-identical
+    # embedding content. If only one side has explicit embeddings, exact
+    # equivalence to token-derived embeddings is not available here.
+    if target_identity is None or snapshot_identity is None:
+        return 0
+
+    target_prompt_len = max(0, int(target_identity.prompt_len))
+    snapshot_prompt_len = max(0, int(snapshot_identity.prompt_len))
+    embed_tokens = min(matched_tokens, target_prompt_len, snapshot_prompt_len)
+    if embed_tokens <= 0:
+        return 0
+
+    target_fingerprint = target_identity.fingerprint(embed_tokens)
+    snapshot_fingerprint = snapshot_identity.fingerprint(embed_tokens)
+    if target_fingerprint is None or snapshot_fingerprint is None:
+        return 0
+    if target_fingerprint != snapshot_fingerprint:
+        return 0
+
+    embed_limit = min(target_prompt_len, snapshot_prompt_len)
+    if matched_tokens <= embed_limit:
+        return matched_tokens
+
+    if target_prompt_len != snapshot_prompt_len:
+        return embed_limit
+
+    if target_token_ids is None or snapshot_token_ids is None:
+        return embed_limit
+
+    common_tokens = target_prompt_len
+    for idx in range(target_prompt_len, min(matched_tokens, len(target_token_ids), len(snapshot_token_ids))):
+        if target_token_ids[idx] != snapshot_token_ids[idx]:
             break
         common_tokens += 1
         if common_tokens >= matched_tokens:

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -616,6 +616,7 @@ class MbltRuntimeCacheManager:
                 first_seq_blocks=request.first_seq_blocks,
                 num_computed_tokens=request.num_computed_tokens,
                 first_seq_block_hashes=request.first_seq_block_hashes,
+                cache_token_ids=request.cache_token_ids,
                 cache_slot_id=slot_id,
             )
         return self.load_snapshot_for_slot(request)

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -17,6 +17,7 @@ class RuntimeCacheSnapshot:
     block_ids: KVBlockIds
     first_seq_blocks: tuple[int, ...]
     num_tokens: int
+    cache_token_ids: tuple[int, ...] | None = None
 
 
 @dataclass
@@ -26,6 +27,7 @@ class RuntimeCacheRequest:
     first_seq_blocks: tuple[int, ...]
     num_computed_tokens: int
     cache_slot_id: int | None = None
+    cache_token_ids: tuple[int, ...] | None = None
 
 
 @dataclass
@@ -33,6 +35,7 @@ class RuntimeCacheSnapshotIndexNode:
     children: dict[int, "RuntimeCacheSnapshotIndexNode"] = field(default_factory=dict)
     best_req_id: str | None = None
     best_num_tokens: int = 0
+    req_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -203,6 +206,7 @@ class MbltRuntimeCacheManager:
         block_ids: KVBlockIds,
         num_tokens: int,
         first_seq_block_ids: tuple[int, ...] | None = None,
+        cache_token_ids: tuple[int, ...] | list[int] | None = None,
     ) -> RuntimeCacheSnapshot:
         return self.store_snapshot(
             req_id=req_id,
@@ -210,6 +214,7 @@ class MbltRuntimeCacheManager:
             block_ids=block_ids,
             first_seq_blocks=first_seq_block_ids if first_seq_block_ids is not None else first_seq_blocks(block_ids),
             num_tokens=num_tokens,
+            cache_token_ids=cache_token_ids,
         )
 
     def store_snapshot(
@@ -220,6 +225,7 @@ class MbltRuntimeCacheManager:
         block_ids: KVBlockIds,
         first_seq_blocks: tuple[int, ...],
         num_tokens: int,
+        cache_token_ids: tuple[int, ...] | list[int] | None = None,
     ) -> RuntimeCacheSnapshot:
         self.finished_snapshot_lru.pop(req_id, None)
         snapshot = RuntimeCacheSnapshot(
@@ -227,6 +233,7 @@ class MbltRuntimeCacheManager:
             block_ids=normalize_block_ids(block_ids),
             first_seq_blocks=tuple(first_seq_blocks),
             num_tokens=max(0, int(num_tokens)),
+            cache_token_ids=tuple(cache_token_ids) if cache_token_ids is not None else None,
         )
         self.snapshots[req_id] = snapshot
         self.rebuild_snapshot_index()
@@ -246,6 +253,7 @@ class MbltRuntimeCacheManager:
         req_id: str,
         num_tokens: int,
     ) -> None:
+        node.req_ids.append(req_id)
         if num_tokens >= node.best_num_tokens:
             node.best_req_id = req_id
             node.best_num_tokens = num_tokens
@@ -299,6 +307,7 @@ class MbltRuntimeCacheManager:
         first_seq_blocks: tuple[int, ...],
         num_tokens: int,
         slot_id: int | None = None,
+        cache_token_ids: tuple[int, ...] | list[int] | None = None,
     ) -> RuntimeCacheSnapshot | None:
         if self._dump_runtime_cache_fn is None:
             raise RuntimeError("Runtime cache dump adapter is not configured.")
@@ -311,6 +320,7 @@ class MbltRuntimeCacheManager:
             block_ids=block_ids,
             first_seq_blocks=first_seq_blocks,
             num_tokens=num_tokens,
+            cache_token_ids=cache_token_ids,
         )
 
     def choose_prefix_snapshot(
@@ -318,8 +328,8 @@ class MbltRuntimeCacheManager:
         target_blocks: RuntimeCacheRequest | tuple[int, ...],
         target_tokens: int | None = None,
     ) -> RuntimeCacheSnapshotMatch:
-        if isinstance(target_blocks, RuntimeCacheRequest):
-            request = target_blocks
+        request = target_blocks if isinstance(target_blocks, RuntimeCacheRequest) else None
+        if request is not None:
             target_blocks = request.first_seq_blocks
             target_tokens = request.num_computed_tokens
         if target_tokens is None:
@@ -333,18 +343,23 @@ class MbltRuntimeCacheManager:
         node = self.snapshot_index_root
         for depth, block_id in enumerate(target_blocks, start=1):
             node = node.children.get(block_id)
-            if node is None or node.best_req_id is None:
+            if node is None or not node.req_ids:
                 break
 
-            snapshot = self.snapshots.get(node.best_req_id)
-            if snapshot is None:
-                continue
-
-            matched_tokens = min(snapshot.num_tokens, depth * self.block_size, target_tokens)
-            if matched_tokens > best_tokens:
-                best_tokens = matched_tokens
-                best_snapshot = snapshot
-                best_req_id = node.best_req_id
+            for req_id in node.req_ids:
+                snapshot = self.snapshots.get(req_id)
+                if snapshot is None:
+                    continue
+                matched_tokens = min(snapshot.num_tokens, depth * self.block_size, target_tokens)
+                matched_tokens = token_compatible_tokens(
+                    matched_tokens,
+                    request.cache_token_ids if request is not None else None,
+                    snapshot.cache_token_ids,
+                )
+                if matched_tokens > best_tokens:
+                    best_tokens = matched_tokens
+                    best_snapshot = snapshot
+                    best_req_id = req_id
 
         return RuntimeCacheSnapshotMatch(snapshot=best_snapshot, matched_tokens=best_tokens, req_id=best_req_id)
 
@@ -360,6 +375,8 @@ class MbltRuntimeCacheManager:
                 target_tokens=target_tokens,
                 snapshot_blocks=own_snapshot.first_seq_blocks,
                 snapshot_tokens=own_snapshot.num_tokens,
+                target_token_ids=request.cache_token_ids,
+                snapshot_token_ids=own_snapshot.cache_token_ids,
             )
             if matched_tokens >= target_tokens:
                 return RuntimeCacheSnapshotMatch(
@@ -369,7 +386,7 @@ class MbltRuntimeCacheManager:
                     is_own_snapshot=True,
                 )
 
-        return self.choose_prefix_snapshot(request.first_seq_blocks, target_tokens)
+        return self.choose_prefix_snapshot(request)
 
     def compatible_tokens(
         self,
@@ -378,14 +395,17 @@ class MbltRuntimeCacheManager:
         target_tokens: int,
         snapshot_blocks: tuple[int, ...],
         snapshot_tokens: int,
+        target_token_ids: tuple[int, ...] | None = None,
+        snapshot_token_ids: tuple[int, ...] | None = None,
     ) -> int:
-        return prefix_compatible_tokens(
+        matched_tokens = prefix_compatible_tokens(
             target_blocks,
             target_tokens,
             snapshot_blocks,
             snapshot_tokens,
             self.block_size,
         )
+        return token_compatible_tokens(matched_tokens, target_token_ids, snapshot_token_ids)
 
     def required_blocks(self, num_tokens: int) -> int:
         return required_blocks(num_tokens, self.block_size)
@@ -417,6 +437,7 @@ class MbltRuntimeCacheManager:
             block_ids=request.block_ids,
             first_seq_blocks=request.first_seq_blocks,
             num_tokens=request.num_computed_tokens,
+            cache_token_ids=request.cache_token_ids,
         )
         return True
 
@@ -612,3 +633,23 @@ def prefix_compatible_tokens(
         return min(target_tokens, snapshot_tokens)
 
     return min(snapshot_tokens, common_blocks * block_size, target_tokens)
+
+
+def token_compatible_tokens(
+    matched_tokens: int,
+    target_token_ids: tuple[int, ...] | None,
+    snapshot_token_ids: tuple[int, ...] | None,
+) -> int:
+    if matched_tokens <= 0:
+        return 0
+    if target_token_ids is None or snapshot_token_ids is None:
+        return matched_tokens
+
+    common_tokens = 0
+    for target_token_id, snapshot_token_id in zip(target_token_ids, snapshot_token_ids):
+        if target_token_id != snapshot_token_id:
+            break
+        common_tokens += 1
+        if common_tokens >= matched_tokens:
+            break
+    return min(matched_tokens, common_tokens)

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -18,6 +18,7 @@ class RuntimeCacheSnapshot:
     first_seq_blocks: tuple[int, ...]
     num_tokens: int
     cache_token_ids: tuple[int, ...] | None = None
+    multimodal_cache_identity: Hashable | None = None
     first_seq_block_hashes: tuple[Hashable, ...] | None = None
 
 
@@ -29,6 +30,7 @@ class RuntimeCacheRequest:
     num_computed_tokens: int
     cache_slot_id: int | None = None
     cache_token_ids: tuple[int, ...] | None = None
+    multimodal_cache_identity: Hashable | None = None
     first_seq_block_hashes: tuple[Hashable, ...] | None = None
 
 
@@ -165,34 +167,18 @@ class MbltRuntimeCacheManager:
         *,
         first_seq_block_hashes: tuple[Hashable, ...] | None = None,
     ) -> list[str]:
-        """Invalidate ID-keyed snapshots when vLLM reuses physical KV blocks.
+        """Record physical KV block ownership observed from the scheduler.
 
-        Content-hashed requests/snapshots are safe to match across physical block
-        reuse. Hashless snapshots are only safe while their physical blocks have
-        not been observed under another request.
+        vLLM 0.11.2 exposes physical block IDs but not scheduler block hashes.
+        A changed physical owner is therefore only a collision signal, not proof
+        that a finished snapshot is stale: prefix caching can intentionally share
+        physical blocks across requests with identical token content. Snapshot
+        removal is deferred to choose/load, where token and multimodal identity
+        are available to prove incompatibility.
         """
-        if first_seq_block_hashes is not None:
-            return []
-
-        stale_req_ids: set[str] = set()
-        for block_id in first_seq_blocks(block_ids):
-            owner = self.physical_block_owner.get(block_id)
-            if owner is None or owner == req_id:
-                continue
-            for snapshot_req_id, snapshot in self.snapshots.items():
-                if snapshot_req_id == req_id or snapshot.first_seq_block_hashes is not None:
-                    continue
-                if block_id in snapshot.first_seq_blocks:
-                    stale_req_ids.add(snapshot_req_id)
-
-        removed: list[str] = []
-        for stale_req_id in sorted(stale_req_ids):
-            if self.remove_snapshot(stale_req_id) is not None:
-                removed.append(stale_req_id)
-
         for block_id in first_seq_blocks(block_ids):
             self.physical_block_owner[block_id] = req_id
-        return removed
+        return []
 
     def get_slot(self, req_id: str) -> int:
         slot_id = self.req_to_slot.get(req_id)
@@ -256,6 +242,7 @@ class MbltRuntimeCacheManager:
         num_tokens: int,
         first_seq_block_ids: tuple[int, ...] | None = None,
         cache_token_ids: tuple[int, ...] | list[int] | None = None,
+        multimodal_cache_identity: Hashable | None = None,
     ) -> RuntimeCacheSnapshot:
         return self.store_snapshot(
             req_id=req_id,
@@ -264,6 +251,7 @@ class MbltRuntimeCacheManager:
             first_seq_blocks=first_seq_block_ids if first_seq_block_ids is not None else first_seq_blocks(block_ids),
             num_tokens=num_tokens,
             cache_token_ids=cache_token_ids,
+            multimodal_cache_identity=multimodal_cache_identity,
         )
 
     def store_snapshot(
@@ -276,6 +264,7 @@ class MbltRuntimeCacheManager:
         first_seq_block_hashes: tuple[Hashable, ...] | None = None,
         num_tokens: int,
         cache_token_ids: tuple[int, ...] | list[int] | None = None,
+        multimodal_cache_identity: Hashable | None = None,
     ) -> RuntimeCacheSnapshot:
         self.finished_snapshot_lru.pop(req_id, None)
         snapshot = RuntimeCacheSnapshot(
@@ -285,6 +274,7 @@ class MbltRuntimeCacheManager:
             first_seq_block_hashes=tuple(first_seq_block_hashes) if first_seq_block_hashes is not None else None,
             num_tokens=max(0, int(num_tokens)),
             cache_token_ids=tuple(cache_token_ids) if cache_token_ids is not None else None,
+            multimodal_cache_identity=multimodal_cache_identity,
         )
         self.snapshots[req_id] = snapshot
         if snapshot.first_seq_block_hashes is None:
@@ -363,6 +353,7 @@ class MbltRuntimeCacheManager:
         num_tokens: int,
         slot_id: int | None = None,
         cache_token_ids: tuple[int, ...] | list[int] | None = None,
+        multimodal_cache_identity: Hashable | None = None,
     ) -> RuntimeCacheSnapshot | None:
         if self._dump_runtime_cache_fn is None:
             raise RuntimeError("Runtime cache dump adapter is not configured.")
@@ -377,6 +368,7 @@ class MbltRuntimeCacheManager:
             first_seq_block_hashes=first_seq_block_hashes,
             num_tokens=num_tokens,
             cache_token_ids=cache_token_ids,
+            multimodal_cache_identity=multimodal_cache_identity,
         )
 
     def choose_prefix_snapshot(
@@ -398,26 +390,65 @@ class MbltRuntimeCacheManager:
         best_snapshot: RuntimeCacheSnapshot | None = None
         best_req_id: str | None = None
         best_tokens = 0
+        stale_req_ids: set[str] = set()
         node = self.snapshot_index_root
         for depth, block_id in enumerate(target_blocks, start=1):
             node = node.children.get(block_id)
             if node is None or not node.req_ids:
                 break
 
-            for req_id in node.req_ids:
+            for req_id in tuple(node.req_ids):
                 snapshot = self.snapshots.get(req_id)
                 if snapshot is None:
                     continue
                 matched_tokens = min(snapshot.num_tokens, depth * self.block_size, target_tokens)
-                matched_tokens = token_compatible_tokens(
+                has_physical_collision = (
+                    request is not None
+                    and snapshot.first_seq_block_hashes is None
+                    and request.first_seq_block_hashes is None
+                    and req_id != request.req_id
+                    and physical_prefix_overlaps(request.first_seq_blocks, snapshot.first_seq_blocks)
+                    and any(
+                        self.physical_block_owner.get(block_id) == request.req_id
+                        for block_id in snapshot.first_seq_blocks
+                    )
+                )
+                if has_physical_collision and (
+                    request.cache_token_ids is None or snapshot.cache_token_ids is None
+                ):
+                    stale_req_ids.add(req_id)
+                    continue
+                token_matched_tokens = token_compatible_tokens(
                     matched_tokens,
                     request.cache_token_ids if request is not None else None,
                     snapshot.cache_token_ids,
                 )
+                matched_tokens = multimodal_compatible_tokens(
+                    token_matched_tokens,
+                    request.multimodal_cache_identity if request is not None else None,
+                    snapshot.multimodal_cache_identity,
+                )
+                if (
+                    request is not None
+                    and matched_tokens <= 0
+                    and token_matched_tokens <= 0
+                    and has_physical_collision
+                ):
+                    stale_req_ids.add(req_id)
+                if (
+                    matched_tokens <= 0
+                    and has_physical_collision
+                    and snapshot.multimodal_cache_identity is not None
+                    and snapshot.multimodal_cache_identity != request.multimodal_cache_identity
+                ):
+                    stale_req_ids.add(req_id)
                 if matched_tokens > best_tokens:
                     best_tokens = matched_tokens
                     best_snapshot = snapshot
                     best_req_id = req_id
+
+        for stale_req_id in sorted(stale_req_ids):
+            self.remove_snapshot(stale_req_id)
 
         return RuntimeCacheSnapshotMatch(snapshot=best_snapshot, matched_tokens=best_tokens, req_id=best_req_id)
 
@@ -435,6 +466,8 @@ class MbltRuntimeCacheManager:
                 snapshot_tokens=own_snapshot.num_tokens,
                 target_token_ids=request.cache_token_ids,
                 snapshot_token_ids=own_snapshot.cache_token_ids,
+                target_multimodal_identity=request.multimodal_cache_identity,
+                snapshot_multimodal_identity=own_snapshot.multimodal_cache_identity,
             )
             if matched_tokens >= target_tokens:
                 return RuntimeCacheSnapshotMatch(
@@ -455,6 +488,8 @@ class MbltRuntimeCacheManager:
         snapshot_tokens: int,
         target_token_ids: tuple[int, ...] | None = None,
         snapshot_token_ids: tuple[int, ...] | None = None,
+        target_multimodal_identity: Hashable | None = None,
+        snapshot_multimodal_identity: Hashable | None = None,
     ) -> int:
         matched_tokens = prefix_compatible_tokens(
             target_blocks,
@@ -463,7 +498,8 @@ class MbltRuntimeCacheManager:
             snapshot_tokens,
             self.block_size,
         )
-        return token_compatible_tokens(matched_tokens, target_token_ids, snapshot_token_ids)
+        matched_tokens = token_compatible_tokens(matched_tokens, target_token_ids, snapshot_token_ids)
+        return multimodal_compatible_tokens(matched_tokens, target_multimodal_identity, snapshot_multimodal_identity)
 
     def required_blocks(self, num_tokens: int) -> int:
         return required_blocks(num_tokens, self.block_size)
@@ -497,6 +533,7 @@ class MbltRuntimeCacheManager:
             first_seq_block_hashes=request.first_seq_block_hashes,
             num_tokens=request.num_computed_tokens,
             cache_token_ids=request.cache_token_ids,
+            multimodal_cache_identity=request.multimodal_cache_identity,
         )
         return True
 
@@ -617,6 +654,7 @@ class MbltRuntimeCacheManager:
                 num_computed_tokens=request.num_computed_tokens,
                 first_seq_block_hashes=request.first_seq_block_hashes,
                 cache_token_ids=request.cache_token_ids,
+                multimodal_cache_identity=request.multimodal_cache_identity,
                 cache_slot_id=slot_id,
             )
         return self.load_snapshot_for_slot(request)
@@ -727,3 +765,24 @@ def token_compatible_tokens(
         if common_tokens >= matched_tokens:
             break
     return min(matched_tokens, common_tokens)
+
+
+def multimodal_compatible_tokens(
+    matched_tokens: int,
+    target_multimodal_identity: Hashable | None,
+    snapshot_multimodal_identity: Hashable | None,
+) -> int:
+    if matched_tokens <= 0:
+        return 0
+    if snapshot_multimodal_identity is None:
+        return matched_tokens
+    if target_multimodal_identity == snapshot_multimodal_identity:
+        return matched_tokens
+    return 0
+
+
+def physical_prefix_overlaps(
+    target_blocks: tuple[int, ...],
+    snapshot_blocks: tuple[int, ...],
+) -> bool:
+    return any(target_block == snapshot_block for target_block, snapshot_block in zip(target_blocks, snapshot_blocks))


### PR DESCRIPTION
## 요약
- Mobilint runtime cache snapshot이 물리 KV block ID만으로 매칭되지 않도록 token identity 기반 검증을 추가했습니다.
- stale block ID 재사용 시 잘못된 snapshot restore가 발생하지 않도록 테스트를 보강했습니다.
- VLM prefix caching의 현재 지원 범위를 단일 요청 LM KV prefix 재사용으로 명확히 하고 관련 테스트/문서를 추가했습니다.

## 테스트
- `pytest tests/`

## 참고
- VLM은 반복 이미지 요청에서도 vision feature 계산은 유지되며, batch VLM 경로는 현재 prefix caching 지원 범위에 포함하지 않습니다.