### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.1
+## 0.2.2
 
 ### Fixed
 
@@ -9,9 +9,18 @@
   plain Linux without an NVIDIA driver made vLLM allocate pinned tensors and
   `Tensor.pin_memory()` raised `Found no NVIDIA driver on your system`. The
   sampling-penalty path hit this first (`apply_all_penalties` ->
-  `make_tensor_with_pad`). MBLT runs on the NPU with CPU-side host tensors, so
-  there is nothing to pin, and `CpuPlatform` answers `False` for the same
-  reason.
+  `make_tensor_with_pad`), which is why the fixes below could not ship as
+  0.2.1. MBLT runs on the NPU with CPU-side host tensors, so there is nothing
+  to pin, and `CpuPlatform` answers `False` for the same reason.
+
+## 0.2.1
+
+Tagged on GitHub but never published to PyPI: the release pipeline's test gate
+caught the pinned memory failure above, so no 0.2.1 artifact was ever built.
+Install 0.2.2 to get the fixes below.
+
+### Fixed
+
 - Sampling penalties (`frequency_penalty`, `presence_penalty`,
   `repetition_penalty`) are now applied by default instead of only when CUDA is
   available. vLLM applies them through a pure-torch fallback when the fused

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 def register():


### PR DESCRIPTION
## Why

`v0.2.1` was tagged and released on GitHub, but its publish pipeline failed at the test gate (the pinned-memory bug fixed in #13), so `Build` / `Publish to TestPyPI` / `Publish to PyPI` were all skipped — **PyPI is still on 0.2.0 and no 0.2.1 artifact ever existed.**

That tag still points at `9019430`, which predates the #13 fix, and `publish.yml` checks out from the tag. Reusing the number would mean deleting the published release and re-cutting the tag. Bumping instead avoids touching a public release object, and skipping 0.2.1 costs nothing because nobody could have installed it.

## Change

- `__version__` → `0.2.2`
- CHANGELOG split into two sections:
  - `## 0.2.2` — the `MbltPlatform.is_pin_memory_available()` fix
  - `## 0.2.1` — the #11 fixes, with a note that it was tagged but never published to PyPI and that 0.2.2 is what to install

No code changes; #13 already landed the fix on `main`.

## After merge

`publish.yml`'s build job validates the release tag against `__version__`, so the release must be tagged **`v0.2.2`**. The existing `v0.2.1` GitHub release stays as-is — a failed release that shipped nothing.

## Verification

```
ruff check vllm_mblt tests  ->  All checks passed!
python -m pytest tests      ->  247 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
