### PR TITLE
CI: run pytest and ruff on every pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,68 @@
+name: Tests
+
+# Runs the same checks the release pipeline gates on (see the `test` job in
+# publish.yml), but on every pull request instead of only at release time.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      # Pinned so a new ruff release cannot fail an unrelated pull request.
+      # Keep in step with the `ruff` entry in the pyproject dev dependency group.
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "ruff==0.16.0"
+
+      - name: Check lint rules
+        run: python -m ruff check vllm_mblt tests
+
+  test:
+    name: Test on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest
+
+      - name: Run tests
+        run: python -m pytest tests


### PR DESCRIPTION
## Problem

Tests only run from the `test` job in `publish.yml`, which is gated on `release: published`. There is no CI on pull requests, so the only evidence a reviewer has is whatever the author ran locally — and a regression is not caught until release time.

Noticed while reviewing #11: that PR reported `245 passed` from a local WSL venv, and nothing in CI confirmed it.

## Change

One new file, `.github/workflows/tests.yml`, running on `pull_request` and on `push` to `main`.

**`test` job** — deliberately the *same recipe* already proven in `publish.yml`:

```yaml
runs-on: ubuntu-latest
python-version: ["3.10", "3.11", "3.12"]   # fail-fast: false
python -m pip install --upgrade pip
python -m pip install -e . pytest
python -m pytest tests
```

Matching the release gate exactly means a PR cannot pass CI and then fail the release pipeline on the same commit. `qbruntime` installs cleanly on a runner without NPU hardware — it comes from `mobilint-qb-runtime`, a public PyPI transitive dependency of `mblt-model-zoo`.

**`lint` job** — `ruff check vllm_mblt tests`. Separate job so lint feedback arrives without waiting on the vllm/torch install.

Other details:

- `ruff` is pinned to `0.16.0` so a new ruff release cannot fail an unrelated PR. The `ruff` entry in the pyproject dev dependency group is unpinned; the workflow comment notes the two should move together. Left pyproject alone to keep this PR to a single file — happy to pin it here instead if you prefer one source of truth.
- `setup-python` pip cache keyed on `pyproject.toml`, to avoid re-downloading torch/vllm on every run.
- `concurrency` cancels superseded runs for the same PR.
- Same `actions/checkout@v5` / `actions/setup-python@v6` / `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` as the existing workflows.

## Verification

Locally on this branch (= current `main`):

```
ruff check vllm_mblt tests  ->  All checks passed!
python -m pytest tests      ->  213 passed
```

This PR is branched from `main`, so its own CI run is the real check that the workflow works.

## Notes

- The 3-version matrix installs vllm + torch three times per PR. If Actions minutes matter more than matching the release gate, the PR trigger can be trimmed to `3.10` only, leaving the full matrix on `push` to `main`.
- The dev environment is uv-managed (`.venv` has no pip) and pyproject uses a PEP 735 `[dependency-groups] dev`. This workflow uses plain pip + official `actions/*` to stay consistent with the existing workflows; switching to `astral-sh/setup-uv` + `uv sync --group dev` would be faster and would install the declared dev group directly, if you would rather take that dependency.
- Not included: branch protection. `main` is currently unprotected, so these checks are informational until someone marks them required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
