### PR TITLE
Report pinned memory as unavailable on MbltPlatform (fixes red main and the v0.2.1 release gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
+## 0.2.2
+
+### Fixed
+
+- `MbltPlatform` now reports `is_pin_memory_available() == False`. The base
+  vLLM `Platform` answers `True` on any non-WSL host, so an MBLT server on
+  plain Linux without an NVIDIA driver made vLLM allocate pinned tensors and
+  `Tensor.pin_memory()` raised `Found no NVIDIA driver on your system`. The
+  sampling-penalty path hit this first (`apply_all_penalties` ->
+  `make_tensor_with_pad`), which is why 0.2.1 could not enable penalties
+  safely. MBLT runs on the NPU with CPU-side host tensors, so there is nothing
+  to pin, and `CpuPlatform` answers `False` for the same reason.
+
 ## 0.2.1
+
+Tagged but never published: the release pipeline's test gate caught the pinned
+memory failure above, so no 0.2.1 artifact reached PyPI. Use 0.2.2.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.2
+## 0.2.1
 
 ### Fixed
 
@@ -9,17 +9,9 @@
   plain Linux without an NVIDIA driver made vLLM allocate pinned tensors and
   `Tensor.pin_memory()` raised `Found no NVIDIA driver on your system`. The
   sampling-penalty path hit this first (`apply_all_penalties` ->
-  `make_tensor_with_pad`), which is why 0.2.1 could not enable penalties
-  safely. MBLT runs on the NPU with CPU-side host tensors, so there is nothing
-  to pin, and `CpuPlatform` answers `False` for the same reason.
-
-## 0.2.1
-
-Tagged but never published: the release pipeline's test gate caught the pinned
-memory failure above, so no 0.2.1 artifact reached PyPI. Use 0.2.2.
-
-### Fixed
-
+  `make_tensor_with_pad`). MBLT runs on the NPU with CPU-side host tensors, so
+  there is nothing to pin, and `CpuPlatform` answers `False` for the same
+  reason.
 - Sampling penalties (`frequency_penalty`, `presence_penalty`,
   `repetition_penalty`) are now applied by default instead of only when CUDA is
   available. vLLM applies them through a pure-torch fallback when the fused

--- a/tests/test_mblt_platform_prefill.py
+++ b/tests/test_mblt_platform_prefill.py
@@ -457,3 +457,28 @@ class TestMbltPlatformPrefill:
 
         assert resolve_npu_prefill_chunk_size(config) == 512
         assert resolve_effective_npu_prefill_chunk_size(config) == 128
+
+    def test_platform_reports_pin_memory_unavailable(self, monkeypatch) -> None:
+        from vllm.utils.platform_utils import is_pin_memory_available
+
+        # The base Platform answers False under WSL for unrelated reasons, so
+        # force the non-WSL branch: that is the plain-Linux NPU server, where
+        # the base implementation used to answer True and vLLM then built
+        # pinned tensors on a host with no NVIDIA driver.
+        monkeypatch.setattr("vllm.platforms.interface.in_wsl", lambda: False)
+        # is_pin_memory_available() is @cache'd; drop the memoized WSL answer.
+        is_pin_memory_available.cache_clear()
+        monkeypatch.setattr(
+            is_pin_memory_available,
+            "cache_clear",
+            is_pin_memory_available.cache_clear,
+            raising=False,
+        )
+
+        try:
+            assert MbltPlatform.is_pin_memory_available() is False
+            # Also assert through the helper vLLM actually calls, so the
+            # override is proven to be wired into current_platform.
+            assert is_pin_memory_available() is False
+        finally:
+            is_pin_memory_available.cache_clear()

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -6,6 +6,7 @@ import torch
 from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from vllm.logprobs import Logprob
 from vllm.sampling_params import SamplingParams
+from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.engine.logprobs import LogprobsProcessor, create_prompt_logprobs
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.sample.logits_processor import LogitsProcessors
@@ -3415,3 +3416,31 @@ class TestMbltWorkerOptimizations:
         # Without the clamp the snapshot would claim 256 tokens and decoding
         # would resume at 256 over 128 tokens of real KV.
         assert cache_size == 128
+
+    def test_sampling_penalties_do_not_require_pinned_memory(self, monkeypatch, request) -> None:
+        # Reproduces the CPU-runner failure: vLLM's penalty path builds its
+        # output-token tensor through make_tensor_with_pad(), which calls
+        # Tensor.pin_memory() whenever the platform claims pinned memory is
+        # available. On a host without an NVIDIA driver that raises
+        # "Found no NVIDIA driver on your system".
+        def _explode(self, *args, **kwargs):
+            raise RuntimeError("Found no NVIDIA driver on your system.")
+
+        monkeypatch.setattr(torch.Tensor, "pin_memory", _explode, raising=True)
+        # Force the plain-Linux branch of Platform.is_pin_memory_available, and
+        # drop the @cache'd answer computed earlier in the process, so this
+        # test fails without the MbltPlatform override even on a WSL host.
+        monkeypatch.setattr("vllm.platforms.interface.in_wsl", lambda: False)
+        is_pin_memory_available.cache_clear()
+        request.addfinalizer(is_pin_memory_available.cache_clear)
+
+        worker = self._make_worker()
+        worker.model = SimpleNamespace(config=SimpleNamespace(vocab_size=4))
+        sampling_params = SamplingParams.from_optional(temperature=0.0, repetition_penalty=2.0)
+        req_state = self._make_request_state(worker, sampling_params, [0], output_token_ids=[1])
+        sampling_metadata = worker._make_sampling_metadata([req_state])
+        logits = torch.tensor([[1.0, 4.0, 3.0, 0.5]], dtype=torch.float32)
+
+        sampler_output = worker._sample_next_token(logits=logits, sampling_metadata=sampling_metadata)
+
+        assert int(sampler_output.sampled_token_ids[0, 0].item()) == 2

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.2"
+__version__ = "0.2.1"
 
 
 def register():

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 def register():

