### PR TITLE
Address mxq serving sanity findings: live cache prefix invariants, sampling penalties, auto core mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - A finished or aborted batch request is no longer snapshotted when it does not
   own its live cache slot, so an abort before the first step can no longer
   publish another request's KV as a prefix snapshot.
+- Prefix snapshots are never labeled with more tokens than the live cache holds.
+  Dump-before-switch and dump-on-finish used the scheduler's
+  `num_computed_tokens`, so a cache holding a shorter prefix produced a snapshot
+  advertising KV that was not in the blobs, and a later load resumed past the
+  missing entries. The dump is now clamped to the tracked count, or skipped when
+  that count is zero.
 - `npu_prefill_chunk_size` / `max_batch_size` dicts now resolve for
   `core_mode: "auto"` artifacts when the dict holds exactly one usable entry,
   instead of silently falling back to the `128` default. Note that accepting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Fixed
+
+- Sampling penalties (`frequency_penalty`, `presence_penalty`,
+  `repetition_penalty`) are now applied by default instead of only when CUDA is
+  available. vLLM applies them through a pure-torch fallback when the fused
+  CUDA kernel is missing, so the CPU-hosted MBLT sampler can honour them. Set
+  `VLLM_MBLT_ENABLE_SAMPLING_PENALTIES=0` for the previous ignore-and-warn
+  behaviour.
+- The worker now tracks the token count held by each live runtime cache and
+  batch `cache_id` slot, and refuses the no-reload live-cache fast path when
+  that count disagrees with the scheduler's `num_computed_tokens`. Such a
+  divergence used to be served silently as fluent-but-wrong output; it now logs
+  a warning and rebuilds the prefix.
+- A finished or aborted batch request is no longer snapshotted when it does not
+  own its live cache slot, so an abort before the first step can no longer
+  publish another request's KV as a prefix snapshot.
+- `npu_prefill_chunk_size` / `max_batch_size` dicts now resolve for
+  `core_mode: "auto"` artifacts when the dict holds exactly one usable entry,
+  instead of silently falling back to the `128` default. Note that accepting
+  `"auto"` at model load still requires `normalize_core_mode` in
+  `mblt_model_zoo.utils.core_mode` to allow it.
+
 ### Breaking Changes
 
 - Moved Mobilint runtime cache snapshot, live-cache ownership, and accelerator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.1
 
 ### Fixed
 
@@ -29,6 +29,8 @@
   instead of silently falling back to the `128` default. Note that accepting
   `"auto"` at model load still requires `normalize_core_mode` in
   `mblt_model_zoo.utils.core_mode` to allow it.
+
+## 0.2.0
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ If a model config includes `npu_prefill_chunk_size`, `vllm-mblt` uses it to tune
 - Dict values are selected by `core_mode`.
 - `core_mode` is resolved from `--model-loader-extra-config` first, then from the model config default.
 - The selected value is applied to vLLM's `max_num_batched_tokens` for chunked prefill.
+- A `default` (or `DEFAULT`) key is used when the resolved `core_mode` has no entry.
+- `core_mode: "auto"` is never a dict key. When the resolved `core_mode` is `"auto"` (or is absent) and the
+  dict holds exactly one usable entry, that entry is used — a global-scheme batch mxq ships only the mode it
+  was compiled for. Multiple entries under `"auto"` are not guessed.
 - If no matching value is found, `vllm-mblt` falls back to `128`.
 - For batch-compiled models with `max_batch_size > 1`, the effective chunked prefill limit is clamped to `128`
   to match the qbruntime batch execution limit used by the worker.
@@ -289,6 +293,24 @@ variables or equivalent model loader extra config keys:
   to `0.9`.
 - `VLLM_MBLT_PREFIX_CACHE_CALIBRATE` defaults to enabled. Set `0` to skip
   startup prefill calibration.
+
+The worker also tracks how many tokens each live runtime cache (or batch
+`cache_id` slot) actually holds. A request may continue from a live cache
+without reloading only when that count matches the scheduler's
+`num_computed_tokens`. On a mismatch the worker logs a warning naming the
+request and `cache_id`, drops the ownership claim, and rebuilds the prefix
+instead of decoding against another sequence's KV. Seeing
+`MBLT runtime cache token count holds fewer tokens than the scheduler expects` in the log
+means measurements taken from that server should be re-checked.
+
+### Sampling Penalties
+
+`frequency_penalty`, `presence_penalty`, and `repetition_penalty` are applied
+by default on the CPU-hosted MBLT sampler. Set
+`VLLM_MBLT_ENABLE_SAMPLING_PENALTIES=0` to ignore them instead; the worker then
+logs once which penalties it dropped. Released MBLT packages ship
+`repetition_penalty` in `generation_config.json`, so ignoring them makes NPU
+output generated under different sampling than a GPU reference run.
 
 VLM prefix caching currently covers the language-model KV cache only. The
 worker may load a compatible LM KV prefix snapshot and run only the uncached

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -420,3 +420,40 @@ class TestMbltPlatformPrefill:
 
         assert config.scheduler_config.max_num_seqs == 32
         assert "Clamping scheduler max_num_seqs" not in caplog.text
+
+    def test_auto_core_mode_resolves_the_only_compiled_chunk_size_entry(self) -> None:
+        # A batch LLM compiled at a global scheme advertises core_mode "auto"
+        # and ships one core-mode entry: the mode it was actually compiled for.
+        config = _make_vllm_config({"global8": 512}, hf_core_mode="auto")
+
+        assert resolve_npu_prefill_chunk_size(config) == 512
+
+    def test_auto_core_mode_from_loader_extra_config_resolves_single_entry(self) -> None:
+        config = _make_vllm_config({"global8": 512}, loader_core_mode="auto")
+
+        assert resolve_npu_prefill_chunk_size(config) == 512
+
+    def test_auto_core_mode_prefers_an_explicit_default_entry(self) -> None:
+        config = _make_vllm_config({"global8": 512, "default": 256}, hf_core_mode="auto")
+
+        assert resolve_npu_prefill_chunk_size(config) == 256
+
+    def test_auto_core_mode_does_not_guess_between_multiple_entries(self, caplog) -> None:
+        caplog.set_level(logging.WARNING, logger="vllm_mblt.mblt_platform")
+        config = _make_vllm_config({"global8": 512, "single": 128}, hf_core_mode="auto")
+
+        assert resolve_npu_prefill_chunk_size(config) is None
+        assert "Could not resolve npu_prefill_chunk_size" in caplog.text
+
+    def test_explicit_core_mode_does_not_borrow_another_modes_chunk_size(self, caplog) -> None:
+        caplog.set_level(logging.WARNING, logger="vllm_mblt.mblt_platform")
+        config = _make_vllm_config({"global8": 512}, hf_core_mode="global4")
+
+        assert resolve_npu_prefill_chunk_size(config) is None
+        assert "Could not resolve npu_prefill_chunk_size" in caplog.text
+
+    def test_auto_core_mode_batch_model_clamps_effective_chunk_size(self) -> None:
+        config = _make_vllm_config({"global8": 512}, hf_core_mode="auto", max_batch_size=16)
+
+        assert resolve_npu_prefill_chunk_size(config) == 512
+        assert resolve_effective_npu_prefill_chunk_size(config) == 128

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -18,6 +18,7 @@ from vllm_mblt.mblt_worker import (
     RequestState,
     _is_multimodal_hf_config,
     _is_qwen3_vl_hf_config,
+    _resolve_enable_sampling_penalties,
 )
 from vllm_mblt.runtime_cache import MbltRuntimeCacheManager, RuntimeCacheRequest
 
@@ -3168,3 +3169,167 @@ class TestMbltWorkerOptimizations:
         worker.load_model()
 
         assert calls == ["sync"]
