### PR TITLE
Batch VLM 서빙 지원 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,10 +297,12 @@ layer: image requests still rebuild vision features through the model's
 multimodal feature hooks before the LM prefill/decode step.
 
 Batch-compiled VLM text backends (`max_batch_size > 1`) are supported for
-Mobilint Qwen2-VL and Qwen3-VL model types. Qwen3-VL batch execution forwards
-the packed text embeddings and the matching packed deepstack embeddings to the
-dual-input text MXQ. Unsupported multimodal model types fail before runtime
-inference with a clear error.
+Mobilint Qwen2-VL and Qwen3-VL model types. With `mblt-model-zoo>=2.3.0`,
+Qwen3-VL dynamic-vision Batch16 artifacts such as
+`mobilint/Qwen3-VL-8B-Instruct-Batch16` forward packed text embeddings plus
+the matching packed RoPE and deepstack tensors to the 3-input text MXQ.
+Unsupported multimodal model types fail before runtime inference with a clear
+error.
 
 Implementation file: [`vllm_mblt/mblt_worker.py`](vllm_mblt/mblt_worker.py)
 

--- a/README.md
+++ b/README.md
@@ -290,14 +290,17 @@ variables or equivalent model loader extra config keys:
 - `VLLM_MBLT_PREFIX_CACHE_CALIBRATE` defaults to enabled. Set `0` to skip
   startup prefill calibration.
 
-VLM prefix caching currently covers the language-model KV cache only. For
-single-request VLM execution (`max_batch_size=1`), the worker may load a
-compatible LM KV prefix snapshot and run only the uncached text/embedding
-suffix. Image/video feature extraction is not cached by this layer: image
-requests still rebuild vision features through the model's multimodal feature
-hooks before the LM prefill/decode step. Batch-compiled VLM execution is not
-supported yet; use VLM models with `max_batch_size=1` until Mobilint batch VLM
-artifacts and worker support are added.
+VLM prefix caching currently covers the language-model KV cache only. The
+worker may load a compatible LM KV prefix snapshot and run only the uncached
+text/embedding suffix. Image/video feature extraction is not cached by this
+layer: image requests still rebuild vision features through the model's
+multimodal feature hooks before the LM prefill/decode step.
+
+Batch-compiled VLM text backends (`max_batch_size > 1`) are supported for
+Mobilint Qwen2-VL and Qwen3-VL model types. Qwen3-VL batch execution forwards
+the packed text embeddings and the matching packed deepstack embeddings to the
+dual-input text MXQ. Unsupported multimodal model types fail before runtime
+inference with a clear error.
 
 Implementation file: [`vllm_mblt/mblt_worker.py`](vllm_mblt/mblt_worker.py)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = [
 ]
 dependencies = [
     "vllm>=0.11.2,<=0.11.2",
-    "mblt-model-zoo[transformers]>=2.1.0",
+    "mblt-model-zoo[transformers]>=2.3.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/test_kv_cache_swap_spec.py
+++ b/tests/test_kv_cache_swap_spec.py
@@ -69,6 +69,8 @@ def _make_request_state(
         num_output_tokens=0,
         prompt_embeds=np.zeros((prompt_len, 2), dtype=np.float32),
         prompt_deepstack_embeds=None,
+        prompt_rope_embeds=None,
+        mrope_position_delta=0,
         is_multimodal=False,
         prompt_len=prompt_len,
         prompt_token_ids=prompt_token_ids,

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -149,6 +149,44 @@ class TestMbltPlatformPrefill:
 
         assert config.scheduler_config.max_num_seqs == 16
 
+    def test_resolves_vlm_text_config_prefill_chunk_size_without_top_level_value(self) -> None:
+        config = _make_vllm_config(
+            None,
+            loader_extra_config={},
+            hf_model_type="mobilint-qwen3_vl",
+            text_config=SimpleNamespace(npu_prefill_chunk_size=32),
+        )
+
+        assert resolve_npu_prefill_chunk_size(config) == 32
+
+    def test_platform_uses_vlm_text_config_prefill_chunk_size_for_scheduler_limit(self) -> None:
+        config = _make_vllm_config(
+            None,
+            loader_extra_config={},
+            hf_model_type="mobilint-qwen3_vl",
+            text_config=SimpleNamespace(
+                max_batch_size=16,
+                npu_prefill_chunk_size=32,
+            ),
+        )
+
+        MbltPlatform.check_and_update_config(config)
+
+        assert config.scheduler_config.max_num_batched_tokens == 32 * 16
+        assert config.scheduler_config.long_prefill_token_threshold == 32
+
+    def test_resolves_vlm_dict_text_config_prefill_chunk_size_without_top_level_value(self) -> None:
+        config = _make_vllm_config(
+            None,
+            loader_extra_config={},
+            hf_config={
+                "model_type": "mobilint-qwen3_vl",
+                "text_config": {"npu_prefill_chunk_size": 32},
+            },
+        )
+
+        assert resolve_npu_prefill_chunk_size(config) == 32
+
     def test_resolves_vlm_dict_text_config_max_batch_size_without_top_level_value(self) -> None:
         config = _make_vllm_config(
             {"global4": 256},

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -15,9 +15,11 @@ def _make_vllm_config(
     *,
     loader_core_mode=None,
     loader_extra_config=None,
+    hf_config=None,
     hf_core_mode=None,
     hf_model_type="qwen2",
     max_batch_size=None,
+    text_config=None,
     scheduler_max_num_batched_tokens=2048,
     scheduler_max_num_seqs=None,
     scheduler_max_num_partial_prefills=1,
@@ -26,6 +28,14 @@ def _make_vllm_config(
 ):
     if loader_extra_config is None:
         loader_extra_config = {"core_mode": loader_core_mode} if loader_core_mode is not None else {}
+    if hf_config is None:
+        hf_config = SimpleNamespace(
+            model_type=hf_model_type,
+            npu_prefill_chunk_size=npu_prefill_chunk_size,
+            max_batch_size=max_batch_size,
+            text_config=text_config,
+            core_mode=hf_core_mode,
+        )
     return SimpleNamespace(
         parallel_config=SimpleNamespace(worker_cls=None),
         cache_config=SimpleNamespace(block_size=None, enable_prefix_caching=None),
@@ -37,16 +47,17 @@ def _make_vllm_config(
             max_long_partial_prefills=scheduler_max_long_partial_prefills,
             long_prefill_token_threshold=scheduler_long_prefill_token_threshold,
         ),
-        model_config=SimpleNamespace(
-            hf_config=SimpleNamespace(
-                model_type=hf_model_type,
-                npu_prefill_chunk_size=npu_prefill_chunk_size,
-                max_batch_size=max_batch_size,
-                core_mode=hf_core_mode,
-            )
-        ),
+        model_config=SimpleNamespace(hf_config=hf_config),
         load_config=SimpleNamespace(model_loader_extra_config=loader_extra_config),
     )
+
+
+class _ToDictConfig:
+    def __init__(self, values):
+        self._values = values
+
+    def to_dict(self):
+        return self._values
 
 
 class TestMbltPlatformPrefill:
@@ -115,6 +126,48 @@ class TestMbltPlatformPrefill:
         )
 
         assert resolve_model_max_batch_size(config) == 4
+
+    def test_resolves_vlm_text_config_max_batch_size_without_top_level_value(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={},
+            hf_model_type="mobilint-qwen3_vl",
+            text_config=SimpleNamespace(max_batch_size=16),
+        )
+
+        assert resolve_model_max_batch_size(config) == 16
+
+    def test_platform_uses_vlm_text_config_max_batch_size_for_scheduler_limit(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={},
+            hf_model_type="mobilint-qwen3_vl",
+            text_config=SimpleNamespace(max_batch_size=16),
+        )
+
+        MbltPlatform.check_and_update_config(config)
+
+        assert config.scheduler_config.max_num_seqs == 16
+
+    def test_resolves_vlm_dict_text_config_max_batch_size_without_top_level_value(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={},
+            hf_config={"model_type": "mobilint-qwen3_vl", "text_config": {"max_batch_size": 16}},
+        )
+
+        assert resolve_model_max_batch_size(config) == 16
+
+    def test_resolves_vlm_to_dict_text_config_npu_max_batch_size_without_top_level_value(self) -> None:
+        config = _make_vllm_config(
+            {"global4": 256},
+            loader_extra_config={},
+            hf_config=_ToDictConfig(
+                {"model_type": "mobilint-qwen3_vl", "text_config": {"npu_max_batch_size": 16}}
+            ),
+        )
+
+        assert resolve_model_max_batch_size(config) == 16
 
     def test_uses_loader_text_core_mode_for_max_batch_size_mapping(self) -> None:
         config = _make_vllm_config(

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -159,6 +159,19 @@ class TestMbltPlatformPrefill:
 
         assert resolve_npu_prefill_chunk_size(config) == 32
 
+    def test_resolves_vlm_text_config_core_mode_for_prefill_chunk_size_mapping(self) -> None:
+        config = _make_vllm_config(
+            None,
+            loader_extra_config={},
+            hf_model_type="mobilint-qwen3_vl",
+            text_config=SimpleNamespace(
+                core_mode="single",
+                npu_prefill_chunk_size={"single": 32},
+            ),
+        )
+
+        assert resolve_npu_prefill_chunk_size(config) == 32
+
     def test_platform_uses_vlm_text_config_prefill_chunk_size_for_scheduler_limit(self) -> None:
         config = _make_vllm_config(
             None,
@@ -182,6 +195,21 @@ class TestMbltPlatformPrefill:
             hf_config={
                 "model_type": "mobilint-qwen3_vl",
                 "text_config": {"npu_prefill_chunk_size": 32},
+            },
+        )
+
+        assert resolve_npu_prefill_chunk_size(config) == 32
+
+    def test_resolves_vlm_dict_text_config_core_mode_for_prefill_chunk_size_mapping(self) -> None:
+        config = _make_vllm_config(
+            None,
+            loader_extra_config={},
+            hf_config={
+                "model_type": "mobilint-qwen3_vl",
+                "text_config": {
+                    "core_mode": "single",
+                    "npu_prefill_chunk_size": {"single": 32},
+                },
             },
         )
 

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -2738,6 +2738,31 @@ class TestMbltWorkerOptimizations:
         assert worker.max_batch_size == 4
         assert worker.runtime_cache.free_slots == [0, 1, 2, 3]
 
+    def test_init_uses_vlm_text_config_max_batch_size_for_cache_slots(self, monkeypatch) -> None:
+        def worker_base_init(self, vllm_config, local_rank, rank, distributed_init_method, is_driver_worker=False):
+            self.vllm_config = vllm_config
+            self.local_rank = local_rank
+            self.rank = rank
+
+        monkeypatch.setattr("vllm_mblt.mblt_worker.WorkerBase.__init__", worker_base_init)
+        config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=128),
+            load_config=SimpleNamespace(model_loader_extra_config={}),
+            model_config=SimpleNamespace(
+                max_model_len=1024,
+                hf_config=SimpleNamespace(
+                    model_type="mobilint-qwen3_vl",
+                    text_config=SimpleNamespace(max_batch_size=16),
+                ),
+            ),
+            scheduler_config=SimpleNamespace(enable_chunked_prefill=True, max_num_batched_tokens=128),
+        )
+
+        worker = MbltWorker(config, local_rank=0, rank=0, distributed_init_method="env://")
+
+        assert worker.max_batch_size == 16
+        assert worker.runtime_cache.free_slots == list(range(16))
+
     def test_init_uses_shared_text_only_max_batch_size_for_cache_slots(self, monkeypatch) -> None:
         def worker_base_init(self, vllm_config, local_rank, rank, distributed_init_method, is_driver_worker=False):
             self.vllm_config = vllm_config

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -2259,6 +2259,30 @@ class TestMbltWorkerOptimizations:
         assert tuple(captured["rope_kwargs"]["image_grid_thw"].shape) == (1, 3)
         assert captured["rope_kwargs"]["input_ids"].tolist() == [[1, 2, 3, 4, 5]]
 
+    def test_build_rope_embeddings_passes_context_tensor_to_rotary_embedding(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        captured = {}
+
+        def rotary_emb(x, position_ids):
+            captured["device"] = x.device
+            captured["dtype"] = x.dtype
+            return position_ids[0].to(dtype=x.dtype, device=x.device).unsqueeze(-1).repeat(1, 1, 2)
+
+        worker.model = SimpleNamespace(
+            config=SimpleNamespace(model_type="mobilint-qwen3_vl"),
+            get_language_model=lambda: SimpleNamespace(rotary_emb=rotary_emb),
+        )
+        position_ids = torch.arange(3, dtype=torch.long).view(1, 1, -1).expand(3, 1, -1)
+
+        rope = worker._build_rope_embeddings_from_position_ids(position_ids)
+
+        assert captured == {"device": torch.device("cpu"), "dtype": torch.float32}
+        np.testing.assert_array_equal(
+            rope,
+            np.asarray([[[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]], dtype=np.float32),
+        )
+
     def test_build_rope_input_embeds_uses_prompt_rows_and_mrope_delta_for_decode(self) -> None:
         worker = self._make_worker()
         worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -2517,8 +2517,30 @@ class TestMbltWorkerOptimizations:
         assert tuple(infer_inputs[1].shape) == (3, 5, 4)
         np.testing.assert_array_equal(infer_inputs[1], np.zeros((3, 5, 4), dtype=np.float32))
 
-    def test_build_infer_inputs_passes_rope_then_deepstack_for_qwen3_vl_three_input_model(self) -> None:
+    def test_build_infer_inputs_passes_deepstack_then_rope_for_nonbatch_qwen3_vl_three_input_model(self) -> None:
         worker = self._make_worker()
+        worker.max_batch_size = 1
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (3, -1, 4), (1, -1, 6)]
+            ),
+        )
+        input_embeds = np.ones((5, 4), dtype=np.float32)
+        rope_embeds = np.full((1, 5, 6), 2.0, dtype=np.float32)
+        deepstack_embeds = np.full((3, 5, 4), 3.0, dtype=np.float32)
+
+        infer_inputs = worker._build_infer_inputs(input_embeds, deepstack_embeds, rope_embeds=rope_embeds)
+
+        assert isinstance(infer_inputs, list)
+        assert [tuple(item.shape) for item in infer_inputs] == [(1, 5, 4), (3, 5, 4), (1, 5, 6)]
+        np.testing.assert_array_equal(infer_inputs[1], deepstack_embeds)
+        np.testing.assert_array_equal(infer_inputs[2], rope_embeds)
+
+    def test_build_infer_inputs_passes_rope_then_deepstack_for_batch_qwen3_vl_three_input_model(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 16
         worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
         worker.cache_model = SimpleNamespace(
             get_num_model_variants=lambda: 1,
@@ -2543,7 +2565,7 @@ class TestMbltWorkerOptimizations:
         worker.cache_model = SimpleNamespace(
             get_num_model_variants=lambda: 1,
             get_model_variant_handle=lambda _idx: SimpleNamespace(
-                get_model_input_shape=lambda: [(1, -1, 4), (1, -1, 6), (3, -1, 4)]
+                get_model_input_shape=lambda: [(1, -1, 4), (3, -1, 4), (1, -1, 6)]
             ),
         )
 
@@ -3086,3 +3108,39 @@ class TestMbltWorkerOptimizations:
                 },
             )
         ]
