### PR TITLE
CI: install test dependencies with uv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,13 @@ name: Tests
 
 # Runs the same checks the release pipeline gates on (see the `test` job in
 # publish.yml), but on every pull request instead of only at release time.
+#
+# The dependency install goes through uv rather than pip. It resolves the same
+# dependencies declared in pyproject.toml, but hardlinks wheels out of its own
+# cache instead of unpacking them again, which is where the ~150-240s of a
+# torch/vllm install went. publish.yml deliberately stays on plain pip so the
+# release gate keeps exercising the install path a user gets from
+# `pip install vllm-mblt`.
 
 on:
   pull_request:
@@ -53,16 +60,26 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
 
+      # Pinned to an exact release: setup-uv publishes no floating major tag
+      # above v7, and a third-party action should not move under us.
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
+      # Build the environment on the interpreter actions/setup-python provided,
+      # so this job runs against the same Python build the release pipeline uses
+      # rather than a uv-managed standalone one.
       - name: Install test dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e . pytest
+          uv venv --python "${{ steps.setup-python.outputs.python-path }}"
+          uv pip install -e . pytest
 
       - name: Run tests
-        run: python -m pytest tests
+        run: .venv/bin/python -m pytest tests


### PR DESCRIPTION
## Where the time actually goes

Measured per-step on the `main` run of the Tests workflow (`33851418884`), with a warm pip cache:

| Job | Install deps | pytest | pip cache save | Total |
|---|---|---|---|---|
| Test on Python 3.10 | **244s** | 39s | 75s | 366s |
| Test on Python 3.11 | **142s** | 28s | 0s | 226s |
| Test on Python 3.12 | **200s** | 32s | 52s | 290s |
| Lint | — | — | — | 5s |

So pytest itself is not the problem. The install is, and it stays expensive *even with a warm pip cache* — the cost is unpacking the torch/vllm wheels, not downloading them. The `Post Set up Python` cache-save adds another 50-75s on top, inconsistently.

## Change

Switch the `test` job's install to uv:

```yaml
- uses: astral-sh/setup-uv@v10.0.1
  with:
    enable-cache: true
    cache-dependency-glob: pyproject.toml

- run: |
    uv venv --python "${{ steps.setup-python.outputs.python-path }}"
    uv pip install -e . pytest

- run: .venv/bin/python -m pytest tests
```

uv hardlinks wheels out of its cache into the venv instead of unpacking them again, which is exactly the step that dominates today. Dropping `cache: pip` from `actions/setup-python` also removes the 50-75s cache-save step.

Deliberate choices:

- **The interpreter still comes from `actions/setup-python`** (`uv venv --python <its path>`), not a uv-managed standalone build, so this job keeps testing the same Python the release pipeline uses.
- **`publish.yml` stays on plain pip.** The release gate should keep exercising the install path a user actually gets from `pip install vllm-mblt`; only the PR gate trades that for speed. This does mean the two resolve independently — a version that pip and uv resolve differently could pass here and fail at release. I verified locally that uv picks the same core versions (`vllm==0.11.2`, `torch==2.9.0`), and the release gate remains the authority.
- **`setup-uv` pinned to an exact release.** It publishes no floating major tag above `v7`, and a third-party action should not move under us. Happy to pin to a full commit SHA instead if you prefer.
- **`lint` job untouched** — already 5s total, since it never installs vllm/torch.

## What this does not change

- The 3-version matrix stays. Legs run in parallel, so trimming it saves Actions minutes but not wall-clock; I left coverage alone. If minutes are the concern, the PR trigger could drop to `3.10` with the full matrix kept on `push` to `main` — say the word.
- `pytest` at 28-39s is mostly `import vllm` pulling in torch on a cold runner; the 247 tests themselves run in well under a second. Not much to win there.

## Numbers

The first run on this PR is a cold uv cache, so the honest comparison is the second run onward. I will post the measured before/after here once a warm run exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