+
+    def test_batch_slot_live_cache_is_reused_when_token_count_matches(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+        load_calls: list[object] = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        worker.runtime_cache.mark_slot_owner(1, "request", 16)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(32)))
+        req_state.num_computed_tokens = 16
+        req_state.cache_slot_id = 1
+
+        cache_size = worker._load_snapshot_if_needed("request", req_state, slot_id=1)
+
+        assert cache_size == 16
+        assert load_calls == []
+
+    def test_batch_slot_live_cache_mismatch_rebuilds_prefix_and_warns(self, caplog) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+        load_calls: list[object] = []
+        worker._load_runtime_cache = lambda blobs, slot_id=None: load_calls.append((blobs, slot_id)) or True
+        # The slot holds 8 tokens while the scheduler believes 16 are computed.
+        worker.runtime_cache.mark_slot_owner(1, "request", 8)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(32)))
+        req_state.num_computed_tokens = 16
+        req_state.cache_slot_id = 1
+
+        with caplog.at_level("WARNING"):
+            cache_size = worker._load_snapshot_if_needed("request", req_state, slot_id=1)
+
+        assert cache_size == 0
+        assert load_calls == []
+        assert worker.runtime_cache.live_slot_tokens(1) == 0
+        assert worker._live_cache_prefix_incomplete_count == 1
+        assert "holds fewer tokens than the scheduler expects" in caplog.text
+
+    def test_single_cache_live_reuse_mismatch_rebuilds_prefix_and_warns(self, caplog) -> None:
+        worker = self._make_worker()
+        worker.runtime_cache.mark_loaded_request("request", 8)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(32)))
+        req_state.num_computed_tokens = 16
+
+        with caplog.at_level("WARNING"):
+            cache_size = worker._load_snapshot_if_needed("request", req_state)
+
+        assert cache_size == 0
+        assert worker.runtime_cache.loaded_req_id is None
+        assert worker._live_cache_prefix_incomplete_count == 1
+        assert "holds fewer tokens than the scheduler expects" in caplog.text
+
+    def test_execute_model_records_live_slot_token_count(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+        worker.max_seq_len = 256
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(temperature=0.0), [1, 2, 3, 4])
+        req_state.prompt_embeds = np.zeros((4, 8), dtype=np.float32)
+        req_state.prompt_len = 4
+        req_state.cache_slot_id = 0
+        worker.req_states = {"req": req_state}
+        worker.runtime_cache.req_to_slot = {"req": 0}
+        worker.runtime_cache.slot_to_req = {0: "req"}
+        worker.runtime_cache.free_slots = [1]
+        worker._infer_normal_logits_batch_chunked = lambda **kwargs: {
+            index: InferenceLogits(
+                last_token_logits=np.zeros((32000,), dtype=np.float32),
+                full_sequence_logits=None,
+            )
+            for index in kwargs["output_indices"]
+        }
+
+        output = worker.execute_model(self._make_scheduler_output({"req": 4}))
+
+        assert output.req_ids == ["req"]
+        assert req_state.num_computed_tokens == 4
+        assert worker.runtime_cache.live_slot_owner(0) == "req"
+        assert worker.runtime_cache.live_slot_tokens(0) == 4
+
+    def test_finished_batch_request_without_live_slot_is_not_snapshotted(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+        dump_calls: list[object] = []
+        worker._dump_runtime_cache = lambda slot_id=None: dump_calls.append(slot_id) or ["stale-blob"]
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(16)))
+        req_state.num_computed_tokens = 16
+        req_state.cache_slot_id = 0
+        worker.req_states = {"aborted": req_state}
+        worker.runtime_cache.req_to_slot = {"aborted": 0}
+        worker.runtime_cache.slot_to_req = {0: "aborted"}
+        worker.runtime_cache.free_slots = [1]
+        # Slot 0 is still live for a different request, so "aborted" never ran
+        # and its KV is not in the slot.
+        worker.runtime_cache.mark_slot_owner(0, "other", 32)
+
+        worker._finalize_finished_request("aborted")
+
+        assert dump_calls == []
+        assert worker.runtime_cache.get_snapshot("aborted") is None
+        assert worker.runtime_cache.live_slot_owner(0) == "other"
+
+    def test_finished_batch_request_owning_its_slot_is_snapshotted(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+        dump_calls: list[object] = []
+        worker._dump_runtime_cache = lambda slot_id=None: dump_calls.append(slot_id) or ["blob"]
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(16)))
+        req_state.num_computed_tokens = 16
+        req_state.cache_slot_id = 0
+        worker.req_states = {"done": req_state}
+        worker.runtime_cache.req_to_slot = {"done": 0}
+        worker.runtime_cache.slot_to_req = {0: "done"}
+        worker.runtime_cache.free_slots = [1]
+        worker.runtime_cache.mark_slot_owner(0, "done", 16)
+
+        worker._finalize_finished_request("done")
+
+        assert dump_calls == [0]
+        assert worker.runtime_cache.get_snapshot("done") is not None
+        assert worker.runtime_cache.live_slot_owner(0) is None
+
+    def test_sampling_penalties_are_enabled_by_default(self) -> None:
+        assert _resolve_enable_sampling_penalties(None)
+        assert _resolve_enable_sampling_penalties("1")
+        assert _resolve_enable_sampling_penalties("true")
+        assert not _resolve_enable_sampling_penalties("0")
+        assert not _resolve_enable_sampling_penalties("")
+
+    def test_requested_sampling_penalties_reach_the_sampler_by_default(self) -> None:
+        worker = self._make_worker()
+        sampling_params = SamplingParams.from_optional(
+            frequency_penalty=0.5, presence_penalty=0.2, repetition_penalty=1.1
+        )
+        req_state = self._make_request_state(worker, sampling_params, [1, 2, 3])
+
+        metadata = worker._make_sampling_metadata([req_state])
+
+        assert not metadata.no_penalties
+        assert metadata.frequency_penalties.tolist() == [pytest.approx(0.5)]
+        assert metadata.presence_penalties.tolist() == [pytest.approx(0.2)]
+        assert metadata.repetition_penalties.tolist() == [pytest.approx(1.1)]
+        assert metadata.prompt_token_ids is not None
+
+    def test_repetition_penalty_is_applied_to_logits_on_cpu(self) -> None:
+        worker = self._make_worker()
+        worker.model = SimpleNamespace(config=SimpleNamespace(vocab_size=4))
+        sampling_params = SamplingParams.from_optional(temperature=0.0, repetition_penalty=2.0)
+        req_state = self._make_request_state(worker, sampling_params, [0], output_token_ids=[1])
+        sampling_metadata = worker._make_sampling_metadata([req_state])
+        logits = torch.tensor([[1.0, 4.0, 3.0, 0.5]], dtype=torch.float32)
+
+        sampler_output = worker._sample_next_token(logits=logits, sampling_metadata=sampling_metadata)
+
+        # Token 0 is in the prompt and token 1 was generated, so both are
+        # penalised; the unpenalised token 2 must win instead of token 1.
+        assert int(sampler_output.sampled_token_ids[0, 0].item()) == 2

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -3333,3 +3333,85 @@ class TestMbltWorkerOptimizations:
         # Token 0 is in the prompt and token 1 was generated, so both are
         # penalised; the unpenalised token 2 must win instead of token 1.
         assert int(sampler_output.sampled_token_ids[0, 0].item()) == 2