+
+    def test_load_model_reconciles_qwen3_vl_dynamic_vision_when_available(self, monkeypatch) -> None:
+        worker = MbltWorker.__new__(MbltWorker)
+        worker.rank = 0
+        worker.local_rank = 0
+        worker.model = None
+        worker.cache_model = None
+        worker._infer_output_buffers = None
+        worker.max_batch_size = 1
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=1, block_size=128)
+        worker.load_config = SimpleNamespace(model_loader_extra_config={})
+        worker.model_config = SimpleNamespace(
+            model="mobilint/Qwen3-VL-8B-Instruct-Batch16",
+            hf_config=SimpleNamespace(model_type="mobilint-qwen3_vl", text_config=SimpleNamespace(max_batch_size=16)),
+            model_kwargs={},
+            hf_overrides={},
+        )
+        worker.vllm_config = SimpleNamespace(
+            load_config=SimpleNamespace(model_loader_extra_config={}), model_config=worker.model_config
+        )
+        calls = []
+        fake_model = SimpleNamespace(
+            eval=lambda: None,
+            get_input_embeddings=lambda: SimpleNamespace(),
+            get_cache_mxq_model=lambda: SimpleNamespace(),
+            sync_dynamic_vision_from_model=lambda: calls.append("sync"),
+        )
+
+        monkeypatch.setattr(
+            "vllm_mblt.mblt_worker.AutoModelForImageTextToText.from_pretrained",
+            lambda *_args, **_kwargs: fake_model,
+        )
+
+        worker.load_model()
+
+        assert calls == ["sync"]

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -2477,21 +2477,113 @@ class TestMbltWorkerOptimizations:
         np.testing.assert_array_equal(infer_inputs[1], deepstack_embeds)
         assert captured["kwargs"] == {"cache_size": 7}
 
-    def test_batch_vlm_fails_fast_until_artifacts_are_available(self) -> None:
+    def test_batch_vlm_no_longer_fails_fast_for_qwen3_vl(self) -> None:
         worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
         req_state = self._make_request_state(worker, SamplingParams.from_optional(), [1, 2])
         req_state.is_multimodal = True
         req_state.prompt_deepstack_embeds = np.zeros((2, 3, 4), dtype=np.float32)
-        with pytest.raises(RuntimeError, match="VLM batch execution is not supported"):
-            worker._ensure_batch_vlm_supported(req_state)
+        worker._ensure_batch_vlm_supported(req_state)
 
-    def test_batch_vlm_without_deepstack_fails_fast_until_artifacts_are_available(self) -> None:
+    def test_infer_logits_batch_passes_qwen3_vl_deepstack_inputs_and_params(self) -> None:
         worker = self._make_worker()
-        req_state = self._make_request_state(worker, SamplingParams.from_optional(), [1, 2])
-        req_state.is_multimodal = True
-        req_state.prompt_deepstack_embeds = None
-        with pytest.raises(RuntimeError, match="VLM batch execution is not supported"):
-            worker._ensure_batch_vlm_supported(req_state)
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        captured = {}
+
+        def infer(inputs, **kwargs):
+            captured["inputs"] = inputs
+            captured["params"] = kwargs["params"]
+            return [np.arange(2 * 5, dtype=np.float32).reshape(2, 5)]
+
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (2, -1, 4)]
+            ),
+            infer=infer,
+        )
+        input_a = np.full((2, 4), 1.0, dtype=np.float32)
+        input_b = np.full((1, 4), 2.0, dtype=np.float32)
+        deepstack_a = np.full((2, 2, 4), 3.0, dtype=np.float32)
+
+        logits = worker._infer_logits_batch(
+            [input_a, input_b],
+            cache_sizes=[5, 7],
+            cache_ids=[1, 2],
+            deepstack_embeds_batch=[deepstack_a, None],
+        )
+
+        assert [tuple(row.shape) for row in logits] == [(5,), (5,)]
+        assert len(captured["inputs"]) == 2
+        np.testing.assert_array_equal(captured["inputs"][0], np.expand_dims(np.concatenate([input_a, input_b]), 0))
+        assert captured["inputs"][1].shape == (2, 3, 4)
+        np.testing.assert_array_equal(captured["inputs"][1][:, :2, :], deepstack_a)
+        np.testing.assert_array_equal(captured["inputs"][1][:, 2:, :], np.zeros((2, 1, 4), dtype=np.float32))
+        assert [
+            (int(param.sequence_length), int(param.cache_size), int(param.cache_id))
+            for param in captured["params"]
+        ] == [(2, 5, 1), (1, 7, 2)]
+
+    def test_text_only_batch_input_shape_remains_rank4(self) -> None:
+        worker = self._make_worker()
+        captured = {}
+
+        def infer(inputs, **kwargs):
+            captured["inputs"] = inputs
+            captured["params"] = kwargs["params"]
+            return [np.arange(2 * 5, dtype=np.float32).reshape(2, 5)]
+
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(get_model_input_shape=lambda: [(1, 1, -1, 4)]),
+            infer=infer,
+        )
+
+        worker._infer_logits_batch(
+            [
+                np.full((2, 4), 1.0, dtype=np.float32),
+                np.full((1, 4), 2.0, dtype=np.float32),
+            ],
+            cache_sizes=[0, 3],
+            cache_ids=[1, 2],
+        )
+
+        assert len(captured["inputs"]) == 1
+        assert captured["inputs"][0].shape == (1, 1, 3, 4)
+        assert [
+            (int(param.sequence_length), int(param.cache_size), int(param.cache_id))
+            for param in captured["params"]
+        ] == [(2, 0, 1), (1, 3, 2)]
+
+    def test_max_batch_size_one_vlm_still_uses_single_request_infer_inputs(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 1
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker._infer_output_buffers = None
+        captured = {}
+
+        def infer(inputs, **kwargs):
+            captured["inputs"] = inputs
+            captured["kwargs"] = kwargs
+            return [np.arange(1 * 2 * 5, dtype=np.float32).reshape(1, 2, 5)]
+
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (2, -1, 4)]
+            ),
+            infer=infer,
+            get_model_output_shape=lambda: [],
+        )
+
+        input_embeds = np.ones((2, 4), dtype=np.float32)
+        deepstack_embeds = np.full((2, 2, 4), 3.0, dtype=np.float32)
+        worker._infer_logits(input_embeds, deepstack_embeds, cache_size=9)
+
+        assert len(captured["inputs"]) == 2
+        np.testing.assert_array_equal(captured["inputs"][0], np.expand_dims(input_embeds, axis=0))
+        np.testing.assert_array_equal(captured["inputs"][1], deepstack_embeds)
+        assert captured["kwargs"] == {"cache_size": 9}
 
     def test_init_uses_text_runtime_max_batch_size_for_cache_slots(self, monkeypatch) -> None:
         def worker_base_init(self, vllm_config, local_rank, rank, distributed_init_method, is_driver_worker=False):

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -49,6 +49,40 @@ class TestMbltWorkerOptimizations:
         assert not _is_qwen3_vl_hf_config(SimpleNamespace(model_type="qwen2_vl"))
         assert not _is_qwen3_vl_hf_config(SimpleNamespace(architectures=["MobilintQwen3VLForConditionalGeneration"]))
 
+    def test_qwen3_vl_composite_config_resolves_text_vocab_size_for_default_top_k(self) -> None:
+        worker = self._make_worker()
+        worker.model.config = SimpleNamespace(
+            model_type="mobilint-qwen3_vl",
+            text_config=SimpleNamespace(vocab_size=151936),
+        )
+
+        cached_state = worker._make_cached_sampling_state(SamplingParams.from_optional(top_k=0), [1, 2, 3])
+
+        assert cached_state.top_k == 151936
+
+    def test_vocab_size_resolution_falls_back_to_hf_text_config(self) -> None:
+        worker = self._make_worker()
+        worker.model.config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.model_config.hf_config = SimpleNamespace(text_config=SimpleNamespace(vocab_size=151936))
+
+        assert worker._resolve_vocab_size() == 151936
+        assert worker._num_prompt_logprobs(SamplingParams.from_optional(prompt_logprobs=-1)) == 151936
+        packed = worker._pack_prompt_token_ids(
+            [
+                torch.as_tensor([1, 2, 3], dtype=torch.int64),
+                torch.as_tensor([4], dtype=torch.int64),
+            ]
+        )
+        assert packed.tolist() == [[1, 2, 3], [4, 151936, 151936]]
+
+    def test_vocab_size_resolution_rejects_missing_vocab_size(self) -> None:
+        worker = self._make_worker()
+        worker.model.config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.model_config.hf_config = SimpleNamespace(text_config=SimpleNamespace())
+
+        with pytest.raises(RuntimeError, match="Unable to resolve a positive vocab_size"):
+            worker._make_cached_sampling_state(SamplingParams.from_optional(top_k=0), [1])
+
     def test_multimodal_model_detection_uses_mobilint_model_type_only(self) -> None:
         worker = self._make_worker()
         assert not worker._is_multimodal_model()

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -311,6 +311,8 @@ class TestMbltWorkerOptimizations:
             num_output_tokens=0,
             prompt_embeds=np.empty((0, 1), dtype=np.float32),
             prompt_deepstack_embeds=None,
+            prompt_rope_embeds=None,
+            mrope_position_delta=0,
             is_multimodal=False,
             prompt_len=0,
             prompt_token_ids=prompt_token_ids,