--- a/vllm_mblt/mblt_platform.py
+++ b/vllm_mblt/mblt_platform.py
@@ -317,6 +317,21 @@ class MbltPlatform(Platform):
     device_name = "cpu"
 
     @classmethod
+    def is_pin_memory_available(cls) -> bool:
+        """Pinned host memory is a CUDA facility and is never available here.
+
+        The base `Platform` implementation returns True on any non-WSL host, so
+        an MBLT server on plain Linux without an NVIDIA driver used to answer
+        True. vLLM then builds tensors with `pin_memory=True` and
+        `Tensor.pin_memory()` raises `Found no NVIDIA driver on your system` —
+        for example in the sampling-penalty path
+        (`apply_all_penalties` -> `make_tensor_with_pad`). MBLT executes on the
+        NPU with CPU-side host tensors, so there is nothing to pin, and
+        `CpuPlatform` answers False for the same reason.
+        """
+        return False
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         parallel_config: ParallelConfig = vllm_config.parallel_config  # type: ignore
         parallel_config.worker_cls = "vllm_mblt.mblt_worker.MbltWorker"


### PR DESCRIPTION
## What broke

`main` is red, and the `v0.2.1` release failed its publish gate. Both for the same reason:

```
RuntimeError: Found no NVIDIA driver on your system.
  vllm/utils/torch_utils.py:353  in make_tensor_with_pad -> tensor.pin_memory()
  vllm/v1/sample/ops/penalties.py:48  in _convert_to_tensors
  vllm/v1/sample/ops/penalties.py:23  in apply_all_penalties
  vllm_mblt/mblt_worker.py:2637  in _sample_next_token
```

## Root cause

`MbltPlatform` sets `device_type = "cpu"` but never overrides `is_pin_memory_available()`. The base vLLM `Platform` implementation returns `True` on **any non-WSL host**:

```python
# vllm/platforms/interface.py
@classmethod
def is_pin_memory_available(cls) -> bool:
    if in_wsl():
        return False   # <- the only False branch
    return True
```

So on a plain-Linux NPU server with no NVIDIA driver, `MbltPlatform` claimed pinned memory was available; vLLM then built tensors with `pin_memory=True` and `Tensor.pin_memory()` raised. `CpuPlatform` overrides this to `False` — `MbltPlatform` should too.

**This is not a CI-only problem.** The GitHub runner has no NVIDIA driver, which is exactly the shape of a real NPU server. The failure would have hit `server102` on any request carrying a sampling penalty.

It also corrects something I got wrong in #11: I read the old `enable_sampling_penalties = torch.cuda.is_available()` gate as stale code written against an older vLLM. It was in fact masking this bug. Enabling penalties (a real fix for finding 4 — released packages ship `repetition_penalty` in `generation_config.json`) is what exposed it. The right resolution is to make the platform report the truth, not to disable penalties again.

## Change

```python
@classmethod
def is_pin_memory_available(cls) -> bool:
    return False
```

## Why the WSL dev environment never caught it

`in_wsl()` is `True` on the development machine, so the base implementation already returned `False` there and the penalty path worked. The bug only appears off WSL. Both new tests therefore pin `vllm.platforms.interface.in_wsl` to `False`, and clear the `@cache` on `vllm.utils.platform_utils.is_pin_memory_available` (whose memoized WSL answer otherwise makes any later assertion vacuous):

- `test_platform_reports_pin_memory_unavailable` — asserts `False` both directly and through `is_pin_memory_available()`, so the override is proven wired into `current_platform`.
- `test_sampling_penalties_do_not_require_pinned_memory` — monkeypatches `Tensor.pin_memory` to raise the exact runner error, then samples with `repetition_penalty=2.0`. This reproduces the CI stack trace end to end.

Removing the override makes both fail:

```
FAILED tests/test_mblt_platform_prefill.py::...::test_platform_reports_pin_memory_unavailable
FAILED tests/test_mblt_worker_optimizations.py::...::test_sampling_penalties_do_not_require_pinned_memory
        RuntimeError: Found no NVIDIA driver on your system.
```

## Version stays 0.2.1

`v0.2.1` was tagged and a GitHub release published, but its pipeline failed at the test gate and `Build` / `Publish to TestPyPI` / `Publish to PyPI` were all skipped — **PyPI is still on 0.2.0, so no broken artifact shipped.** The release gate did its job.

Because nothing was ever published under 0.2.1, this PR keeps `__version__ = "0.2.1"` and folds the pinned-memory entry into the existing `## 0.2.1` CHANGELOG section rather than skipping a number.

**Follow-up needed after merge:** the existing `v0.2.1` tag and release point at `bc733cc`, which does not contain this fix, and `publish.yml` builds from the tag. The release has to be re-cut from the new `main` — delete the `v0.2.1` release and tag, then create it again — otherwise a re-run of the publish workflow rebuilds the broken commit.

## Verification

```
ruff check vllm_mblt tests  ->  All checks passed!
python -m pytest tests      ->  247 passed
```

CI on this PR runs the workflow added in #12, so the runner itself is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