+
+    def test_dump_before_switch_does_not_advertise_more_tokens_than_cached(self) -> None:
+        worker = self._make_worker()
+        dump_calls: list[object] = []
+        worker._dump_runtime_cache = lambda slot_id=None: dump_calls.append(slot_id) or ["short-blob"]
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(32)))
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+        # The scheduler view says 32 tokens, the live cache only holds 8.
+        req_state.num_computed_tokens = 32
+        worker.req_states = {"live": req_state}
+        worker.runtime_cache.mark_loaded_request("live", 8)
+
+        worker._dump_loaded_request_before_switch(next_req_id="other")
+
+        assert dump_calls == [None]
+        snapshot = worker.runtime_cache.get_snapshot("live")
+        assert snapshot is not None
+        assert snapshot.num_tokens == 8
+        assert snapshot.cache_token_ids == tuple(range(8))
+
+    def test_dump_before_switch_is_skipped_when_live_cache_is_empty(self) -> None:
+        worker = self._make_worker()
+        dump_calls: list[object] = []
+        worker._dump_runtime_cache = lambda slot_id=None: dump_calls.append(slot_id) or ["blob"]
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(32)))
+        req_state.num_computed_tokens = 32
+        worker.req_states = {"live": req_state}
+        worker.runtime_cache.mark_loaded_request("live", 0)
+
+        worker._dump_loaded_request_before_switch(next_req_id="other")
+
+        assert dump_calls == []
+        assert worker.runtime_cache.get_snapshot("live") is None
+
+    def test_finalize_clamps_snapshot_to_the_tokens_the_slot_holds(self) -> None:
+        worker = self._make_worker()
+        worker.max_batch_size = 2
+        worker.runtime_cache = MbltRuntimeCacheManager(max_batch_size=2, block_size=128)
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+        dump_calls: list[object] = []
+        worker._dump_runtime_cache = lambda slot_id=None: dump_calls.append(slot_id) or ["short-blob"]
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(64)))
+        req_state.block_ids = ([10],)
+        req_state.first_seq_blocks = (10,)
+        req_state.num_computed_tokens = 64
+        req_state.cache_slot_id = 0
+        worker.req_states = {"done": req_state}
+        worker.runtime_cache.req_to_slot = {"done": 0}
+        worker.runtime_cache.slot_to_req = {0: "done"}
+        worker.runtime_cache.free_slots = [1]
+        worker.runtime_cache.mark_slot_owner(0, "done", 16)
+
+        worker._finalize_finished_request("done")
+
+        assert dump_calls == [0]
+        snapshot = worker.runtime_cache.get_snapshot("done")
+        assert snapshot is not None
+        assert snapshot.num_tokens == 16
+
+    def test_clamped_snapshot_cannot_resume_past_missing_kv(self) -> None:
+        worker = self._make_worker()
+        dump_calls: list[object] = []
+        worker._dump_runtime_cache = lambda slot_id=None: dump_calls.append(slot_id) or ["short-blob"]
+        worker._load_runtime_cache = lambda blobs, slot_id=None: True
+        worker.prefix_cache_cost_model = PrefixCacheCostModel(block_size=128)
+        req_state = self._make_request_state(worker, SamplingParams.from_optional(), list(range(256)))
+        req_state.block_ids = ([10, 11],)
+        req_state.first_seq_blocks = (10, 11)
+        req_state.num_computed_tokens = 256
+        worker.req_states = {"live": req_state}
+        worker.runtime_cache.mark_loaded_request("live", 128)
+
+        worker._dump_loaded_request_before_switch(next_req_id="other")
+        # Another request takes the single live cache, then "live" comes back.
+        worker.runtime_cache.mark_loaded_request("other", 8)
+
+        cache_size = worker._load_snapshot_if_needed("live", req_state)
+
+        # Without the clamp the snapshot would claim 256 tokens and decoding
+        # would resume at 256 over 128 tokens of real KV.
+        assert cache_size == 128

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -1072,3 +1072,57 @@ class TestMbltRuntimeCacheLiveTokenTracking:
         assert manager.loaded_req_tokens == 8
         assert not manager.live_request_prefix_incomplete(8)
         assert manager.live_request_prefix_incomplete(9)