@@ -2217,6 +2219,97 @@ class TestMbltWorkerOptimizations:
         torch.testing.assert_close(deepstack[:, :1], torch.zeros(2, 1, 4))
         torch.testing.assert_close(deepstack[:, 3:], torch.zeros(2, 2, 4))
 
+    def test_build_prompt_rope_embeds_uses_qwen3_vl_rope_index_and_image_grid(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (1, -1, 2), (2, -1, 4)]
+            ),
+        )
+        captured = {}
+
+        def rotary_emb(_x, position_ids):
+            captured["position_ids"] = position_ids.clone()
+            return position_ids[0].to(torch.float32).unsqueeze(-1).repeat(1, 1, 2).numpy()
+
+        def get_rope_index(**kwargs):
+            captured["rope_kwargs"] = kwargs
+            position_ids = torch.arange(5, dtype=torch.long).view(1, 1, -1).expand(3, 1, -1) + 10
+            return position_ids, torch.tensor([[7]], dtype=torch.long)
+
+        language_model = SimpleNamespace(rotary_emb=rotary_emb)
+        worker.model = SimpleNamespace(
+            config=SimpleNamespace(model_type="mobilint-qwen3_vl"),
+            get_language_model=lambda: language_model,
+            model=SimpleNamespace(get_rope_index=get_rope_index),
+        )
+        feature = self._make_mm_feature(
+            "image",
+            data={"image_grid_thw": torch.tensor([1, 4, 4]), "pixel_values": torch.zeros(16, 2)},
+        )
+
+        rope, delta = worker._build_prompt_rope_embeds([1, 2, 3, 4, 5], [feature], prompt_len=5)
+
+        assert delta == 7
+        assert rope is not None
+        assert tuple(rope.shape) == (1, 5, 2)
+        np.testing.assert_array_equal(rope[0, :, 0], np.arange(10, 15, dtype=np.float32))
+        assert tuple(captured["rope_kwargs"]["image_grid_thw"].shape) == (1, 3)
+        assert captured["rope_kwargs"]["input_ids"].tolist() == [[1, 2, 3, 4, 5]]
+
+    def test_build_rope_input_embeds_uses_prompt_rows_and_mrope_delta_for_decode(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (1, -1, 2), (2, -1, 4)]
+            ),
+        )
+
+        def rotary_emb(_x, position_ids):
+            return position_ids[0].to(torch.float32).unsqueeze(-1).repeat(1, 1, 2).numpy()
+
+        worker.model = SimpleNamespace(
+            config=SimpleNamespace(model_type="mobilint-qwen3_vl", vocab_size=32000),
+            get_language_model=lambda: SimpleNamespace(rotary_emb=rotary_emb),
+        )
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), [1, 2, 3])
+        req_state.prompt_len = 3
+        req_state.prompt_rope_embeds = np.asarray([[[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]], dtype=np.float32)
+        req_state.mrope_position_delta = 5
+
+        rope = worker._build_rope_input_embeds(req_state, 2, 5)
+
+        assert rope is not None
+        np.testing.assert_array_equal(
+            rope,
+            np.asarray([[[2.0, 2.0], [8.0, 8.0], [9.0, 9.0]]], dtype=np.float32),
+        )
+
+    def test_build_prompt_rope_embeds_rejects_multimodal_without_mrope_helper(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (1, -1, 2), (2, -1, 4)]
+            ),
+        )
+        worker.model = SimpleNamespace(
+            config=SimpleNamespace(model_type="mobilint-qwen3_vl", vocab_size=32000),
+            get_language_model=lambda: SimpleNamespace(rotary_emb=lambda _x, _position_ids: np.zeros((1, 1, 2))),
+        )
+        feature = self._make_mm_feature(
+            "image",
+            data={"image_grid_thw": torch.tensor([1, 4, 4]), "pixel_values": torch.zeros(16, 2)},
+        )
+
+        with pytest.raises(RuntimeError, match="requires get_mrope_input_positions"):
+            worker._build_prompt_rope_embeds([1, 2, 3], [feature], prompt_len=3)
+
     def test_build_prompt_embeds_ignores_deepstack_outputs_for_non_qwen3_vl(self) -> None:
         worker = self._make_worker()
         base_prompt_embeds = torch.arange(20, dtype=torch.float32).reshape(5, 4)
@@ -2424,6 +2517,39 @@ class TestMbltWorkerOptimizations:
         assert tuple(infer_inputs[1].shape) == (3, 5, 4)
         np.testing.assert_array_equal(infer_inputs[1], np.zeros((3, 5, 4), dtype=np.float32))
 
+    def test_build_infer_inputs_passes_rope_then_deepstack_for_qwen3_vl_three_input_model(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (1, -1, 6), (3, -1, 4)]
+            ),
+        )
+        input_embeds = np.ones((5, 4), dtype=np.float32)
+        rope_embeds = np.full((1, 5, 6), 2.0, dtype=np.float32)
+        deepstack_embeds = np.full((3, 5, 4), 3.0, dtype=np.float32)
+
+        infer_inputs = worker._build_infer_inputs(input_embeds, deepstack_embeds, rope_embeds=rope_embeds)
+
+        assert isinstance(infer_inputs, list)
+        assert [tuple(item.shape) for item in infer_inputs] == [(1, 5, 4), (1, 5, 6), (3, 5, 4)]
+        np.testing.assert_array_equal(infer_inputs[1], rope_embeds)
+        np.testing.assert_array_equal(infer_inputs[2], deepstack_embeds)
+
+    def test_build_infer_inputs_requires_rope_for_qwen3_vl_three_input_model(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (1, -1, 6), (3, -1, 4)]
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="requires RoPE"):
+            worker._build_infer_inputs(np.ones((5, 4), dtype=np.float32), None)
+
     def test_build_infer_inputs_ignores_dual_input_shape_for_non_qwen3_vl_model(self) -> None:
         worker = self._make_worker()
         worker.model_config.hf_config = SimpleNamespace(model_type="qwen2_vl")
@@ -2557,6 +2683,44 @@ class TestMbltWorkerOptimizations:
             (int(param.sequence_length), int(param.cache_size), int(param.cache_id))
             for param in captured["params"]
         ] == [(2, 5, 1), (1, 7, 2)]
+
+    def test_infer_logits_batch_passes_qwen3_vl_rope_then_deepstack_inputs(self) -> None:
+        worker = self._make_worker()
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        captured = {}
+
+        def infer(inputs, **kwargs):
+            captured["inputs"] = inputs
+            captured["params"] = kwargs["params"]
+            return [np.arange(2 * 5, dtype=np.float32).reshape(2, 5)]
+
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (1, -1, 6), (2, -1, 4)]
+            ),
+            infer=infer,
+        )
+        input_a = np.full((2, 4), 1.0, dtype=np.float32)
+        input_b = np.full((1, 4), 2.0, dtype=np.float32)
+        rope_a = np.full((1, 2, 6), 4.0, dtype=np.float32)
+        rope_b = np.full((1, 1, 6), 5.0, dtype=np.float32)
+        deepstack_a = np.full((2, 2, 4), 3.0, dtype=np.float32)
+
+        worker._infer_logits_batch(
+            [input_a, input_b],
+            cache_sizes=[5, 7],
+            cache_ids=[1, 2],
+            deepstack_embeds_batch=[deepstack_a, None],
+            rope_embeds_batch=[rope_a, rope_b],
+        )
+
+        assert len(captured["inputs"]) == 3
+        np.testing.assert_array_equal(captured["inputs"][0], np.expand_dims(np.concatenate([input_a, input_b]), 0))
+        np.testing.assert_array_equal(captured["inputs"][1], np.concatenate([rope_a, rope_b], axis=1))
+        assert captured["inputs"][2].shape == (2, 3, 4)
+        np.testing.assert_array_equal(captured["inputs"][2][:, :2, :], deepstack_a)
+        np.testing.assert_array_equal(captured["inputs"][2][:, 2:, :], np.zeros((2, 1, 4), dtype=np.float32))
 
     def test_batch_compiled_single_qwen3_vl_execute_uses_batch_params_and_deepstack(self) -> None:
         worker = self._make_worker()

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -2558,6 +2558,104 @@ class TestMbltWorkerOptimizations:
             for param in captured["params"]
         ] == [(2, 5, 1), (1, 7, 2)]
 
+    def test_batch_compiled_single_qwen3_vl_execute_uses_batch_params_and_deepstack(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 16
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=16, block_size=128)
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.req_states = {}
+        worker._infer_output_buffers = None
+
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(temperature=0.0), list(range(82)))
+        req_state.prompt_len = 82
+        req_state.prompt_embeds = np.ones((82, 4), dtype=np.float32)
+        req_state.prompt_deepstack_embeds = np.full((2, 82, 4), 3.0, dtype=np.float32)
+        req_state.is_multimodal = True
+        worker.req_states = {"vlm": req_state}
+
+        captured = {}
+
+        def infer(inputs, **kwargs):
+            captured["inputs"] = inputs
+            captured["kwargs"] = kwargs
+            return [np.zeros((1, 82, 8), dtype=np.float32)]
+
+        worker.cache_model = SimpleNamespace(
+            infer=infer,
+            get_model_output_shape=lambda: [(1, -1, 8)],
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (2, -1, 4)]
+            ),
+        )
+        worker._load_snapshot_if_needed = lambda _req_id, req_state, **_kwargs: int(req_state.num_computed_tokens)
+        worker._infer_logits_with_sequence = lambda *_args, **_kwargs: pytest.fail(
+            "batch-compiled single request used cache_size-only infer"
+        )
+        worker._make_sampling_metadata = lambda _states: None
+        worker._sample_next_token = lambda _logits, _metadata: SimpleNamespace(
+            sampled_token_ids=torch.tensor([[7]], dtype=torch.int64),
+            logprobs_tensors=None,
+        )
+
+        output = worker.execute_model(self._make_scheduler_output({"vlm": 82}))
+
+        assert output is not None
+        assert output.sampled_token_ids[output.req_id_to_index["vlm"]].tolist() == [7]
+        assert tuple(captured["inputs"][0].shape) == (1, 82, 4)
+        assert tuple(captured["inputs"][1].shape) == (2, 82, 4)
+        np.testing.assert_array_equal(captured["inputs"][1], req_state.prompt_deepstack_embeds)
+        assert "cache_size" not in captured["kwargs"]
+        assert [
+            (int(param.sequence_length), int(param.cache_size), int(param.cache_id))
+            for param in captured["kwargs"]["params"]
+        ] == [(82, 0, 0)]
+
+    def test_batch_compiled_single_text_execute_uses_batch_params(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 16
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=16, block_size=128)
+        worker.req_states = {}
+
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(temperature=0.0), [1, 2, 3, 4, 5])
+        req_state.prompt_len = 5
+        req_state.prompt_embeds = np.ones((5, 4), dtype=np.float32)
+        worker.req_states = {"text": req_state}
+
+        captured = {}
+
+        def infer(inputs, **kwargs):
+            captured["inputs"] = inputs
+            captured["kwargs"] = kwargs
+            return [np.zeros((1, 8), dtype=np.float32)]
+
+        worker.cache_model = SimpleNamespace(
+            infer=infer,
+            get_model_output_shape=lambda: [(16, 8)],
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(get_model_input_shape=lambda: [(1, 1, -1, 4)]),
+        )
+        worker._load_snapshot_if_needed = lambda _req_id, req_state, **_kwargs: int(req_state.num_computed_tokens)
+        worker._infer_logits_with_sequence = lambda *_args, **_kwargs: pytest.fail(
+            "batch-compiled single request used cache_size-only infer"
+        )
+        worker._make_sampling_metadata = lambda _states: None
+        worker._sample_next_token = lambda _logits, _metadata: SimpleNamespace(
+            sampled_token_ids=torch.tensor([[9]], dtype=torch.int64),
+            logprobs_tensors=None,
+        )
+
+        output = worker.execute_model(self._make_scheduler_output({"text": 5}))
+
+        assert output is not None
+        assert output.sampled_token_ids[output.req_id_to_index["text"]].tolist() == [9]
+        assert tuple(captured["inputs"][0].shape) == (1, 1, 5, 4)
+        assert "cache_size" not in captured["kwargs"]
+        assert [
+            (int(param.sequence_length), int(param.cache_size), int(param.cache_id))
+            for param in captured["kwargs"]["params"]
+        ] == [(5, 0, 0)]
+
     def test_text_only_batch_input_shape_remains_rank4(self) -> None:
         worker = self._make_worker()
         captured = {}

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -56,10 +56,41 @@ def _get_hf_config(vllm_config: "VllmConfig") -> object:
     return getattr(model_config, "hf_config", None)
 
 
+def _to_config_dict(config: object) -> dict | None:
+    if isinstance(config, dict):
+        return config
+
+    to_dict = getattr(config, "to_dict", None)
+    if callable(to_dict):
+        try:
+            config_dict = to_dict()
+        except Exception:
+            return None
+        return config_dict if isinstance(config_dict, dict) else None
+
+    return None
+
+
+def _get_config_field_value(config: object, field_name: str) -> object:
+    if config is None:
+        return None
+
+    if isinstance(config, dict) and field_name in config:
+        return config[field_name]
+
+    value = getattr(config, field_name, None)
+    if value is not None:
+        return value
+
+    config_dict = _to_config_dict(config)
+    if isinstance(config_dict, dict) and field_name in config_dict:
+        return config_dict[field_name]
+
+    return None
+
+
 def _is_multimodal_hf_config(hf_config: object) -> bool:
-    model_type = getattr(hf_config, "model_type", None)
-    if not isinstance(model_type, str) and isinstance(hf_config, dict):
-        model_type = hf_config.get("model_type")
+    model_type = _get_config_field_value(hf_config, "model_type")
     return isinstance(model_type, str) and model_type in _MULTIMODAL_HF_MODEL_TYPES
 
 
@@ -92,25 +123,23 @@ def _get_model_config_value(vllm_config: "VllmConfig", *field_names: str) -> obj
     if hf_config is None:
         return None
 
-    config_dict = None
-    to_dict = getattr(hf_config, "to_dict", None)
-    if callable(to_dict):
-        try:
-            config_dict = to_dict()
-        except Exception:
-            config_dict = None
-
     for field_name in field_names:
-        if isinstance(hf_config, dict) and field_name in hf_config:
-            return hf_config[field_name]
-
-        value = getattr(hf_config, field_name, None)
+        value = _get_config_field_value(hf_config, field_name)
         if value is not None:
             return value
 
-        if isinstance(config_dict, dict) and field_name in config_dict:
-            return config_dict[field_name]
+    return None
 
+
+def _get_text_model_config_value(vllm_config: "VllmConfig", *field_names: str) -> object:
+    text_config = _get_config_field_value(_get_hf_config(vllm_config), "text_config")
+    if text_config is None:
+        return None
+
+    for field_name in field_names:
+        value = _get_config_field_value(text_config, field_name)
+        if value is not None:
+            return value
     return None
 
 