+
+    def test_dump_snapshot_if_needed_clamps_to_tracked_slot_tokens(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        manager.mark_slot_owner(slot_id, "req", 4)
+        dump_calls: list[object] = []
+
+        dumped = manager.dump_snapshot_if_needed(
+            _request("req", (1, 2, 3), 12, cache_slot_id=slot_id),
+            lambda dump_slot_id: dump_calls.append(dump_slot_id) or ["short-blob"],
+        )
+
+        assert dumped
+        assert dump_calls == [slot_id]
+        assert manager.get_snapshot("req").num_tokens == 4
+
+    def test_dump_snapshot_if_needed_skips_an_empty_tracked_slot(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        manager.mark_slot_owner(slot_id, "req", 0)
+        dump_calls: list[object] = []
+
+        dumped = manager.dump_snapshot_if_needed(
+            _request("req", (1, 2, 3), 12, cache_slot_id=slot_id),
+            lambda dump_slot_id: dump_calls.append(dump_slot_id) or ["blob"],
+        )
+
+        assert not dumped
+        assert dump_calls == []
+        assert manager.get_snapshot("req") is None
+
+    def test_dump_snapshot_if_needed_keeps_a_longer_tracked_prefix_label(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        manager.mark_slot_owner(slot_id, "req", 20)
+
+        dumped = manager.dump_snapshot_if_needed(
+            _request("req", (1, 2, 3), 12, cache_slot_id=slot_id),
+            lambda dump_slot_id: ["blob"],
+        )
+
+        assert dumped
+        assert manager.get_snapshot("req").num_tokens == 12
+
+    def test_owned_live_cache_tokens_ignores_another_requests_cache(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        manager.mark_slot_owner(slot_id, "other", 4)
+        manager.mark_loaded_request("other", 4)
+
+        assert manager.owned_live_cache_tokens("req", slot_id) is None
+        assert manager.owned_live_cache_tokens("req", None) is None
+        assert manager.owned_live_cache_tokens("other", slot_id) == 4
+        assert manager.owned_live_cache_tokens("other", None) == 4

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -921,3 +921,154 @@ class TestMbltRuntimeCacheManagerSlots:
         assert dumped
         assert dump_calls == [slot_id]
         assert manager.get_snapshot("req").blobs == ["slot-blob"]
+
+
+class TestMbltRuntimeCacheLiveTokenTracking:
+    def test_live_slot_reuse_requires_matching_token_count(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        manager.mark_slot_owner(slot_id, "req", 8)
+        load_calls: list[object] = []
+
+        result = manager.load_snapshot_for_slot(
+            _request("req", (1, 2), 8, cache_slot_id=slot_id),
+            lambda blobs, load_slot_id: load_calls.append((blobs, load_slot_id)) or True,
+        )
+
+        assert result.reused_live_cache
+        assert result.matched_tokens == 8
+        assert result.live_cache_tokens == 8
+        assert not result.live_prefix_incomplete
+        assert load_calls == []
+
+    def test_live_slot_reuse_refused_when_token_count_diverges(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        # The slot only holds a 4-token replay while the scheduler believes the
+        # request has 8 computed tokens: continuing from it would decode
+        # against KV that does not belong to this prefix.
+        manager.mark_slot_owner(slot_id, "req", 4)
+        load_calls: list[object] = []
+
+        result = manager.load_snapshot_for_slot(
+            _request("req", (1, 2), 8, cache_slot_id=slot_id),
+            lambda blobs, load_slot_id: load_calls.append((blobs, load_slot_id)) or True,
+        )
+
+        assert not result.reused_live_cache
+        assert result.cache_miss
+        assert result.matched_tokens == 0
+        assert result.live_prefix_incomplete
+        assert result.live_cache_tokens == 4
+        assert result.action == "live-prefix-incomplete"
+        assert load_calls == []
+        # The rebuild starts from an empty prefix, so the tracked count must say so.
+        assert manager.live_slot_owner(slot_id) == "req"
+        assert manager.live_slot_tokens(slot_id) == 0
+
+    def test_live_slot_mismatch_can_still_load_a_compatible_snapshot(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        manager.mark_slot_owner(slot_id, "req", 4)
+        _store_snapshot(manager, "req", (1, 2), 8)
+        load_calls: list[object] = []
+
+        result = manager.load_snapshot_for_slot(
+            _request("req", (1, 2), 8, cache_slot_id=slot_id),
+            lambda blobs, load_slot_id: load_calls.append((blobs, load_slot_id)) or True,
+        )
+
+        assert result.loaded
+        assert result.matched_tokens == 8
+        assert result.live_prefix_incomplete
+        assert load_calls == [(["blob:req"], slot_id)]
+        assert manager.live_slot_tokens(slot_id) == 8
+
+    def test_live_slot_with_extra_tokens_is_still_reused(self) -> None:
+        manager = _make_manager(max_batch_size=2, block_size=4)
+        slot_id = manager.assign_slot("req")
+        # After a preemption the scheduler can report fewer computed tokens than
+        # the slot still holds. The owner's token sequence is append-only, so
+        # positions 0..7 in the slot are this request's and continuing at 8
+        # simply overwrites the stale tail.
+        manager.mark_slot_owner(slot_id, "req", 12)
+        load_calls: list[object] = []
+
+        result = manager.load_snapshot_for_slot(
+            _request("req", (1, 2), 8, cache_slot_id=slot_id),
+            lambda blobs, load_slot_id: load_calls.append((blobs, load_slot_id)) or True,
+        )
+
+        assert result.reused_live_cache
+        assert result.matched_tokens == 8
+        assert not result.live_prefix_incomplete
+        assert load_calls == []
+
+    def test_live_single_cache_with_extra_tokens_is_still_reused(self) -> None:
+        manager = _make_manager(block_size=4)
+        manager.mark_loaded_request("req", 12)
+
+        result = manager.load_snapshot_for_request(
+            _request("req", (1, 2), 8),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.reused_live_cache
+        assert result.matched_tokens == 8
+        assert not result.live_prefix_incomplete
+
+    def test_released_slot_does_not_inherit_a_token_count(self) -> None:
+        manager = _make_manager(max_batch_size=1, block_size=4)
+        slot_id = manager.assign_slot("first")
+        manager.mark_slot_owner(slot_id, "first", 8)
+        manager.release_slot("first")
+
+        assert manager.live_slot_owner(slot_id) is None
+        assert manager.live_slot_tokens(slot_id) is None
+        assert manager.assign_slot("second") == slot_id
+
+    def test_single_cache_reuse_refused_when_token_count_diverges(self) -> None:
+        manager = _make_manager(block_size=4)
+        manager.mark_loaded_request("req", 4)
+        load_calls: list[object] = []
+
+        result = manager.load_snapshot_for_request(
+            _request("req", (1, 2), 8),
+            lambda blobs, slot_id: load_calls.append((blobs, slot_id)) or True,
+        )
+
+        assert not result.reused_live_cache
+        assert result.cache_miss
+        assert result.live_prefix_incomplete
+        assert result.live_cache_tokens == 4
+        assert result.action == "live-prefix-incomplete"
+        assert load_calls == []
+        assert manager.loaded_req_id is None
+
+    def test_untracked_live_owner_keeps_trusting_the_owner(self) -> None:
+        manager = _make_manager(block_size=4)
+        manager.mark_loaded_request("req")
+
+        result = manager.load_snapshot_for_request(
+            _request("req", (1, 2), 8),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.reused_live_cache
+        assert result.matched_tokens == 8
+        assert result.live_cache_tokens is None
+
+    def test_snapshot_load_records_matched_token_count(self) -> None:
+        manager = _make_manager(block_size=4)
+        _store_snapshot(manager, "req", (1, 2), 8)
+
+        result = manager.load_snapshot_for_request(
+            _request("req", (1, 2), 8),
+            lambda blobs, slot_id: True,
+        )
+
+        assert result.loaded
+        assert manager.loaded_req_id == "req"
+        assert manager.loaded_req_tokens == 8
+        assert not manager.live_request_prefix_incomplete(8)
+        assert manager.live_request_prefix_incomplete(9)

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 def register():

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -18,6 +18,12 @@ _MULTIMODAL_HF_MODEL_TYPES = frozenset(
     }
 )
 _TRUE_ENV_VALUES = {"1", "true", "TRUE", "True"}
+# A batch LLM compiled at a global scheme mixes core modes inside one mxq (the
+# collective segments target the cluster GlobalCore, the iterative ones Core0),
+# so qbruntime only accepts it under CoreMode.Auto. Such a package declares
+# core_mode "auto" and therefore cannot name a key in a core-mode-indexed map
+# like npu_prefill_chunk_size.
+AUTO_CORE_MODE = "auto"
 
 
 def _mblt_debug_enabled() -> bool:
@@ -179,6 +185,29 @@ def _resolve_model_config_positive_int(
         chunk_size = _coerce_positive_int(raw_value.get(fallback_key))
         if chunk_size is not None:
             return chunk_size
+
+    if core_mode is None or core_mode == AUTO_CORE_MODE:
+        # "auto" is a real core mode for global-scheme batch artifacts, but it
+        # is never a key of a core-mode-indexed map. When the map describes a
+        # single compiled mode, that entry is the artifact's own value; falling
+        # through to the generic default would silently shrink the prefill
+        # chunk size instead.
+        usable_entries = {
+            str(key): value
+            for key, value in raw_value.items()
+            if _coerce_positive_int(value) is not None
+        }
+        if len(usable_entries) == 1:
+            only_key, only_value = next(iter(usable_entries.items()))
+            resolved = _coerce_positive_int(only_value)
+            logger.info(
+                "Resolved %s=%s from the only core-mode entry %r for core_mode=%s.",
+                field_name,
+                resolved,
+                only_key,
+                core_mode,
+            )
+            return resolved
 
     logger.warning(
         "Could not resolve %s from model config for core_mode=%s: %r",

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -43,6 +43,25 @@ from vllm_mblt.runtime_cache import (
 logger = init_logger(__name__)
 
 
+_TRUE_ENV_VALUES = frozenset({"1", "true", "TRUE", "True"})
+
+
+def _resolve_enable_sampling_penalties(env_value: Optional[str]) -> bool:
+    """Decide whether frequency/presence/repetition penalties are applied.
+
+    vLLM applies these with a pure-torch fallback when the fused CUDA kernel is
+    unavailable, so the CPU-hosted MBLT sampler can honour them and the default
+    is on regardless of CUDA. The released MBLT packages ship
+    ``repetition_penalty`` in ``generation_config.json``; dropping it silently
+    would generate NPU output under different sampling than the GPU reference it
+    is compared against. Setting VLLM_MBLT_ENABLE_SAMPLING_PENALTIES to a
+    non-true value restores the previous ignore-and-warn behaviour.
+    """
+    if env_value is None:
+        return True
+    return env_value in _TRUE_ENV_VALUES
+
+
 _MULTIMODAL_HF_MODEL_TYPES = frozenset(
     {
         "mobilint-qwen2_vl",
@@ -349,6 +368,7 @@ class MbltWorker(WorkerBase):
         self.req_states: Dict[str, RequestState] = {}
         self._warned_batch_cache_snapshot_unsupported = False
         self._warned_last_logit_prompt_logprobs = False
+        self._live_cache_prefix_incomplete_count = 0
         self._vlm_image_positions_by_session: dict[str, tuple[int, int, Optional[tuple[bool, ...]]]] = {}
 
         self.max_batch_size = resolve_model_max_batch_size(self.vllm_config) or 1
@@ -371,11 +391,9 @@ class MbltWorker(WorkerBase):
         self.max_num_batched_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
         # Disabled by default to avoid per-token stdout spam in production runs.
         self.print_debug = os.getenv("VLLM_MBLT_DEBUG", "0") in {"1", "true", "TRUE", "True"}
-        penalties_env = os.getenv("VLLM_MBLT_ENABLE_SAMPLING_PENALTIES")
-        if penalties_env is None:
-            self.enable_sampling_penalties = torch.cuda.is_available()
-        else:
-            self.enable_sampling_penalties = penalties_env in {"1", "true", "TRUE", "True"}
+        self.enable_sampling_penalties = _resolve_enable_sampling_penalties(
+            os.getenv("VLLM_MBLT_ENABLE_SAMPLING_PENALTIES")
+        )
         self._warned_penalties_disabled = False
 
     def _log_init_stage(self, stage: str, start_time: Optional[float] = None, **fields: object) -> None:
@@ -1620,6 +1638,34 @@ class MbltWorker(WorkerBase):
         )
         self._warned_last_logit_prompt_logprobs = True
 
+    def _warn_live_cache_prefix_incomplete(
+        self,
+        *,
+        req_id: str,
+        slot_id: Optional[int],
+        live_tokens: Optional[int],
+        target_tokens: int,
+    ) -> None:
+        """Report a live runtime cache that is missing part of the request prefix.
+
+        Reaching this means the accelerator cache no longer holds the prefix the
+        request is about to continue from, which is exactly the state that used
+        to be served silently as fluent-but-wrong output. The caller rebuilds
+        the prefix instead, but the divergence is a bug signal and must be
+        visible in the log rather than only in the generated text.
+        """
+        self._live_cache_prefix_incomplete_count = getattr(self, "_live_cache_prefix_incomplete_count", 0) + 1
+        logger.warning(
+            "MBLT runtime cache holds fewer tokens than the scheduler expects for req_id=%s "
+            "(cache_id=%s, live_tokens=%s, expected=%d). Rebuilding the prefix instead of "
+            "decoding against stale KV. occurrences=%d",
+            req_id,
+            slot_id,
+            live_tokens,
+            target_tokens,
+            self._live_cache_prefix_incomplete_count,
+        )
+
     @staticmethod
     def _can_reuse_output_buffers(
         cache_model: Any,
@@ -2645,6 +2691,11 @@ class MbltWorker(WorkerBase):
                 print(f"[cache] req={req_id} load-shared matched={result.matched_tokens}/{target_tokens}")
             elif result.action == "skip-cost":
                 print(f"[cache] req={req_id} skip-load-cost matched={result.matched_tokens}/{target_tokens}")
+            elif result.action == "live-prefix-incomplete":
+                print(
+                    f"[cache] req={req_id} live-prefix-incomplete "
+                    f"live={result.live_cache_tokens} expected={target_tokens} rebuild matched=0/{target_tokens}"
+                )
             else:
                 print(f"[cache] req={req_id} cache-miss fallback matched=0/{target_tokens}")
         return result.matched_tokens
@@ -2664,18 +2715,37 @@ class MbltWorker(WorkerBase):
             first_seq_block_hashes=request.first_seq_block_hashes,
         )
 
+        live_prefix_incomplete = False
+        live_cache_tokens: Optional[int] = None
         if self.runtime_cache.loaded_req_id == request.req_id:
-            return RuntimeCacheLoadResult(
-                matched_tokens=target_tokens,
-                reused_live_cache=True,
-                action="reuse-live",
-                snapshot_req_id=request.req_id,
+            if not self.runtime_cache.live_request_prefix_incomplete(target_tokens):
+                return RuntimeCacheLoadResult(
+                    matched_tokens=target_tokens,
+                    reused_live_cache=True,
+                    action="reuse-live",
+                    snapshot_req_id=request.req_id,
+                    live_cache_tokens=self.runtime_cache.loaded_req_tokens,
+                )
+            live_prefix_incomplete = True
+            live_cache_tokens = self.runtime_cache.loaded_req_tokens
+            self._warn_live_cache_prefix_incomplete(
+                req_id=request.req_id,
+                slot_id=None,
+                live_tokens=live_cache_tokens,
+                target_tokens=target_tokens,
             )
+            self.runtime_cache.clear_loaded_request(request.req_id)
 
         match = self.runtime_cache.choose_snapshot(request)
         if match.snapshot is None or match.matched_tokens <= 0:
             self.runtime_cache.clear_loaded_request()
-            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+            return RuntimeCacheLoadResult(
+                matched_tokens=0,
+                cache_miss=True,
+                action="live-prefix-incomplete" if live_prefix_incomplete else "cache-miss",
+                live_prefix_incomplete=live_prefix_incomplete,
+                live_cache_tokens=live_cache_tokens,
+            )
 
         if not self._ensure_prefix_cache_cost_model().should_load(
             matched_tokens=match.matched_tokens,
@@ -2710,7 +2780,7 @@ class MbltWorker(WorkerBase):
             )
 
         if self._timed_load_runtime_cache(match.snapshot.blobs, None):
-            self.runtime_cache.mark_loaded_request(request.req_id)
+            self.runtime_cache.mark_loaded_request(request.req_id, match.matched_tokens)
             return RuntimeCacheLoadResult(
                 matched_tokens=match.matched_tokens,
                 loaded=True,
@@ -2718,10 +2788,15 @@ class MbltWorker(WorkerBase):
                 is_own_snapshot=match.is_own_snapshot,
                 action="load-own" if match.is_own_snapshot else "load-shared",
                 snapshot_req_id=match.req_id,
+                live_prefix_incomplete=live_prefix_incomplete,
             )
 
         self.runtime_cache.clear_loaded_request()
-        return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+        return RuntimeCacheLoadResult(
+            matched_tokens=0,
+            cache_miss=True,
+            live_prefix_incomplete=live_prefix_incomplete,
+        )
 
     def _load_snapshot_for_batch_slot(
         self,
@@ -2767,6 +2842,11 @@ class MbltWorker(WorkerBase):
                     f"[cache] req={req_id} slot={slot_id} "
                     f"skip-load-cost matched={result.matched_tokens}/{target_tokens}"
                 )
+            elif result.action == "live-prefix-incomplete":
+                print(
+                    f"[cache] req={req_id} slot={slot_id} live-prefix-incomplete "
+                    f"live={result.live_cache_tokens} expected={target_tokens} rebuild matched=0/{target_tokens}"
+                )
             else:
                 print(f"[cache] req={req_id} slot={slot_id} cache-miss fallback matched=0/{target_tokens}")
         return result.matched_tokens
@@ -2789,13 +2869,26 @@ class MbltWorker(WorkerBase):
             first_seq_block_hashes=request.first_seq_block_hashes,
         )
 
+        live_prefix_incomplete = False
+        live_cache_tokens: Optional[int] = None
         if self.runtime_cache.live_slot_owner(slot_id) == request.req_id:
-            return RuntimeCacheLoadResult(
-                matched_tokens=target_tokens,
-                reused_live_cache=True,
-                action="reuse-live",
-                snapshot_req_id=request.req_id,
+            if not self.runtime_cache.live_slot_prefix_incomplete(slot_id, target_tokens):
+                return RuntimeCacheLoadResult(
+                    matched_tokens=target_tokens,
+                    reused_live_cache=True,
+                    action="reuse-live",
+                    snapshot_req_id=request.req_id,
+                    live_cache_tokens=self.runtime_cache.live_slot_tokens(slot_id),
+                )
+            live_prefix_incomplete = True
+            live_cache_tokens = self.runtime_cache.live_slot_tokens(slot_id)
+            self._warn_live_cache_prefix_incomplete(
+                req_id=request.req_id,
+                slot_id=slot_id,
+                live_tokens=live_cache_tokens,
+                target_tokens=target_tokens,
             )
+            self.runtime_cache.clear_slot_owner(slot_id)
 
         match = self.runtime_cache.choose_snapshot(request)
         if match.snapshot is not None and match.matched_tokens > 0:
@@ -2803,7 +2896,7 @@ class MbltWorker(WorkerBase):
                 matched_tokens=match.matched_tokens,
                 cache_id=slot_id,
             ):
-                self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
+                self.runtime_cache.mark_slot_owner(slot_id, request.req_id, 0)
                 return RuntimeCacheLoadResult(
                     matched_tokens=0,
                     cache_miss=True,
@@ -2811,17 +2904,24 @@ class MbltWorker(WorkerBase):
                     is_own_snapshot=match.is_own_snapshot,
                     action="skip-cost",
                     snapshot_req_id=match.req_id,
+                    live_prefix_incomplete=live_prefix_incomplete,
                 )
 
             match = self.runtime_cache.verify_prompt_embed_match(request, match)
             if match.snapshot is None or match.matched_tokens <= 0:
-                self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
-                return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+                self.runtime_cache.mark_slot_owner(slot_id, request.req_id, 0)
+                return RuntimeCacheLoadResult(
+                    matched_tokens=0,
+                    cache_miss=True,
+                    action="live-prefix-incomplete" if live_prefix_incomplete else "cache-miss",
+                    live_prefix_incomplete=live_prefix_incomplete,
+                    live_cache_tokens=live_cache_tokens,
+                )
             if not self._ensure_prefix_cache_cost_model().should_load(
                 matched_tokens=match.matched_tokens,
                 cache_id=slot_id,
             ):
-                self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
+                self.runtime_cache.mark_slot_owner(slot_id, request.req_id, 0)
                 return RuntimeCacheLoadResult(
                     matched_tokens=0,
                     cache_miss=True,
@@ -2829,10 +2929,11 @@ class MbltWorker(WorkerBase):
                     is_own_snapshot=match.is_own_snapshot,
                     action="skip-cost",
                     snapshot_req_id=match.req_id,
+                    live_prefix_incomplete=live_prefix_incomplete,
                 )
 
             if self._timed_load_runtime_cache(match.snapshot.blobs, slot_id):
-                self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
+                self.runtime_cache.mark_slot_owner(slot_id, request.req_id, match.matched_tokens)
                 return RuntimeCacheLoadResult(
                     matched_tokens=match.matched_tokens,
                     loaded=True,
@@ -2840,10 +2941,17 @@ class MbltWorker(WorkerBase):
                     is_own_snapshot=match.is_own_snapshot,
                     action="load-own" if match.is_own_snapshot else "load-shared",
                     snapshot_req_id=match.req_id,
+                    live_prefix_incomplete=live_prefix_incomplete,
                 )
 
-        self.runtime_cache.mark_slot_owner(slot_id, request.req_id)
-        return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+        self.runtime_cache.mark_slot_owner(slot_id, request.req_id, 0)
+        return RuntimeCacheLoadResult(
+            matched_tokens=0,
+            cache_miss=True,
+            action="live-prefix-incomplete" if live_prefix_incomplete else "cache-miss",
+            live_prefix_incomplete=live_prefix_incomplete,
+            live_cache_tokens=live_cache_tokens,
+        )
 
     def _dump_snapshot(
         self,
@@ -2955,8 +3063,17 @@ class MbltWorker(WorkerBase):
                 finished_req_state.num_computed_tokens,
             )
             if self._is_batch_model():
+                # Only the request that still owns the live slot can be dumped:
+                # a request that was aborted before it ever ran leaves the slot
+                # holding somebody else's KV, and snapshotting that under this
+                # req_id would publish a prefix the tokens do not match.
+                owns_live_slot = (
+                    finished_slot_id is not None
+                    and self.runtime_cache.live_slot_owner(finished_slot_id) == req_id
+                )
                 if (
-                    should_dump
+                    owns_live_slot
+                    and should_dump
                     and self._dump_snapshot(
                         req_id=req_id,
                         req_state=finished_req_state,
@@ -3095,8 +3212,9 @@ class MbltWorker(WorkerBase):
         else:
             if penalties_requested and not getattr(self, "_warned_penalties_disabled", False):
                 logger.warning(
-                    "Sampling penalties are disabled for non-CUDA MBLT runtime. "
-                    "Ignoring frequency_penalty=%s, presence_penalty=%s, repetition_penalty=%s.",
+                    "Sampling penalties are disabled by VLLM_MBLT_ENABLE_SAMPLING_PENALTIES. "
+                    "Ignoring frequency_penalty=%s, presence_penalty=%s, repetition_penalty=%s. "
+                    "NPU output will not match a GPU reference run that applies them.",
                     requested_frequency_penalty,
                     requested_presence_penalty,
                     requested_repetition_penalty,
@@ -3479,7 +3597,7 @@ class MbltWorker(WorkerBase):
             for i, req_id in enumerate(req_ids):
                 req_state = self.req_states[req_id]
                 req_state.num_computed_tokens = next_cache_sizes[i]
-                self.runtime_cache.mark_slot_owner(cache_ids[i], req_id)
+                self.runtime_cache.mark_slot_owner(cache_ids[i], req_id, next_cache_sizes[i])
                 if self._should_sample_after_step(
                     req_state,
                     scheduled_end_positions[i],
@@ -3591,7 +3709,7 @@ class MbltWorker(WorkerBase):
                 # next_cache_size tokens, so later same-request decode can reuse it
                 # without forcing a block-boundary snapshot dump.
                 req_state.num_computed_tokens = next_cache_size
-                self.runtime_cache.mark_loaded_request(req_id)
+                self.runtime_cache.mark_loaded_request(req_id, next_cache_size)
                 if self._should_sample_after_step(
                     req_state,
                     scheduled_end,

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -2953,6 +2953,12 @@ class MbltWorker(WorkerBase):
             live_cache_tokens=live_cache_tokens,
         )
 
+    def _owned_live_cache_tokens(self, req_id: str, slot_id: Optional[int]) -> Optional[int]:
+        return self.runtime_cache.owned_live_cache_tokens(
+            req_id,
+            slot_id if self._is_batch_model() else None,
+        )
+
     def _dump_snapshot(
         self,
         req_id: str,
@@ -2961,6 +2967,25 @@ class MbltWorker(WorkerBase):
         slot_id: Optional[int] = None,
         print_debug: bool = False,
     ) -> bool:
+        # A snapshot must never advertise more tokens than its blobs contain.
+        # The scheduler's num_computed_tokens is the caller's label of choice,
+        # but the live cache can legitimately hold a shorter prefix of this
+        # request (a cost-policy skip, a rebuilt prefix). Labeling the longer
+        # count would let a later load resume past KV that is not there, which
+        # is the same silent-wrong-output failure this tracking exists to stop.
+        live_tokens = self._owned_live_cache_tokens(req_id, slot_id)
+        if live_tokens is not None and live_tokens < max(0, int(next_num_tokens)):
+            if live_tokens <= 0:
+                return False
+            if not self.runtime_cache.should_dump_snapshot_after_step(req_id, live_tokens):
+                return False
+            if print_debug:
+                print(
+                    f"[cache] req={req_id} slot={slot_id} dump-clamped "
+                    f"tokens={live_tokens} requested={max(0, int(next_num_tokens))}"
+                )
+            next_num_tokens = live_tokens
+
         blobs = self._timed_dump_runtime_cache(slot_id)
         if blobs is None:
             if self._is_batch_model() and not self._warned_batch_cache_snapshot_unsupported:

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -81,6 +81,8 @@ class RuntimeCacheLoadResult:
     is_own_snapshot: bool = False
     action: str = "cache-miss"
     snapshot_req_id: str | None = None
+    live_prefix_incomplete: bool = False
+    live_cache_tokens: int | None = None
 
 
 class MbltRuntimeCacheManager:
@@ -121,11 +123,15 @@ class MbltRuntimeCacheManager:
 
         # Single-cache runtime owner.
         self.loaded_req_id: str | None = None
+        # Token count the live single runtime cache is believed to hold for
+        # loaded_req_id. None means the count is not tracked.
+        self.loaded_req_tokens: int | None = None
 
         # Batch cache slot assignment and live slot owners.
         self.req_to_slot: dict[str, int] = {}
         self.slot_to_req: dict[int, str] = {}
         self.slot_live_req: dict[int, str] = {}
+        self.slot_live_tokens: dict[int, int] = {}
         self.free_slots: list[int] = []
         self.reset_slots(max_batch_size=self.max_batch_size)
 
@@ -145,6 +151,7 @@ class MbltRuntimeCacheManager:
     @loaded_cache_req_id.setter
     def loaded_cache_req_id(self, req_id: str | None) -> None:
         self.loaded_req_id = req_id
+        self.loaded_req_tokens = None
 
     @property
     def req_to_cache_slot(self) -> dict[str, int]:
@@ -164,6 +171,7 @@ class MbltRuntimeCacheManager:
         self.req_to_slot = {}
         self.slot_to_req = {}
         self.slot_live_req = {}
+        self.slot_live_tokens = {}
         self.free_slots = list(range(self.max_batch_size))
 
     def _request_index_blocks(self, request: RuntimeCacheRequest) -> tuple[Hashable, ...]:
@@ -224,6 +232,7 @@ class MbltRuntimeCacheManager:
             self.slot_to_req.pop(slot_id, None)
         if self.slot_live_req.get(slot_id) == req_id:
             self.slot_live_req.pop(slot_id, None)
+            self.slot_live_tokens.pop(slot_id, None)
         if slot_id not in self.free_slots:
             self.free_slots.append(slot_id)
             self.free_slots.sort()
@@ -231,15 +240,48 @@ class MbltRuntimeCacheManager:
     def live_slot_owner(self, slot_id: int) -> str | None:
         return self.slot_live_req.get(slot_id)
 
-    def mark_slot_owner(self, slot_id: int, req_id: str) -> None:
+    def live_slot_tokens(self, slot_id: int) -> int | None:
+        return self.slot_live_tokens.get(slot_id)
+
+    def mark_slot_owner(self, slot_id: int, req_id: str, num_tokens: int | None = None) -> None:
         self.slot_live_req[slot_id] = req_id
+        if num_tokens is None:
+            self.slot_live_tokens.pop(slot_id, None)
+        else:
+            self.slot_live_tokens[slot_id] = max(0, int(num_tokens))
+
+    def clear_slot_owner(self, slot_id: int) -> None:
+        self.slot_live_req.pop(slot_id, None)
+        self.slot_live_tokens.pop(slot_id, None)
+
+    def live_slot_prefix_incomplete(self, slot_id: int, target_tokens: int) -> bool:
+        """Report a live batch slot that does not hold the whole request prefix.
+
+        Continuing from a live slot at ``cache_size=target_tokens`` is only
+        correct when the accelerator cache really holds those tokens. Holding
+        more is fine: the owner's token sequence is append-only, so the extra
+        tail is simply overwritten (this is the preempt-and-resume case).
+        Holding fewer means positions the request is about to build on were
+        never computed in this slot, and decoding anyway is what produces
+        fluent-but-wrong output. An untracked slot (None) keeps the previous
+        trust-the-owner behaviour.
+        """
+        live_tokens = self.slot_live_tokens.get(slot_id)
+        return live_tokens is not None and live_tokens < max(0, int(target_tokens))
+
+    def live_request_prefix_incomplete(self, target_tokens: int) -> bool:
+        """Single-cache counterpart of live_slot_prefix_incomplete."""
+        live_tokens = self.loaded_req_tokens
+        return live_tokens is not None and live_tokens < max(0, int(target_tokens))
 
     def clear_loaded_request(self, req_id: str | None = None) -> None:
         if req_id is None or self.loaded_req_id == req_id:
             self.loaded_req_id = None
+            self.loaded_req_tokens = None
 
-    def mark_loaded_request(self, req_id: str) -> None:
+    def mark_loaded_request(self, req_id: str, num_tokens: int | None = None) -> None:
         self.loaded_req_id = req_id
+        self.loaded_req_tokens = None if num_tokens is None else max(0, int(num_tokens))
 
     def get_snapshot(self, req_id: str) -> RuntimeCacheSnapshot | None:
         return self.snapshots.get(req_id)
@@ -627,25 +669,41 @@ class MbltRuntimeCacheManager:
             first_seq_block_hashes=request.first_seq_block_hashes,
         )
 
+        live_prefix_incomplete = False
+        live_cache_tokens: int | None = None
         if self.loaded_req_id == request.req_id:
-            return RuntimeCacheLoadResult(
-                matched_tokens=target_tokens,
-                reused_live_cache=True,
-                action="reuse-live",
-                snapshot_req_id=request.req_id,
-            )
+            if not self.live_request_prefix_incomplete(target_tokens):
+                return RuntimeCacheLoadResult(
+                    matched_tokens=target_tokens,
+                    reused_live_cache=True,
+                    action="reuse-live",
+                    snapshot_req_id=request.req_id,
+                    live_cache_tokens=self.loaded_req_tokens,
+                )
+            # The live cache no longer holds this request's prefix. Drop the
+            # ownership claim so the prefix is rebuilt instead of decoded
+            # against stale KV.
+            live_prefix_incomplete = True
+            live_cache_tokens = self.loaded_req_tokens
+            self.clear_loaded_request(request.req_id)
 
         match = self.choose_snapshot(request)
         match = self.verify_prompt_embed_match(request, match)
         if match.snapshot is None or match.matched_tokens <= 0:
             self.clear_loaded_request()
-            return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+            return RuntimeCacheLoadResult(
+                matched_tokens=0,
+                cache_miss=True,
+                action="live-prefix-incomplete" if live_prefix_incomplete else "cache-miss",
+                live_prefix_incomplete=live_prefix_incomplete,
+                live_cache_tokens=live_cache_tokens,
+            )
 
         load_runtime_cache = load_runtime_cache or self._load_runtime_cache_fn
         if load_runtime_cache is None:
             raise RuntimeError("Runtime cache load adapter is not configured.")
         if load_runtime_cache(match.snapshot.blobs, None):
-            self.mark_loaded_request(request.req_id)
+            self.mark_loaded_request(request.req_id, match.matched_tokens)
             return RuntimeCacheLoadResult(
                 matched_tokens=match.matched_tokens,
                 loaded=True,
@@ -653,10 +711,17 @@ class MbltRuntimeCacheManager:
                 is_own_snapshot=match.is_own_snapshot,
                 action="load-own" if match.is_own_snapshot else "load-shared",
                 snapshot_req_id=match.req_id,
+                live_prefix_incomplete=live_prefix_incomplete,
+                live_cache_tokens=live_cache_tokens,
             )
 
         self.clear_loaded_request()
-        return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+        return RuntimeCacheLoadResult(
+            matched_tokens=0,
+            cache_miss=True,
+            live_prefix_incomplete=live_prefix_incomplete,
+            live_cache_tokens=live_cache_tokens,
+        )
 
     def load_for_request(self, request: RuntimeCacheRequest) -> RuntimeCacheLoadResult:
         return self.load_snapshot_for_request(request)
@@ -680,13 +745,23 @@ class MbltRuntimeCacheManager:
             first_seq_block_hashes=request.first_seq_block_hashes,
         )
 
+        live_prefix_incomplete = False
+        live_cache_tokens: int | None = None
         if self.live_slot_owner(slot_id) == request.req_id:
-            return RuntimeCacheLoadResult(
-                matched_tokens=target_tokens,
-                reused_live_cache=True,
-                action="reuse-live",
-                snapshot_req_id=request.req_id,
-            )
+            if not self.live_slot_prefix_incomplete(slot_id, target_tokens):
+                return RuntimeCacheLoadResult(
+                    matched_tokens=target_tokens,
+                    reused_live_cache=True,
+                    action="reuse-live",
+                    snapshot_req_id=request.req_id,
+                    live_cache_tokens=self.live_slot_tokens(slot_id),
+                )
+            # The slot no longer holds this request's prefix. Drop the
+            # ownership claim so the prefix is rebuilt instead of decoded
+            # against stale KV.
+            live_prefix_incomplete = True
+            live_cache_tokens = self.live_slot_tokens(slot_id)
+            self.clear_slot_owner(slot_id)
 
         match = self.choose_snapshot(request)
         match = self.verify_prompt_embed_match(request, match)
@@ -695,7 +770,7 @@ class MbltRuntimeCacheManager:
             if load_runtime_cache is None:
                 raise RuntimeError("Runtime cache load adapter is not configured.")
             if load_runtime_cache(match.snapshot.blobs, slot_id):
-                self.mark_slot_owner(slot_id, request.req_id)
+                self.mark_slot_owner(slot_id, request.req_id, match.matched_tokens)
                 return RuntimeCacheLoadResult(
                     matched_tokens=match.matched_tokens,
                     loaded=True,
@@ -703,10 +778,18 @@ class MbltRuntimeCacheManager:
                     is_own_snapshot=match.is_own_snapshot,
                     action="load-own" if match.is_own_snapshot else "load-shared",
                     snapshot_req_id=match.req_id,
+                    live_prefix_incomplete=live_prefix_incomplete,
+                    live_cache_tokens=live_cache_tokens,
                 )
 
-        self.mark_slot_owner(slot_id, request.req_id)
-        return RuntimeCacheLoadResult(matched_tokens=0, cache_miss=True)
+        self.mark_slot_owner(slot_id, request.req_id, 0)
+        return RuntimeCacheLoadResult(
+            matched_tokens=0,
+            cache_miss=True,
+            action="live-prefix-incomplete" if live_prefix_incomplete else "cache-miss",
+            live_prefix_incomplete=live_prefix_incomplete,
+            live_cache_tokens=live_cache_tokens,
+        )
 
     def load_for_slot(self, request: RuntimeCacheRequest, slot_id: int | None = None) -> RuntimeCacheLoadResult:
         if slot_id is not None and request.cache_slot_id != slot_id:
@@ -750,6 +833,7 @@ class MbltRuntimeCacheManager:
         self.snapshot_index_root = RuntimeCacheSnapshotIndexNode()
         self.physical_block_owner.clear()
         self.loaded_req_id = None
+        self.loaded_req_tokens = None
         self.reset_slots()
 
 

--- a/vllm_mblt/runtime_cache.py
+++ b/vllm_mblt/runtime_cache.py
@@ -614,13 +614,39 @@ class MbltRuntimeCacheManager:
             return False
         return self.required_blocks(next_num_tokens) > self.required_blocks(snapshot.num_tokens)
 
+    def owned_live_cache_tokens(self, req_id: str, slot_id: int | None) -> int | None:
+        """Tokens the live cache is tracked to hold *for this request*.
+
+        Returns None when there is nothing to go on — the count is untracked,
+        or the live cache belongs to another request — so callers keep their
+        previous behaviour instead of acting on a number that is not about
+        ``req_id``.
+        """
+        if slot_id is not None:
+            if self.slot_live_req.get(slot_id) != req_id:
+                return None
+            return self.slot_live_tokens.get(slot_id)
+        if self.loaded_req_id != req_id:
+            return None
+        return self.loaded_req_tokens
+
     def dump_snapshot_if_needed(
         self,
         request: RuntimeCacheRequest,
         dump_runtime_cache: DumpRuntimeCache | None = None,
     ) -> bool:
-        if not self.should_dump_snapshot_after_step(request.req_id, request.num_computed_tokens):
+        num_tokens = max(0, int(request.num_computed_tokens))
+        if not self.should_dump_snapshot_after_step(request.req_id, num_tokens):
             return False
+        # Never label a snapshot with more tokens than its blobs hold: a later
+        # load would report the full match and resume past missing KV.
+        live_tokens = self.owned_live_cache_tokens(request.req_id, request.cache_slot_id)
+        if live_tokens is not None and live_tokens < num_tokens:
+            if live_tokens <= 0:
+                return False
+            if not self.should_dump_snapshot_after_step(request.req_id, live_tokens):
+                return False
+            num_tokens = live_tokens
         dump_runtime_cache = dump_runtime_cache or self._dump_runtime_cache_fn
         if dump_runtime_cache is None:
             raise RuntimeError("Runtime cache dump adapter is not configured.")
@@ -633,7 +659,7 @@ class MbltRuntimeCacheManager:
             block_ids=request.block_ids,
             first_seq_blocks=request.first_seq_blocks,
             first_seq_block_hashes=request.first_seq_block_hashes,
-            num_tokens=request.num_computed_tokens,
+            num_tokens=num_tokens,
             cache_token_ids=request.cache_token_ids,
             multimodal_cache_identity=request.multimodal_cache_identity,
             prompt_embed_cache_identity=request.prompt_embed_cache_identity,


### PR DESCRIPTION
## 배경

2026-09-04 batch-16 LLM mxq(`Qwen2.5-0.5B-Instruct`, w8, seq 4096) `vllm serve` 점검에서 나온 findings 대응.
원본 리포트: `/nas/algorithm-division/workspaces/beomsu/mxq-sanity-2026-09-04/vllm_mblt_issues.md`

리포트는 **v0.1.5** 기준(uv cache에서 `PYTHONPATH`로 주입)이라 라인 번호가 현재 트리와 다르다.
이 PR은 각 finding을 현재 HEAD 기준으로 다시 확인한 뒤, 이 레포에서 실제로 고칠 수 있는 것만 다룬다.

## 변경 내용

### 1. runtime cache 라이브 프리픽스 불변식 (finding 3: 클라이언트 중단 후 조용한 캐시 오염)

v0.1.5의 근본 원인은 finding 1과 같다 — 비배치 분기를 타면서 16개 요청이 `cache_id` 0을 공유했다.
현재 트리는 요청별 `cache_id`를 갖지만, 라이브 캐시를 신뢰하는 고속 경로에 불변식 검사가 없었다.

- 라이브 단일 캐시(`loaded_req_tokens`)와 배치 슬롯(`slot_live_tokens`)이 실제로 몇 토큰을 들고 있는지 추적한다.
- 추적된 토큰 수가 스케줄러의 `num_computed_tokens`보다 **적을 때만** no-reload `reuse-live` 경로를 거부한다.
  더 많이 들고 있는 경우는 같은 요청의 append-only 토큰 시퀀스이므로 뒤쪽 tail만 덮어쓰면 되고, 그대로
  재사용한다 (preempt/resume 케이스에서 불필요한 재계산을 만들지 않기 위함).
- 거부 시 `req_id` / `cache_id` / 실제 토큰 수 / 기대 토큰 수를 경고로 남기고 프리픽스를 재구성한다.

  ```
  WARNING mblt_worker.py: MBLT runtime cache holds fewer tokens than the scheduler expects for
  req_id=... (cache_id=3, live_tokens=8, expected=16). Rebuilding the prefix instead of decoding
  against stale KV. occurrences=1
  ```

  리포트가 요청한 *"fail loudly rather than serving from a cache whose mapping no longer matches"* 를
  "재구성 + 경고"로 구현한 것. 예전에는 이 상태가 HTTP 200 / 정상 `finish_reason` / 그럴듯한 `usage` 와
  함께 조용히 서빙되어 API에서 감지가 불가능했다.
- 배치 요청이 라이브 슬롯 소유자가 아니면 종료 시 스냅샷을 뜨지 않는다. 첫 스텝 전에 abort된 요청이
  다른 요청의 KV를 자기 프리픽스 스냅샷으로 발행하는 경로를 막는다.

### 2. 샘플링 페널티 (finding 4)

`enable_sampling_penalties`가 `torch.cuda.is_available()`로 게이트되어 있어 NPU 서버(비 CUDA)에서는
`frequency_penalty` / `presence_penalty` / `repetition_penalty`가 항상 버려졌다.

vLLM 0.11.2의 `vllm._custom_ops.apply_repetition_penalties`는 fused CUDA 커널이 없으면 순수 torch로
폴백하므로 CPU 호스팅 MBLT 샘플러에서도 적용 가능하다 (venv에서 CPU 텐서로 직접 확인).

- CUDA 게이트를 제거하고 기본 적용으로 변경.
- `VLLM_MBLT_ENABLE_SAMPLING_PENALTIES=0` 으로 기존 ignore-and-warn 동작을 강제할 수 있다 (경고 문구도
  실제 원인을 가리키도록 수정).
- 릴리스 패키지가 `generation_config.json`에 `repetition_penalty: 1.1`을 싣고 있어, 이를 무시하면
  GPU 기준 출력과 **다른 샘플링**으로 생성된 결과를 비교하게 된다. 반복(repetition)은 정확히 그 비교에서
  판정하려는 실패 모드다.

### 3. `core_mode: "auto"` (finding 2)

하드 리젝트(`Value error, Invalid core mode 'auto'`)는 `mblt_model_zoo/utils/core_mode.py`의
`normalize_core_mode`(허용값 `single|multi|global4|global8`)에 있어 **이 레포 밖**이다.
여기서 고칠 수 있는 절반만 처리한다:

- `core_mode`가 `"auto"`(또는 미지정)이고 core-mode 키 맵에 쓸 수 있는 항목이 정확히 하나면 그 값을 쓴다.
  global 스킴 배치 mxq는 컴파일된 모드 하나만 싣고 오는데, 지금은 `"auto"`가 맵의 키가 될 수 없어
  `npu_prefill_chunk_size`가 조용히 `128` 기본값으로 떨어진다 (예: `{"global8": 512}` → 512 대신 128).
- 항목이 여러 개면 추측하지 않고 기존 경고를 유지한다. 명시적 `core_mode`(예: `global4`)가 다른 모드의
  값을 빌려오지도 않는다.

`"auto"`를 모델 로드 시점에 받아들이려면 `normalize_core_mode` 쪽 수정이 여전히 필요하다 —
**mblt-model-zoo에 별도 이슈/PR 필요.**

### 4. finding 1 (배치 디코드 경로) — 코드 변경 없음

리포트의 라인 번호(`_infer_logits_with_sequence` 1018, `_infer_logits_batch` 1054, `params=params` 1078,
`execute_model` 2132)는 `v0.1.5`와 정확히 일치한다. 그런데 **v0.1.5에도 이미 배치 분기가 있다**:

```
$ git show v0.1.5:vllm_mblt/mblt_worker.py | sed -n '2132,2450p' | grep -n '_is_batch_model\|_infer_normal_logits_batch_chunked'
102:        if self._is_batch_model():
180:                normal_logits = self._infer_normal_logits_batch_chunked(
```

리포트가 인용한 2403/2436은 그 **`else`(비배치) 분기**다. 배치 분기는
`_infer_normal_logits_batch_chunked` → `_infer_logits_batch_with_sequence(params=BatchParam[...])` 로
스텝당 런타임 호출 1회를 이미 수행한다 (디코드는 요청별 `seq_len=1`이라 16개가 한 번에 나간다).

즉 관측된 원인은 "배치 구현이 없음"이 아니라 **워커의 `max_batch_size`가 1로 해석되어 비배치 분기를 탔다**
쪽이다. 플랫폼(`Using model-configured max batch size 16`)과 워커(`mblt_worker.py:373`, `:3138`)가 같은
`resolve_model_max_batch_size`를 쓰는데도 갈렸다면 그게 진짜 버그 지점이므로, 근거 없이 코드를 바꾸기보다
재측정을 먼저 제안한다:

```bash
VLLM_MBLT_DEBUG=1 vllm serve <batch16-package> --trust-remote-code \
  --model-loader-extra-config '{"dev_no": 0}'
# 16 concurrent 요청 중 다음 라인이 나오는지 확인
# [mblt-batch-debug] prepared batch: req_count=16 normal_count=16 ...
```

이 라인이 안 나오면 `max_batch_size` 해석 경로를 파야 한다.

## 테스트

```
237 passed
ruff check: All checks passed!
```

추가한 테스트:
- `tests/test_runtime_cache.py` — 라이브 슬롯/단일 캐시의 토큰 수 일치 시 재사용, 부족 시 거부 +
  호환 스냅샷 폴백, 초과 시(preempt/resume) 재사용 유지, 슬롯 반납 시 카운트 미상속, 미추적 소유자는
  기존 trust-the-owner 동작 유지.
- `tests/test_mblt_worker_optimizations.py` — 워커 cost-policy 경로의 거부 + 경고, `execute_model`이
  스텝 후 슬롯 토큰 수를 기록, 라이브 슬롯 비소유 종료 요청은 스냅샷 없음(소유 시에는 있음),
  페널티 기본값 해석, 페널티가 CPU 로짓에 실제 반영됨.
- `tests/test_mblt_platform_prefill.py` — `auto` 단일 항목 해석(hf config / loader extra config),
  명시적 `default` 우선, 항목 여러 개일 때 추측 안 함, 명시적 core mode가 남의 값 안 빌림,
  batch 모델에서 clamp 동작 유지.

README(chunked prefill 규칙 / 새 경고 / Sampling Penalties 절)와 CHANGELOG도 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