@@ -200,6 +229,21 @@ def resolve_model_max_batch_size(
         override = _coerce_positive_int(extra_config.get("max_batch_size"))
         if override is not None:
             return override
+
+    if prefer_text_runtime:
+        raw_text_max_batch_size = _get_text_model_config_value(
+            vllm_config,
+            "max_batch_size",
+            "npu_max_batch_size",
+        )
+        resolved_text_max_batch_size = _resolve_model_config_positive_int(
+            vllm_config,
+            raw_text_max_batch_size,
+            field_name="text_config.max_batch_size",
+            prefer_text_core_mode=True,
+        )
+        if resolved_text_max_batch_size is not None:
+            return resolved_text_max_batch_size
 
     raw_max_batch_size = _get_model_config_value(
         vllm_config,

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -181,12 +181,27 @@ def _resolve_model_config_positive_int(
 
 
 def resolve_npu_prefill_chunk_size(vllm_config: "VllmConfig") -> int | None:
+    prefer_text_runtime = _prefer_text_runtime(vllm_config)
+    if prefer_text_runtime:
+        raw_text_chunk_size = _get_text_model_config_value(
+            vllm_config,
+            "npu_prefill_chunk_size",
+        )
+        resolved_text_chunk_size = _resolve_model_config_positive_int(
+            vllm_config,
+            raw_text_chunk_size,
+            field_name="text_config.npu_prefill_chunk_size",
+            prefer_text_core_mode=True,
+        )
+        if resolved_text_chunk_size is not None:
+            return resolved_text_chunk_size
+
     raw_chunk_size = _get_model_config_value(vllm_config, "npu_prefill_chunk_size")
     return _resolve_model_config_positive_int(
         vllm_config,
         raw_chunk_size,
         field_name="npu_prefill_chunk_size",
-        prefer_text_core_mode=_prefer_text_runtime(vllm_config),
+        prefer_text_core_mode=prefer_text_runtime,
     )
 
 

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -110,6 +110,15 @@ def _resolve_core_mode(vllm_config: "VllmConfig", *, prefer_text_core_mode: bool
         if isinstance(configured_core_mode, str) and configured_core_mode:
             return configured_core_mode
 
+    if prefer_text_core_mode:
+        configured_text_core_mode = _get_text_model_config_value(
+            vllm_config,
+            "core_mode",
+            "text_core_mode",
+        )
+        if isinstance(configured_text_core_mode, str) and configured_text_core_mode:
+            return configured_text_core_mode
+
     hf_config = _get_hf_config(vllm_config)
     configured_core_mode = getattr(hf_config, "core_mode", None)
     if isinstance(configured_core_mode, str) and configured_core_mode:

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -127,6 +127,8 @@ class RequestState:
     num_output_tokens: int
     prompt_embeds: np.ndarray
     prompt_deepstack_embeds: Optional[np.ndarray]
+    prompt_rope_embeds: Optional[np.ndarray]
+    mrope_position_delta: int
     is_multimodal: bool
     prompt_len: int
     prompt_token_ids: list[int]
@@ -190,6 +192,7 @@ class NormalBatchChunkState:
     output_index: int
     input_embeds: np.ndarray
     deepstack_embeds: Optional[np.ndarray]
+    rope_embeds: Optional[np.ndarray]
     cache_id: int
     cache_size: int
     offset: int = 0
@@ -1132,6 +1135,120 @@ class MbltWorker(WorkerBase):
             return pieces[0]
         return np.concatenate(pieces, axis=1)
 
+    def _get_qwen3_vl_rotary_embedding(self) -> Any | None:
+        if not self._supports_deepstack_input():
+            return None
+
+        language_model = None
+        get_language_model = getattr(self.model, "get_language_model", None)
+        if callable(get_language_model):
+            language_model = get_language_model()
+        if language_model is None:
+            language_model = getattr(getattr(self.model, "model", None), "language_model", None)
+
+        rotary_emb = getattr(language_model, "rotary_emb", None)
+        return rotary_emb if callable(rotary_emb) else None
+
+    def _build_rope_embeddings_from_position_ids(self, position_ids: torch.Tensor) -> np.ndarray:
+        rotary_emb = self._get_qwen3_vl_rotary_embedding()
+        if rotary_emb is None:
+            raise RuntimeError(
+                "Qwen3-VL 3-input text MXQ requires a callable language_model.rotary_emb "
+                "to build RoPE input tensors."
+            )
+        return np.asarray(rotary_emb(None, position_ids), dtype=np.float32)
+
+    def _build_prompt_rope_embeds(
+        self,
+        prompt_token_ids: Optional[list[int]],
+        mm_features: Optional[list[MultiModalFeatureSpec]],
+        prompt_len: int,
+    ) -> tuple[Optional[np.ndarray], int]:
+        if not self._text_mxq_uses_rope_input():
+            return None, 0
+
+        if not prompt_token_ids:
+            if mm_features:
+                raise RuntimeError(
+                    "Qwen3-VL 3-input text MXQ requires prompt_token_ids to build multimodal MRoPE positions."
+                )
+            position_ids = torch.arange(prompt_len, dtype=torch.long).view(1, 1, -1).expand(3, 1, -1)
+            return self._build_rope_embeddings_from_position_ids(position_ids), 0
+
+        get_mrope_input_positions = getattr(self.model, "get_mrope_input_positions", None)
+        if callable(get_mrope_input_positions) and mm_features:
+            position_ids, mrope_delta = get_mrope_input_positions(prompt_token_ids, mm_features)
+            position_ids = torch.as_tensor(position_ids, dtype=torch.long)
+            if position_ids.ndim == 2:
+                position_ids = position_ids.unsqueeze(1)
+            delta = int(torch.as_tensor(mrope_delta).reshape(-1)[0].item())
+            return self._build_rope_embeddings_from_position_ids(position_ids), delta
+
+        input_ids = torch.as_tensor(prompt_token_ids, dtype=torch.long).view(1, -1)
+        image_grids = []
+        if mm_features:
+            for feature in mm_features:
+                if not str(getattr(feature, "modality", "")).startswith("image"):
+                    continue
+                image_grid_thw = self._normalize_grid_thw(
+                    self._extract_multimodal_value(feature, "image_grid_thw")
+                )
+                if image_grid_thw is not None:
+                    image_grids.append(image_grid_thw)
+
+        get_rope_index = getattr(getattr(self.model, "model", None), "get_rope_index", None)
+        if callable(get_rope_index) and image_grids:
+            position_ids, mrope_delta = get_rope_index(
+                input_ids=input_ids,
+                image_grid_thw=torch.cat(image_grids, dim=0),
+            )
+            delta = int(torch.as_tensor(mrope_delta).reshape(-1)[0].item())
+            return self._build_rope_embeddings_from_position_ids(position_ids), delta
+
+        if mm_features:
+            raise RuntimeError(
+                "Qwen3-VL 3-input text MXQ requires get_mrope_input_positions() or "
+                "model.get_rope_index() to build multimodal MRoPE positions."
+            )
+
+        position_ids = torch.arange(input_ids.shape[1], dtype=torch.long).view(1, 1, -1).expand(3, 1, -1)
+        return self._build_rope_embeddings_from_position_ids(position_ids), 0
+
+    def _build_rope_input_embeds(
+        self,
+        req_state: RequestState,
+        start: int,
+        end: int,
+    ) -> Optional[np.ndarray]:
+        prompt_rope = req_state.prompt_rope_embeds
+        if prompt_rope is None:
+            return None
+        if end < start:
+            raise RuntimeError(f"Invalid token slice: start={start}, end={end}")
+        if end == start:
+            return np.empty((1, 0, prompt_rope.shape[-1]), dtype=np.float32)
+
+        pieces: list[np.ndarray] = []
+        prompt_start = min(start, req_state.prompt_len)
+        prompt_end = min(end, req_state.prompt_len)
+        if prompt_end > prompt_start:
+            pieces.append(prompt_rope[:, prompt_start:prompt_end, :])
+
+        if end > req_state.prompt_len:
+            decode_start = max(start, req_state.prompt_len)
+            position_ids = torch.arange(
+                decode_start + req_state.mrope_position_delta,
+                end + req_state.mrope_position_delta,
+                dtype=torch.long,
+            ).view(1, 1, -1).expand(3, 1, -1)
+            pieces.append(self._build_rope_embeddings_from_position_ids(position_ids))
+
+        if not pieces:
+            return np.empty((1, 0, prompt_rope.shape[-1]), dtype=np.float32)
+        if len(pieces) == 1:
+            return pieces[0].astype(np.float32, copy=False)
+        return np.concatenate(pieces, axis=1).astype(np.float32, copy=False)
+
     def _ensure_batch_vlm_supported(self, req_state: RequestState) -> None:
         if getattr(req_state, "is_multimodal", False):
             if req_state.prompt_deepstack_embeds is not None and not self._supports_deepstack_input():
@@ -1151,10 +1268,16 @@ class MbltWorker(WorkerBase):
         except Exception:
             return []
 
+    def _text_mxq_uses_rope_input(self) -> bool:
+        if not self._supports_deepstack_input():
+            return False
+        return len(self._cache_model_input_shapes(self._get_cache_model())) >= 3
+
     def _build_infer_inputs(
         self,
         input_embeds: np.ndarray,
         deepstack_embeds: Optional[np.ndarray],
+        rope_embeds: Optional[np.ndarray] = None,
     ) -> np.ndarray | list[np.ndarray]:
         cache_model = self._get_cache_model()
         input_shapes = self._cache_model_input_shapes(cache_model)
@@ -1166,7 +1289,36 @@ class MbltWorker(WorkerBase):
                 raise RuntimeError("Deepstack embeddings are only supported for Qwen3-VL models.")
             return batched_input
 
-        deepstack_shape = input_shapes[1]
+        uses_rope_input = len(input_shapes) >= 3
+        rope_shape = input_shapes[1] if uses_rope_input else None
+        deepstack_shape = input_shapes[2] if uses_rope_input else input_shapes[1]
+        if uses_rope_input:
+            if rope_embeds is None:
+                raise RuntimeError("Qwen3-VL 3-input text MXQ requires RoPE embeddings.")
+            if len(rope_shape) != 3:
+                raise RuntimeError(
+                    "3-input Qwen3-VL text MXQ rope input must have rank 3 "
+                    f"(1, sequence, pe_size), but got shape={rope_shape}."
+                )
+            expected_rope_batch, expected_rope_seq, expected_rope_size = rope_shape
+            if expected_rope_batch not in (-1, 1):
+                raise RuntimeError(f"3-input Qwen3-VL text MXQ rope batch dimension must be 1, got {rope_shape}.")
+            if expected_rope_seq > 0 and expected_rope_seq != input_embeds.shape[0]:
+                raise RuntimeError(
+                    "3-input Qwen3-VL text MXQ rope sequence dimension mismatch: "
+                    f"expected={expected_rope_seq}, input_seq_len={input_embeds.shape[0]}, shape={rope_shape}."
+                )
+            if expected_rope_size > 0 and expected_rope_size != rope_embeds.shape[-1]:
+                raise RuntimeError(
+                    "3-input Qwen3-VL text MXQ rope hidden dimension mismatch: "
+                    f"expected={expected_rope_size}, rope_size={rope_embeds.shape[-1]}, shape={rope_shape}."
+                )
+            expected_rope_shape = (1, int(input_embeds.shape[0]), int(rope_embeds.shape[-1]))
+            if tuple(rope_embeds.shape) != expected_rope_shape:
+                raise RuntimeError(
+                    "RoPE embedding shape mismatch for 3-input Qwen3-VL text MXQ: "
+                    f"expected={expected_rope_shape}, got={tuple(rope_embeds.shape)}."
+                )
         if len(deepstack_shape) != 3:
             raise RuntimeError(
                 "Dual-input model deepstack input must have rank 3 "
@@ -1207,12 +1359,19 @@ class MbltWorker(WorkerBase):
                     "Deepstack embedding shape mismatch for dual-input model: "
                     f"expected={expected_shape}, got={tuple(deepstack_embeds.shape)}."
                 )
+        if uses_rope_input:
+            return [
+                batched_input,
+                rope_embeds.astype(np.float32, copy=False),
+                deepstack_embeds.astype(np.float32, copy=False),
+            ]
         return [batched_input, deepstack_embeds.astype(np.float32, copy=False)]
 
     def _build_batch_infer_inputs(
         self,
         input_embeds_batch: list[np.ndarray],
         deepstack_embeds_batch: Optional[list[Optional[np.ndarray]]],
+        rope_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
     ) -> list[np.ndarray]:
         cache_model = self._get_cache_model()
         input_shapes = self._cache_model_input_shapes(cache_model)
@@ -1221,6 +1380,11 @@ class MbltWorker(WorkerBase):
             raise RuntimeError(
                 "Batched deepstack inputs must match input embeddings: "
                 f"input_embeds={len(input_embeds_batch)}, deepstack={len(deepstack_embeds_batch)}"
+            )
+        if rope_embeds_batch is not None and len(rope_embeds_batch) != len(input_embeds_batch):
+            raise RuntimeError(
+                "Batched RoPE inputs must match input embeddings: "
+                f"input_embeds={len(input_embeds_batch)}, rope={len(rope_embeds_batch)}"
             )
         if deepstack_embeds_batch is not None and not has_deepstack_input:
             if any(deepstack_embeds is not None for deepstack_embeds in deepstack_embeds_batch):
@@ -1246,7 +1410,27 @@ class MbltWorker(WorkerBase):
                 text_input = np.expand_dims(text_input, axis=0)
             return [text_input]
 
-        deepstack_shape = input_shapes[1]
+        hidden_size = int(concat_input.shape[-1])
+        packed_tokens = int(concat_input.shape[0])
+        uses_rope_input = len(input_shapes) >= 3
+        rope_shape = input_shapes[1] if uses_rope_input else None
+        deepstack_shape = input_shapes[2] if uses_rope_input else input_shapes[1]
+        if uses_rope_input:
+            if rope_embeds_batch is None:
+                raise RuntimeError("Qwen3-VL 3-input batch text MXQ requires batched RoPE embeddings.")
+            if len(rope_shape) != 3:
+                raise RuntimeError(
+                    "3-input Qwen3-VL batch text MXQ rope input must have rank 3 "
+                    f"(1, packed_tokens, pe_size), but got shape={rope_shape}."
+                )
+            expected_rope_batch, expected_rope_seq, expected_rope_size = rope_shape
+            if expected_rope_batch not in (-1, 1):
+                raise RuntimeError(f"3-input Qwen3-VL batch text MXQ rope batch dimension must be 1, got {rope_shape}.")
+            if expected_rope_seq > 0 and expected_rope_seq != packed_tokens:
+                raise RuntimeError(
+                    "3-input Qwen3-VL batch text MXQ rope packed-token dimension mismatch: "
+                    f"expected={expected_rope_seq}, packed_tokens={packed_tokens}, shape={rope_shape}."
+                )
         if len(deepstack_shape) != 3:
             raise RuntimeError(
                 "Dual-input batch model deepstack input must have rank 3 "
@@ -1259,8 +1443,6 @@ class MbltWorker(WorkerBase):
                 f"but got shape={deepstack_shape}."
             )
 
-        hidden_size = int(concat_input.shape[-1])
-        packed_tokens = int(concat_input.shape[0])
         if expected_seq_len > 0 and expected_seq_len != packed_tokens:
             raise RuntimeError(
                 "Dual-input batch model deepstack packed-token dimension mismatch: "
@@ -1288,7 +1470,34 @@ class MbltWorker(WorkerBase):
                 deepstack_embeds = deepstack_embeds.astype(np.float32, copy=False)
             deepstack_chunks.append(deepstack_embeds)
 
-        return [text_input, np.concatenate(deepstack_chunks, axis=1)]
+        if not uses_rope_input:
+            return [text_input, np.concatenate(deepstack_chunks, axis=1)]
+
+        rope_chunks: list[np.ndarray] = []
+        assert rope_embeds_batch is not None
+        for i, input_embeds in enumerate(input_embeds_batch):
+            seq_len = int(input_embeds.shape[0])
+            rope_embeds = rope_embeds_batch[i]
+            if rope_embeds is None:
+                raise RuntimeError("Qwen3-VL 3-input batch text MXQ is missing RoPE embeddings for a request.")
+            expected_rope_shape = (1, seq_len, int(rope_embeds.shape[-1]))
+            if tuple(rope_embeds.shape) != expected_rope_shape:
+                raise RuntimeError(
+                    "Batched RoPE embedding shape mismatch for 3-input Qwen3-VL text MXQ: "
+                    f"expected={expected_rope_shape}, got={tuple(rope_embeds.shape)}."
+                )
+            if expected_rope_size > 0 and expected_rope_size != rope_embeds.shape[-1]:
+                raise RuntimeError(
+                    "3-input Qwen3-VL batch text MXQ rope hidden dimension mismatch: "
+                    f"expected={expected_rope_size}, rope_size={rope_embeds.shape[-1]}, shape={rope_shape}."
+                )
+            rope_chunks.append(rope_embeds.astype(np.float32, copy=False))
+
+        return [
+            text_input,
+            np.concatenate(rope_chunks, axis=1),
+            np.concatenate(deepstack_chunks, axis=1),
+        ]
 
     @staticmethod
     def _last_token_logits(logits: np.ndarray) -> np.ndarray:
@@ -1424,9 +1633,10 @@ class MbltWorker(WorkerBase):
         input_embeds: np.ndarray,
         deepstack_embeds: Optional[np.ndarray],
         cache_size: int,
+        rope_embeds: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         cache_model = self._get_cache_model()
-        infer_inputs = self._build_infer_inputs(input_embeds, deepstack_embeds)
+        infer_inputs = self._build_infer_inputs(input_embeds, deepstack_embeds, rope_embeds=rope_embeds)
         output_buffers = self._infer_output_buffers
 
         if output_buffers is not None and self._can_reuse_output_buffers(
@@ -1456,9 +1666,10 @@ class MbltWorker(WorkerBase):
         input_embeds: np.ndarray,
         deepstack_embeds: Optional[np.ndarray],
         cache_size: int,
+        rope_embeds: Optional[np.ndarray] = None,
     ) -> InferenceLogits:
         cache_model = self._get_cache_model()
-        infer_inputs = self._build_infer_inputs(input_embeds, deepstack_embeds)
+        infer_inputs = self._build_infer_inputs(input_embeds, deepstack_embeds, rope_embeds=rope_embeds)
         output_buffers = self._infer_output_buffers
 
         if output_buffers is not None and self._can_reuse_output_buffers(
@@ -1493,6 +1704,7 @@ class MbltWorker(WorkerBase):
         cache_sizes: list[int],
         cache_ids: list[int],
         deepstack_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
+        rope_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
     ) -> list[np.ndarray]:
         if not input_embeds_batch:
             return []
@@ -1505,7 +1717,11 @@ class MbltWorker(WorkerBase):
             cache_ids=cache_ids,
         )
 
-        infer_inputs = self._build_batch_infer_inputs(input_embeds_batch, deepstack_embeds_batch)
+        infer_inputs = self._build_batch_infer_inputs(
+            input_embeds_batch,
+            deepstack_embeds_batch,
+            rope_embeds_batch=rope_embeds_batch,
+        )
         infer_output = cache_model.infer(infer_inputs, params=params)
 
         logits = infer_output[0] if isinstance(infer_output, (list, tuple)) else infer_output
@@ -1538,6 +1754,7 @@ class MbltWorker(WorkerBase):
         cache_sizes: list[int],
         cache_ids: list[int],
         deepstack_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
+        rope_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
     ) -> list[InferenceLogits]:
         if not input_embeds_batch:
             return []
@@ -1550,7 +1767,11 @@ class MbltWorker(WorkerBase):
             cache_ids=cache_ids,
         )
 
-        infer_inputs = self._build_batch_infer_inputs(input_embeds_batch, deepstack_embeds_batch)
+        infer_inputs = self._build_batch_infer_inputs(
+            input_embeds_batch,
+            deepstack_embeds_batch,
+            rope_embeds_batch=rope_embeds_batch,
+        )
         infer_output = cache_model.infer(infer_inputs, params=params)
         logits = infer_output[0] if isinstance(infer_output, (list, tuple)) else infer_output
         logits_np = np.asarray(logits)
@@ -1590,6 +1811,7 @@ class MbltWorker(WorkerBase):
         cache_sizes: list[int],
         cache_ids: list[int],
         deepstack_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
+        rope_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
     ) -> dict[int, InferenceLogits]:
         if not output_indices:
             return {}
@@ -1604,6 +1826,11 @@ class MbltWorker(WorkerBase):
                 "Normal batch deepstack inputs must match input embeddings: "
                 f"input_embeds={len(input_embeds_batch)}, deepstack={len(deepstack_embeds_batch)}"
             )
+        if rope_embeds_batch is not None and len(rope_embeds_batch) != len(input_embeds_batch):
+            raise RuntimeError(
+                "Normal batch RoPE inputs must match input embeddings: "
+                f"input_embeds={len(input_embeds_batch)}, rope={len(rope_embeds_batch)}"
+            )
 
         token_cap = self._normal_batch_chunk_token_cap()
         states = [
@@ -1611,14 +1838,16 @@ class MbltWorker(WorkerBase):
                 output_index=output_index,
                 input_embeds=input_embeds,
                 deepstack_embeds=None if deepstack_embeds_batch is None else deepstack_embeds,
+                rope_embeds=None if rope_embeds_batch is None else rope_embeds,
                 cache_size=cache_size,
                 cache_id=cache_id,
                 full_sequence_logits=[],
             )
-            for output_index, input_embeds, deepstack_embeds, cache_size, cache_id in zip(
+            for output_index, input_embeds, deepstack_embeds, rope_embeds, cache_size, cache_id in zip(
                 output_indices,
                 input_embeds_batch,
                 [None] * len(input_embeds_batch) if deepstack_embeds_batch is None else deepstack_embeds_batch,
+                [None] * len(input_embeds_batch) if rope_embeds_batch is None else rope_embeds_batch,
                 cache_sizes,
                 cache_ids,
             )
@@ -1633,6 +1862,7 @@ class MbltWorker(WorkerBase):
                 batch_states = active_states[batch_start : batch_start + self.max_batch_size]
                 chunk_embeds_batch: list[np.ndarray] = []
                 chunk_deepstack_batch: list[Optional[np.ndarray]] = []
+                chunk_rope_batch: list[Optional[np.ndarray]] = []
                 chunk_cache_sizes: list[int] = []
                 chunk_cache_ids: list[int] = []
                 for state in batch_states:
@@ -1648,6 +1878,9 @@ class MbltWorker(WorkerBase):
                         if state.deepstack_embeds is None
                         else state.deepstack_embeds[:, chunk_start:chunk_end, :]
                     )
+                    chunk_rope_batch.append(
+                        None if state.rope_embeds is None else state.rope_embeds[:, chunk_start:chunk_end, :]
+                    )
                     chunk_cache_sizes.append(state.cache_size)
                     chunk_cache_ids.append(state.cache_id)
 
@@ -1657,6 +1890,8 @@ class MbltWorker(WorkerBase):
                 infer_kwargs: dict[str, object] = {}
                 if any(deepstack_embeds is not None for deepstack_embeds in chunk_deepstack_batch):
                     infer_kwargs["deepstack_embeds_batch"] = chunk_deepstack_batch
+                if any(rope_embeds is not None for rope_embeds in chunk_rope_batch):
+                    infer_kwargs["rope_embeds_batch"] = chunk_rope_batch
                 logits_batch = self._infer_logits_batch_with_sequence(
                     input_embeds_batch=chunk_embeds_batch,
                     cache_sizes=chunk_cache_sizes,
@@ -1865,10 +2100,13 @@ class MbltWorker(WorkerBase):
                 if req_state.prompt_deepstack_embeds is not None
                 else None
             )
+            input_rope = self._build_rope_input_embeds(req_state, input_start, input_end)
             if cache_id is not None:
                 infer_kwargs: dict[str, object] = {}
                 if input_deepstack is not None:
                     infer_kwargs["deepstack_embeds_batch"] = [input_deepstack]
+                if input_rope is not None:
+                    infer_kwargs["rope_embeds_batch"] = [input_rope]
                 logits = self._infer_logits_batch(
                     input_embeds_batch=[input_embeds],
                     cache_sizes=[fallback_cache_size],
@@ -1876,7 +2114,15 @@ class MbltWorker(WorkerBase):
                     **infer_kwargs,
                 )[0]
             else:
-                logits = self._infer_logits(input_embeds, input_deepstack, cache_size=fallback_cache_size)
+                if input_rope is None:
+                    logits = self._infer_logits(input_embeds, input_deepstack, cache_size=fallback_cache_size)
+                else:
+                    logits = self._infer_logits(
+                        input_embeds,
+                        input_deepstack,
+                        cache_size=fallback_cache_size,
+                        rope_embeds=input_rope,
+                    )
             # _infer_logits may return a view into qbruntime's reusable output
             # buffer.  Prompt logprob replay/microstep paths keep one row per
             # prompt position, so each row must be detached immediately.  If we
@@ -1961,6 +2207,7 @@ class MbltWorker(WorkerBase):
                 batch_states = active_states[batch_start : batch_start + self.max_batch_size]
                 input_embeds_batch: list[np.ndarray] = []
                 deepstack_embeds_batch: list[Optional[np.ndarray]] = []
+                rope_embeds_batch: list[Optional[np.ndarray]] = []
                 cache_sizes: list[int] = []
                 cache_ids: list[int] = []
 
@@ -1979,14 +2226,18 @@ class MbltWorker(WorkerBase):
                         if state.req_state.prompt_deepstack_embeds is not None
                         else None
                     )
+                    input_rope = self._build_rope_input_embeds(state.req_state, input_start, input_end)
                     input_embeds_batch.append(input_embeds)
                     deepstack_embeds_batch.append(input_deepstack)
+                    rope_embeds_batch.append(input_rope)
                     cache_sizes.append(state.fallback_cache_size)
                     cache_ids.append(state.cache_id)
 
                 infer_kwargs: dict[str, object] = {}
                 if any(deepstack_embeds is not None for deepstack_embeds in deepstack_embeds_batch):
                     infer_kwargs["deepstack_embeds_batch"] = deepstack_embeds_batch
+                if any(rope_embeds is not None for rope_embeds in rope_embeds_batch):
+                    infer_kwargs["rope_embeds_batch"] = rope_embeds_batch
                 logits_batch = self._infer_logits_batch(
                     input_embeds_batch=input_embeds_batch,
                     cache_sizes=cache_sizes,
@@ -2066,12 +2317,18 @@ class MbltWorker(WorkerBase):
                     self._build_deepstack_input_embeds(state.req_state, state.cache_size, state.cache_size + 1)
                     for state in batch_states
                 ]
+                rope_embeds_batch = [
+                    self._build_rope_input_embeds(state.req_state, state.cache_size, state.cache_size + 1)
+                    for state in batch_states
+                ]
                 cache_sizes = [state.cache_size for state in batch_states]
                 cache_ids = [state.cache_id for state in batch_states]
 
                 infer_kwargs: dict[str, object] = {}
                 if any(deepstack_embeds is not None for deepstack_embeds in deepstack_embeds_batch):
                     infer_kwargs["deepstack_embeds_batch"] = deepstack_embeds_batch
+                if any(rope_embeds is not None for rope_embeds in rope_embeds_batch):
+                    infer_kwargs["rope_embeds_batch"] = rope_embeds_batch
                 logits_batch = self._infer_logits_batch(
                     input_embeds_batch=input_embeds_batch,
                     cache_sizes=cache_sizes,
@@ -2147,7 +2404,16 @@ class MbltWorker(WorkerBase):
         while cache_size < scheduled_end:
             input_embeds = self._build_input_embeds(req_state, cache_size, cache_size + 1)
             deepstack_embeds = self._build_deepstack_input_embeds(req_state, cache_size, cache_size + 1)
-            logits = self._infer_logits(input_embeds, deepstack_embeds, cache_size=cache_size)
+            rope_embeds = self._build_rope_input_embeds(req_state, cache_size, cache_size + 1)
+            if rope_embeds is None:
+                logits = self._infer_logits(input_embeds, deepstack_embeds, cache_size=cache_size)
+            else:
+                logits = self._infer_logits(
+                    input_embeds,
+                    deepstack_embeds,
+                    cache_size=cache_size,
+                    rope_embeds=rope_embeds,
+                )
             # Keep a copy of the position-specific logits row.  _infer_logits
             # can return a view into self._infer_output_buffers/qbruntime output
             # memory, which is overwritten by the next infer() call.
@@ -2967,6 +3233,11 @@ class MbltWorker(WorkerBase):
             prompt_deepstack_embeds_np = (
                 self._to_cpu_float32_numpy(prompt_deepstack_embeds) if prompt_deepstack_embeds is not None else None
             )
+            prompt_rope_embeds_np, mrope_position_delta = self._build_prompt_rope_embeds(
+                new_req.prompt_token_ids,
+                new_req.mm_features,
+                int(prompt_embeds_np.shape[0]),
+            )
             cache_slot_id = self._assign_cache_slot(new_req.req_id) if self._is_batch_model() else None
 
             self.req_states[new_req.req_id] = RequestState(
@@ -2984,6 +3255,8 @@ class MbltWorker(WorkerBase):
                 num_output_tokens=0,
                 prompt_embeds=prompt_embeds_np,
                 prompt_deepstack_embeds=prompt_deepstack_embeds_np,
+                prompt_rope_embeds=prompt_rope_embeds_np,
+                mrope_position_delta=mrope_position_delta,
                 is_multimodal=bool(new_req.mm_features),
                 prompt_len=int(prompt_embeds_np.shape[0]),
                 prompt_token_ids=new_req.prompt_token_ids or [],
@@ -3074,6 +3347,7 @@ class MbltWorker(WorkerBase):
 
             input_embeds_batch: list[np.ndarray] = []
             deepstack_embeds_batch: list[Optional[np.ndarray]] = []
+            rope_embeds_batch: list[Optional[np.ndarray]] = []
             cache_sizes: list[int] = []
             cache_ids: list[int] = []
             microstep_indices: list[int] = []
@@ -3097,6 +3371,7 @@ class MbltWorker(WorkerBase):
                 )
                 input_embeds = self._build_input_embeds(req_state, cache_size, scheduled_end)
                 deepstack_embeds = self._build_deepstack_input_embeds(req_state, cache_size, scheduled_end)
+                rope_embeds = self._build_rope_input_embeds(req_state, cache_size, scheduled_end)
                 sequence_length = int(input_embeds.shape[0])
                 next_cache_size = cache_size + sequence_length
                 req_state.is_prefill = scheduled_end < req_state.prompt_len
@@ -3108,6 +3383,7 @@ class MbltWorker(WorkerBase):
                 sequence_lengths.append(sequence_length)
                 input_embeds_batch.append(input_embeds)
                 deepstack_embeds_batch.append(deepstack_embeds)
+                rope_embeds_batch.append(rope_embeds)
                 cache_sizes.append(cache_size)
                 cache_ids.append(slot_id)
 
@@ -3141,6 +3417,7 @@ class MbltWorker(WorkerBase):
                     cache_sizes=[cache_sizes[i] for i in normal_indices],
                     cache_ids=[cache_ids[i] for i in normal_indices],
                     deepstack_embeds_batch=[deepstack_embeds_batch[i] for i in normal_indices],
+                    rope_embeds_batch=[rope_embeds_batch[i] for i in normal_indices],
                 )
                 for i, inference_logits in normal_logits.items():
                     batched_logits[i] = inference_logits
@@ -3222,6 +3499,11 @@ class MbltWorker(WorkerBase):
                     cache_size,
                     scheduled_end,
                 )
+                rope_embeds = self._build_rope_input_embeds(
+                    req_state,
+                    cache_size,
+                    scheduled_end,
+                )
                 sequence_length = int(input_embeds.shape[0])
                 next_cache_size = cache_size + sequence_length
                 req_state.is_prefill = scheduled_end < req_state.prompt_len
@@ -3242,6 +3524,7 @@ class MbltWorker(WorkerBase):
                         input_embeds,
                         deepstack_embeds,
                         cache_size=cache_size,
+                        rope_embeds=rope_embeds,
                     )
                 prompt_logprob_pos_before = req_state.next_prompt_logprob_pos
                 self._get_completed_prompt_logprobs_tensors_for_scheduler(
@@ -3267,6 +3550,11 @@ class MbltWorker(WorkerBase):
                         0,
                         scheduled_end,
                     )
+                    rope_embeds = self._build_rope_input_embeds(
+                        req_state,
+                        0,
+                        scheduled_end,
+                    )
                     sequence_length = int(input_embeds.shape[0])
                     next_cache_size = sequence_length
                     next_cache_sizes[-1] = next_cache_size
@@ -3275,6 +3563,7 @@ class MbltWorker(WorkerBase):
                         input_embeds,
                         deepstack_embeds,
                         cache_size=0,
+                        rope_embeds=rope_embeds,
                     )
                 # The live accelerator KV now belongs to this request at
                 # next_cache_size tokens, so later same-request decode can reuse it

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -101,6 +101,19 @@ def _normalize_model_kwargs_for_hf_config(
     return normalized
 
 
+def _positive_int_attr(root: object, path: str) -> Optional[int]:
+    value = root
+    for attr in path.split("."):
+        value = getattr(value, attr, None)
+        if value is None:
+            return None
+    try:
+        int_value = int(value)
+    except (TypeError, ValueError):
+        return None
+    return int_value if int_value > 0 else None
+
+
 @dataclass
 class RequestState:
     is_prefill: bool
@@ -1682,10 +1695,32 @@ class MbltWorker(WorkerBase):
         if num_prompt_logprobs is None:
             return None
         if num_prompt_logprobs == -1:
-            if self.model is None:
-                raise RuntimeError("Model is not initialized.")
-            return int(self.model.config.vocab_size)
+            return self._resolve_vocab_size()
         return int(num_prompt_logprobs)
+
+    def _resolve_vocab_size(self) -> int:
+        if self.model is None:
+            raise RuntimeError("Model is not initialized.")
+
+        candidates = (
+            (getattr(self.model, "config", None), "vocab_size", "model.config.vocab_size"),
+            (getattr(self.model, "config", None), "text_config.vocab_size", "model.config.text_config.vocab_size"),
+            (getattr(self.model_config, "hf_config", None), "vocab_size", "model_config.hf_config.vocab_size"),
+            (
+                getattr(self.model_config, "hf_config", None),
+                "text_config.vocab_size",
+                "model_config.hf_config.text_config.vocab_size",
+            ),
+        )
+        for root, path, _source in candidates:
+            if root is None:
+                continue
+            vocab_size = _positive_int_attr(root, path)
+            if vocab_size is not None:
+                return vocab_size
+
+        searched = ", ".join(source for _root, _path, source in candidates)
+        raise RuntimeError(f"Unable to resolve a positive vocab_size for MBLT sampling state. Checked: {searched}.")
 
     def _should_recompute_prompt_logprobs_from_start(self, req_state: RequestState) -> bool:
         return (
@@ -2794,10 +2829,12 @@ class MbltWorker(WorkerBase):
             if max_num_logprobs < 0:
                 max_num_logprobs = 0
 
+        vocab_size = self._resolve_vocab_size()
+
         return CachedSamplingState(
             temperature=float(sampling_params.temperature),
             top_p=float(sampling_params.top_p),
-            top_k=int(sampling_params.top_k if sampling_params.top_k > 0 else self.model.config.vocab_size),
+            top_k=int(sampling_params.top_k if sampling_params.top_k > 0 else vocab_size),
             frequency_penalty=frequency_penalty,
             presence_penalty=presence_penalty,
             repetition_penalty=repetition_penalty,
@@ -2823,7 +2860,7 @@ class MbltWorker(WorkerBase):
 
         prompt_token_ids = torch.full(
             (len(prompt_token_ids_list), max_prompt_len),
-            fill_value=self.model.config.vocab_size,
+            fill_value=self._resolve_vocab_size(),
             dtype=torch.int64,
         )
         for row, token_ids in enumerate(prompt_token_ids_list):

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1156,7 +1156,8 @@ class MbltWorker(WorkerBase):
                 "Qwen3-VL 3-input text MXQ requires a callable language_model.rotary_emb "
                 "to build RoPE input tensors."
             )
-        return np.asarray(rotary_emb(None, position_ids), dtype=np.float32)
+        rotary_context = torch.empty((), device=position_ids.device, dtype=torch.float32)
+        return np.asarray(rotary_emb(rotary_context, position_ids), dtype=np.float32)
 
     def _build_prompt_rope_embeds(
         self,

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -3133,6 +3133,8 @@ class MbltWorker(WorkerBase):
             batched_logits: list[Optional[InferenceLogits]] = [None for _ in req_ids]
 
             if normal_indices:
+                # Batch-compiled MXQs require BatchParam even when only one request
+                # is currently active; keep active batch size 1 on the batch helper.
                 normal_logits = self._infer_normal_logits_batch_chunked(
                     output_indices=normal_indices,
                     input_embeds_batch=[input_embeds_batch[i] for i in normal_indices],

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -176,6 +176,7 @@ class PromptLogprobMicrostepState:
 class NormalBatchChunkState:
     output_index: int
     input_embeds: np.ndarray
+    deepstack_embeds: Optional[np.ndarray]
     cache_id: int
     cache_size: int
     offset: int = 0
@@ -1118,19 +1119,14 @@ class MbltWorker(WorkerBase):
             return pieces[0]
         return np.concatenate(pieces, axis=1)
 
-    @staticmethod
-    def _ensure_batch_vlm_supported(req_state: RequestState) -> None:
-        # VLM batch execution is intentionally not implemented yet. Mobilint
-        # batch-compiled VLM artifacts are not available at the moment, so the
-        # batch path below only supports text-only language-model inputs. Keep
-        # this fail-fast guard near the batch scheduling path to avoid silently
-        # calling qbruntime with missing or unsupported VLM-specific inputs.
+    def _ensure_batch_vlm_supported(self, req_state: RequestState) -> None:
         if getattr(req_state, "is_multimodal", False):
-            raise RuntimeError(
-                "VLM batch execution is not supported yet. "
-                "Batch-compiled VLM artifacts are not available, so run VLM "
-                "models with max_batch_size=1 until batch VLM support is added."
-            )
+            if req_state.prompt_deepstack_embeds is not None and not self._supports_deepstack_input():
+                raise RuntimeError("Deepstack batch VLM inputs are only supported for Qwen3-VL models.")
+            if not self._is_multimodal_model():
+                raise RuntimeError(
+                    "Batch VLM execution is only supported for Mobilint Qwen2-VL and Qwen3-VL model types."
+                )
 
     @staticmethod
     def _cache_model_input_shapes(cache_model: Any) -> list[tuple[int, ...]]:
@@ -1199,6 +1195,87 @@ class MbltWorker(WorkerBase):
                     f"expected={expected_shape}, got={tuple(deepstack_embeds.shape)}."
                 )
         return [batched_input, deepstack_embeds.astype(np.float32, copy=False)]
+
+    def _build_batch_infer_inputs(
+        self,
+        input_embeds_batch: list[np.ndarray],
+        deepstack_embeds_batch: Optional[list[Optional[np.ndarray]]],
+    ) -> list[np.ndarray]:
+        cache_model = self._get_cache_model()
+        input_shapes = self._cache_model_input_shapes(cache_model)
+        has_deepstack_input = len(input_shapes) >= 2
+        if deepstack_embeds_batch is not None and len(deepstack_embeds_batch) != len(input_embeds_batch):
+            raise RuntimeError(
+                "Batched deepstack inputs must match input embeddings: "
+                f"input_embeds={len(input_embeds_batch)}, deepstack={len(deepstack_embeds_batch)}"
+            )
+        if deepstack_embeds_batch is not None and not has_deepstack_input:
+            if any(deepstack_embeds is not None for deepstack_embeds in deepstack_embeds_batch):
+                raise RuntimeError("Batched deepstack embeddings require a dual-input Qwen3-VL MXQ.")
+
+        concat_input = np.concatenate(input_embeds_batch, axis=0).astype(
+            np.float32,
+            copy=False,
+        )
+        text_input = np.expand_dims(concat_input, axis=0)
+
+        if not has_deepstack_input:
+            while text_input.ndim < 4:
+                text_input = np.expand_dims(text_input, axis=0)
+            return [text_input]
+
+        if not self._supports_deepstack_input():
+            if deepstack_embeds_batch is not None and any(
+                deepstack_embeds is not None for deepstack_embeds in deepstack_embeds_batch
+            ):
+                raise RuntimeError("Deepstack embeddings are only supported for Qwen3-VL models.")
+            while text_input.ndim < 4:
+                text_input = np.expand_dims(text_input, axis=0)
+            return [text_input]
+
+        deepstack_shape = input_shapes[1]
+        if len(deepstack_shape) != 3:
+            raise RuntimeError(
+                "Dual-input batch model deepstack input must have rank 3 "
+                f"(layers, packed_tokens, hidden), but got shape={deepstack_shape}."
+            )
+        expected_layers, expected_seq_len, expected_hidden = deepstack_shape
+        if expected_layers <= 0:
+            raise RuntimeError(
+                "Dual-input batch model deepstack layer dimension must be fixed and positive, "
+                f"but got shape={deepstack_shape}."
+            )
+
+        hidden_size = int(concat_input.shape[-1])
+        packed_tokens = int(concat_input.shape[0])
+        if expected_seq_len > 0 and expected_seq_len != packed_tokens:
+            raise RuntimeError(
+                "Dual-input batch model deepstack packed-token dimension mismatch: "
+                f"expected={expected_seq_len}, packed_tokens={packed_tokens}, shape={deepstack_shape}."
+            )
+        if expected_hidden > 0 and expected_hidden != hidden_size:
+            raise RuntimeError(
+                "Dual-input batch model deepstack hidden dimension mismatch: "
+                f"expected={expected_hidden}, hidden_size={hidden_size}, shape={deepstack_shape}."
+            )
+
+        deepstack_chunks: list[np.ndarray] = []
+        for i, input_embeds in enumerate(input_embeds_batch):
+            seq_len = int(input_embeds.shape[0])
+            deepstack_embeds = None if deepstack_embeds_batch is None else deepstack_embeds_batch[i]
+            if deepstack_embeds is None:
+                deepstack_embeds = np.zeros((int(expected_layers), seq_len, hidden_size), dtype=np.float32)
+            else:
+                expected_shape = (int(expected_layers), seq_len, hidden_size)
+                if tuple(deepstack_embeds.shape) != expected_shape:
+                    raise RuntimeError(
+                        "Batched deepstack embedding shape mismatch for dual-input model: "
+                        f"expected={expected_shape}, got={tuple(deepstack_embeds.shape)}."
+                    )
+                deepstack_embeds = deepstack_embeds.astype(np.float32, copy=False)
+            deepstack_chunks.append(deepstack_embeds)
+
+        return [text_input, np.concatenate(deepstack_chunks, axis=1)]
 
     @staticmethod
     def _last_token_logits(logits: np.ndarray) -> np.ndarray:
@@ -1402,6 +1479,7 @@ class MbltWorker(WorkerBase):
         input_embeds_batch: list[np.ndarray],
         cache_sizes: list[int],
         cache_ids: list[int],
+        deepstack_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
     ) -> list[np.ndarray]:
         if not input_embeds_batch:
             return []
@@ -1414,14 +1492,8 @@ class MbltWorker(WorkerBase):
             cache_ids=cache_ids,
         )
 
-        concat_input = np.concatenate(input_embeds_batch, axis=0).astype(
-            np.float32,
-            copy=False,
-        )
-        while concat_input.ndim < 4:
-            concat_input = np.expand_dims(concat_input, axis=0)
-
-        infer_output = cache_model.infer([concat_input], params=params)
+        infer_inputs = self._build_batch_infer_inputs(input_embeds_batch, deepstack_embeds_batch)
+        infer_output = cache_model.infer(infer_inputs, params=params)
 
         logits = infer_output[0] if isinstance(infer_output, (list, tuple)) else infer_output
         logits_np = np.asarray(logits)
@@ -1452,6 +1524,7 @@ class MbltWorker(WorkerBase):
         input_embeds_batch: list[np.ndarray],
         cache_sizes: list[int],
         cache_ids: list[int],
+        deepstack_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
     ) -> list[InferenceLogits]:
         if not input_embeds_batch:
             return []
@@ -1464,14 +1537,8 @@ class MbltWorker(WorkerBase):
             cache_ids=cache_ids,
         )
 
-        concat_input = np.concatenate(input_embeds_batch, axis=0).astype(
-            np.float32,
-            copy=False,
-        )
-        while concat_input.ndim < 4:
-            concat_input = np.expand_dims(concat_input, axis=0)
-
-        infer_output = cache_model.infer([concat_input], params=params)
+        infer_inputs = self._build_batch_infer_inputs(input_embeds_batch, deepstack_embeds_batch)
+        infer_output = cache_model.infer(infer_inputs, params=params)
         logits = infer_output[0] if isinstance(infer_output, (list, tuple)) else infer_output
         logits_np = np.asarray(logits)
         if logits_np.ndim == 3:
@@ -1509,16 +1576,20 @@ class MbltWorker(WorkerBase):
         input_embeds_batch: list[np.ndarray],
         cache_sizes: list[int],
         cache_ids: list[int],
+        deepstack_embeds_batch: Optional[list[Optional[np.ndarray]]] = None,
     ) -> dict[int, InferenceLogits]:
         if not output_indices:
             return {}
-        if not (
-            len(output_indices) == len(input_embeds_batch) == len(cache_sizes) == len(cache_ids)
-        ):
+        if not (len(output_indices) == len(input_embeds_batch) == len(cache_sizes) == len(cache_ids)):
             raise RuntimeError(
                 "Normal batch chunk inputs must have identical lengths: "
                 f"indices={len(output_indices)}, input_embeds={len(input_embeds_batch)}, "
                 f"cache_sizes={len(cache_sizes)}, cache_ids={len(cache_ids)}"
+            )
+        if deepstack_embeds_batch is not None and len(deepstack_embeds_batch) != len(input_embeds_batch):
+            raise RuntimeError(
+                "Normal batch deepstack inputs must match input embeddings: "
+                f"input_embeds={len(input_embeds_batch)}, deepstack={len(deepstack_embeds_batch)}"
             )
 
         token_cap = self._normal_batch_chunk_token_cap()
@@ -1526,13 +1597,15 @@ class MbltWorker(WorkerBase):
             NormalBatchChunkState(
                 output_index=output_index,
                 input_embeds=input_embeds,
+                deepstack_embeds=None if deepstack_embeds_batch is None else deepstack_embeds,
                 cache_size=cache_size,
                 cache_id=cache_id,
                 full_sequence_logits=[],
             )
-            for output_index, input_embeds, cache_size, cache_id in zip(
+            for output_index, input_embeds, deepstack_embeds, cache_size, cache_id in zip(
                 output_indices,
                 input_embeds_batch,
+                [None] * len(input_embeds_batch) if deepstack_embeds_batch is None else deepstack_embeds_batch,
                 cache_sizes,
                 cache_ids,
             )
@@ -1546,6 +1619,7 @@ class MbltWorker(WorkerBase):
             for batch_start in range(0, len(active_states), self.max_batch_size):
                 batch_states = active_states[batch_start : batch_start + self.max_batch_size]
                 chunk_embeds_batch: list[np.ndarray] = []
+                chunk_deepstack_batch: list[Optional[np.ndarray]] = []
                 chunk_cache_sizes: list[int] = []
                 chunk_cache_ids: list[int] = []
                 for state in batch_states:
@@ -1556,16 +1630,25 @@ class MbltWorker(WorkerBase):
                     chunk_start = state.offset
                     chunk_end = chunk_start + chunk_len
                     chunk_embeds_batch.append(state.input_embeds[chunk_start:chunk_end])
+                    chunk_deepstack_batch.append(
+                        None
+                        if state.deepstack_embeds is None
+                        else state.deepstack_embeds[:, chunk_start:chunk_end, :]
+                    )
                     chunk_cache_sizes.append(state.cache_size)
                     chunk_cache_ids.append(state.cache_id)
 
                 if not chunk_embeds_batch:
                     continue
 
+                infer_kwargs: dict[str, object] = {}
+                if any(deepstack_embeds is not None for deepstack_embeds in chunk_deepstack_batch):
+                    infer_kwargs["deepstack_embeds_batch"] = chunk_deepstack_batch
                 logits_batch = self._infer_logits_batch_with_sequence(
                     input_embeds_batch=chunk_embeds_batch,
                     cache_sizes=chunk_cache_sizes,
                     cache_ids=chunk_cache_ids,
+                    **infer_kwargs,
                 )
                 for state, chunk_embeds, inference_logits in zip(batch_states, chunk_embeds_batch, logits_batch):
                     chunk_len = int(chunk_embeds.shape[0])
@@ -1748,12 +1831,14 @@ class MbltWorker(WorkerBase):
                 else None
             )
             if cache_id is not None:
+                infer_kwargs: dict[str, object] = {}
                 if input_deepstack is not None:
-                    raise RuntimeError("Batch prompt-logprob fallback does not support deepstack embeddings.")
+                    infer_kwargs["deepstack_embeds_batch"] = [input_deepstack]
                 logits = self._infer_logits_batch(
                     input_embeds_batch=[input_embeds],
                     cache_sizes=[fallback_cache_size],
                     cache_ids=[cache_id],
+                    **infer_kwargs,
                 )[0]
             else:
                 logits = self._infer_logits(input_embeds, input_deepstack, cache_size=fallback_cache_size)
@@ -1793,9 +1878,6 @@ class MbltWorker(WorkerBase):
         first_prompt_pos = max(1, start_idx + 1, req_state.next_prompt_logprob_pos)
         if prompt_end <= first_prompt_pos:
             return None
-        if req_state.prompt_deepstack_embeds is not None:
-            raise RuntimeError("Batch prompt-logprob fallback does not support deepstack embeddings.")
-
         return PromptLogprobFallbackReplayState(
             output_index=output_index,
             req_state=req_state,
@@ -1843,6 +1925,7 @@ class MbltWorker(WorkerBase):
             for batch_start in range(0, len(active_states), self.max_batch_size):
                 batch_states = active_states[batch_start : batch_start + self.max_batch_size]
                 input_embeds_batch: list[np.ndarray] = []
+                deepstack_embeds_batch: list[Optional[np.ndarray]] = []
                 cache_sizes: list[int] = []
                 cache_ids: list[int] = []
 
@@ -1856,14 +1939,24 @@ class MbltWorker(WorkerBase):
                         input_end = prompt_pos
 
                     input_embeds = state.req_state.prompt_embeds[input_start:input_end]
+                    input_deepstack = (
+                        state.req_state.prompt_deepstack_embeds[:, input_start:input_end, :]
+                        if state.req_state.prompt_deepstack_embeds is not None
+                        else None
+                    )
                     input_embeds_batch.append(input_embeds)
+                    deepstack_embeds_batch.append(input_deepstack)
                     cache_sizes.append(state.fallback_cache_size)
                     cache_ids.append(state.cache_id)
 
+                infer_kwargs: dict[str, object] = {}
+                if any(deepstack_embeds is not None for deepstack_embeds in deepstack_embeds_batch):
+                    infer_kwargs["deepstack_embeds_batch"] = deepstack_embeds_batch
                 logits_batch = self._infer_logits_batch(
                     input_embeds_batch=input_embeds_batch,
                     cache_sizes=cache_sizes,
                     cache_ids=cache_ids,
+                    **infer_kwargs,
                 )
 
                 for state, input_embeds, logits in zip(batch_states, input_embeds_batch, logits_batch):
@@ -1934,13 +2027,21 @@ class MbltWorker(WorkerBase):
                     self._build_input_embeds(state.req_state, state.cache_size, state.cache_size + 1)
                     for state in batch_states
                 ]
+                deepstack_embeds_batch = [
+                    self._build_deepstack_input_embeds(state.req_state, state.cache_size, state.cache_size + 1)
+                    for state in batch_states
+                ]
                 cache_sizes = [state.cache_size for state in batch_states]
                 cache_ids = [state.cache_id for state in batch_states]
 
+                infer_kwargs: dict[str, object] = {}
+                if any(deepstack_embeds is not None for deepstack_embeds in deepstack_embeds_batch):
+                    infer_kwargs["deepstack_embeds_batch"] = deepstack_embeds_batch
                 logits_batch = self._infer_logits_batch(
                     input_embeds_batch=input_embeds_batch,
                     cache_sizes=cache_sizes,
                     cache_ids=cache_ids,
+                    **infer_kwargs,
                 )
 
                 for state, logits in zip(batch_states, logits_batch):
@@ -2935,6 +3036,7 @@ class MbltWorker(WorkerBase):
                 )
 
             input_embeds_batch: list[np.ndarray] = []
+            deepstack_embeds_batch: list[Optional[np.ndarray]] = []
             cache_sizes: list[int] = []
             cache_ids: list[int] = []
             microstep_indices: list[int] = []
@@ -2957,6 +3059,7 @@ class MbltWorker(WorkerBase):
                     print_debug=print_debug,
                 )
                 input_embeds = self._build_input_embeds(req_state, cache_size, scheduled_end)
+                deepstack_embeds = self._build_deepstack_input_embeds(req_state, cache_size, scheduled_end)
                 sequence_length = int(input_embeds.shape[0])
                 next_cache_size = cache_size + sequence_length
                 req_state.is_prefill = scheduled_end < req_state.prompt_len
@@ -2967,6 +3070,7 @@ class MbltWorker(WorkerBase):
                 next_cache_sizes.append(next_cache_size)
                 sequence_lengths.append(sequence_length)
                 input_embeds_batch.append(input_embeds)
+                deepstack_embeds_batch.append(deepstack_embeds)
                 cache_sizes.append(cache_size)
                 cache_ids.append(slot_id)
 
@@ -2997,6 +3101,7 @@ class MbltWorker(WorkerBase):
                     input_embeds_batch=[input_embeds_batch[i] for i in normal_indices],
                     cache_sizes=[cache_sizes[i] for i in normal_indices],
                     cache_ids=[cache_ids[i] for i in normal_indices],
+                    deepstack_embeds_batch=[deepstack_embeds_batch[i] for i in normal_indices],
                 )
                 for i, inference_logits in normal_logits.items():
                     batched_logits[i] = inference_logits

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1273,6 +1273,18 @@ class MbltWorker(WorkerBase):
             return False
         return len(self._cache_model_input_shapes(self._get_cache_model())) >= 3
 
+    def _qwen3_vl_text_extra_input_order(self) -> tuple[str, str]:
+        """Return the Qwen3-VL 3-input text MXQ extra-input order.
+
+        mblt-model-zoo 2.3.0 ships different 3-input signatures for dynamic
+        Qwen3-VL text artifacts: non-batch uses [inputs, deepstack, rope],
+        while Batch16 uses [inputs, rope, deepstack].
+        """
+
+        if self._is_batch_model():
+            return ("rope", "deepstack")
+        return ("deepstack", "rope")
+
     def _build_infer_inputs(
         self,
         input_embeds: np.ndarray,
@@ -1290,8 +1302,14 @@ class MbltWorker(WorkerBase):
             return batched_input
 
         uses_rope_input = len(input_shapes) >= 3
-        rope_shape = input_shapes[1] if uses_rope_input else None
-        deepstack_shape = input_shapes[2] if uses_rope_input else input_shapes[1]
+        if uses_rope_input:
+            first_extra, second_extra = self._qwen3_vl_text_extra_input_order()
+            extra_shapes = {first_extra: input_shapes[1], second_extra: input_shapes[2]}
+            rope_shape = extra_shapes["rope"]
+            deepstack_shape = extra_shapes["deepstack"]
+        else:
+            rope_shape = None
+            deepstack_shape = input_shapes[1]
         if uses_rope_input:
             if rope_embeds is None:
                 raise RuntimeError("Qwen3-VL 3-input text MXQ requires RoPE embeddings.")
@@ -1360,11 +1378,11 @@ class MbltWorker(WorkerBase):
                     f"expected={expected_shape}, got={tuple(deepstack_embeds.shape)}."
                 )
         if uses_rope_input:
-            return [
-                batched_input,
-                rope_embeds.astype(np.float32, copy=False),
-                deepstack_embeds.astype(np.float32, copy=False),
-            ]
+            extras = {
+                "rope": rope_embeds.astype(np.float32, copy=False),
+                "deepstack": deepstack_embeds.astype(np.float32, copy=False),
+            }
+            return [batched_input, *(extras[name] for name in self._qwen3_vl_text_extra_input_order())]
         return [batched_input, deepstack_embeds.astype(np.float32, copy=False)]
 
     def _build_batch_infer_inputs(
@@ -3011,6 +3029,9 @@ class MbltWorker(WorkerBase):
             trust_remote_code=True,
             **model_kwargs,
         )
+        sync_dynamic_vision_from_model = getattr(self.model, "sync_dynamic_vision_from_model", None)
+        if callable(sync_dynamic_vision_from_model):
+            sync_dynamic_vision_from_model()
         self._log_init_stage(
             "load_model:after_from_pretrained",
             start,


### PR DESCRIPTION
## 요약
- batch-compiled VLM 요청에서 기존 fail-fast 제한을 제거하고 Mobilint Qwen2-VL/Qwen3-VL batch 실행을 허용합니다.
- Qwen3-VL dual-input text MXQ에 packed text embeddings와 packed deepstack embeddings를 함께 전달하도록 batch infer 경로를 확장했습니다.
- batch VLM 동작, text-only batch shape 유지, max_batch_size=1 VLM 기존 경로 유지를 검증하는 테스트를 추가하고 README 제한 사항을 갱신했습니다.

## 검증
- `.venv/bin/pytest tests/test_mblt_worker_optimizations.py -q`
- `.venv/bin/pytest tests/test_runtime_cache.py tests/test_kv_cache_swap_spec.py tests/test_mblt_platform_prefill.py -q`
- `.venv/bin/pytest tests -q`
- `python -m compileall -q vllm_mblt tests`
- `.venv/bin/ruff check vllm_mblt tests`

## 참고
- `mblt-model-zoo` master의 Qwen3-VL batch deepstack packing 구현을 참고해 포팅했습니다.
- 실제 NPU end-to-end 요청은 이 환경에서 실행하지 못했고, 단위 테스트와 reference 구현 대조로 검증했습니다.