### PR TITLE
Select batch rope/deepstack inputs by shape, not position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@
   layer) -- and the same answer drives both validation and the order the
   tensors are emitted in. Classifying one way while emitting the other would
   have put RoPE in the deepstack slot and returned wrong logits with no error.
-  A signature neither discriminator can read still falls back to the shipped
-  positional order, so shipped artifacts are unchanged.
+  A signature neither discriminator can read -- a single-layer deepstack whose
+  declared size the rope input shares -- still falls back to the positional
+  order for the model kind, so shipped artifacts are unchanged. That fallback
+  remains the one path that can emit the two tensors in the wrong slots without
+  raising, because the declared shapes are then identical and every validation
+  check passes either way; it now logs a warning once per worker naming the
+  shapes it could not tell apart.
 
 ## 0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.3
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- The 3-input Qwen3-VL text MXQ no longer assumes a fixed order for its two
+  trailing inputs. `_build_infer_inputs` and `_build_batch_infer_inputs` read
+  `input_shapes[1]`/`[2]` positionally, which holds for the MXQs shipped so far
+  but is not something the compiler guarantees: a rebuild of the same model can
+  declare `[inputs, deepstack, rope]`, and serving one failed with
+  `RuntimeError: 3-input Qwen3-VL batch text MXQ rope batch dimension must be
+  1, got (3, -1, 4096).` The two inputs are now classified from their declared
+  shapes -- by the last axis (deepstack's is the hidden size) and, when that is
+  unreadable, by the leading axis (only deepstack may declare more than one
+  layer) -- and the same answer drives both validation and the order the
+  tensors are emitted in. Classifying one way while emitting the other would
+  have put RoPE in the deepstack slot and returned wrong logits with no error.
+  A signature neither discriminator can read still falls back to the shipped
+  positional order, so shipped artifacts are unchanged.
+
 ## 0.2.2
 
 ### Fixed

--- a/tests/test_mblt_worker_optimizations.py
+++ b/tests/test_mblt_worker_optimizations.py
@@ -2543,7 +2543,11 @@ class TestMbltWorkerOptimizations:
         assert tuple(infer_inputs[1].shape) == (3, 5, 4)
         np.testing.assert_array_equal(infer_inputs[1], np.zeros((3, 5, 4), dtype=np.float32))
 
-    def test_build_infer_inputs_passes_deepstack_then_rope_for_nonbatch_qwen3_vl_three_input_model(self) -> None:
+    def test_build_infer_inputs_follows_declared_deepstack_then_rope_shapes(self) -> None:
+        # max_batch_size is set but inert: these shapes are unambiguous, so the
+        # declared order decides and the batch/non-batch default never applies.
+        # test_build_infer_inputs_falls_back_to_*_order_when_shapes_are_ambiguous
+        # below covers the default itself.
         worker = self._make_worker()
         worker.max_batch_size = 1
         worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
@@ -2564,7 +2568,8 @@ class TestMbltWorkerOptimizations:
         np.testing.assert_array_equal(infer_inputs[1], deepstack_embeds)
         np.testing.assert_array_equal(infer_inputs[2], rope_embeds)
 
-    def test_build_infer_inputs_passes_rope_then_deepstack_for_batch_qwen3_vl_three_input_model(self) -> None:
+    def test_build_infer_inputs_follows_declared_rope_then_deepstack_shapes(self) -> None:
+        # Mirror of the test above, and max_batch_size is inert here too.
         worker = self._make_worker()
         worker.max_batch_size = 16
         worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
@@ -2582,6 +2587,51 @@ class TestMbltWorkerOptimizations:
 
         assert isinstance(infer_inputs, list)
         assert [tuple(item.shape) for item in infer_inputs] == [(1, 5, 4), (1, 5, 6), (3, 5, 4)]
+        np.testing.assert_array_equal(infer_inputs[1], rope_embeds)
+        np.testing.assert_array_equal(infer_inputs[2], deepstack_embeds)
+
+    def _make_ambiguous_three_input_worker(self, max_batch_size: int):
+        """A 3-input Qwen3-VL worker whose two trailing shapes are identical.
+
+        Neither discriminator can read this signature -- one deepstack layer,
+        and a pe_size equal to the hidden size -- so `_is_batch_model()` decides
+        the order. That fallback is the only remaining path that can emit the
+        tensors in the wrong slots without raising, since both declared shapes
+        pass every validation check either way, so it needs pinning in both
+        directions: swapping the two branches of the `default` ternary in
+        `_qwen3_vl_text_extra_input_order` has to fail one of these two tests.
+        """
+
+        worker = self._make_worker()
+        worker.max_batch_size = max_batch_size
+        worker.model_config.hf_config = SimpleNamespace(model_type="mobilint-qwen3_vl")
+        worker.cache_model = SimpleNamespace(
+            get_num_model_variants=lambda: 1,
+            get_model_variant_handle=lambda _idx: SimpleNamespace(
+                get_model_input_shape=lambda: [(1, -1, 4), (1, -1, 4), (1, -1, 4)]
+            ),
+        )
+        return worker
+
+    def test_build_infer_inputs_falls_back_to_nonbatch_order_when_shapes_are_ambiguous(self) -> None:
+        worker = self._make_ambiguous_three_input_worker(max_batch_size=1)
+        input_embeds = np.ones((5, 4), dtype=np.float32)
+        rope_embeds = np.full((1, 5, 4), 2.0, dtype=np.float32)
+        deepstack_embeds = np.full((1, 5, 4), 3.0, dtype=np.float32)
+
+        infer_inputs = worker._build_infer_inputs(input_embeds, deepstack_embeds, rope_embeds=rope_embeds)
+
+        np.testing.assert_array_equal(infer_inputs[1], deepstack_embeds)
+        np.testing.assert_array_equal(infer_inputs[2], rope_embeds)
+
+    def test_build_infer_inputs_falls_back_to_batch_order_when_shapes_are_ambiguous(self) -> None:
+        worker = self._make_ambiguous_three_input_worker(max_batch_size=16)
+        input_embeds = np.ones((5, 4), dtype=np.float32)
+        rope_embeds = np.full((1, 5, 4), 2.0, dtype=np.float32)
+        deepstack_embeds = np.full((1, 5, 4), 3.0, dtype=np.float32)
+
+        infer_inputs = worker._build_infer_inputs(input_embeds, deepstack_embeds, rope_embeds=rope_embeds)
+
         np.testing.assert_array_equal(infer_inputs[1], rope_embeds)
         np.testing.assert_array_equal(infer_inputs[2], deepstack_embeds)
 

--- a/tests/test_qwen3_vl_extra_input_order.py
+++ b/tests/test_qwen3_vl_extra_input_order.py
@@ -1,0 +1,119 @@
+"""Qwen3-VL 3-input text MXQ: which trailing input is rope and which is deepstack.
+
+The compiler does not fix that order. Shipped Batch16 artifacts declare
+[inputs, rope, deepstack]; a rebuild can emit [inputs, deepstack, rope].
+Getting it wrong is silent -- both tensors are float32 and the NPU happily
+returns garbage logits -- so these tests pin both the classification and the
+order the tensors are actually emitted in.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vllm_mblt.mblt_worker import MbltWorker
+
+HIDDEN = 4096
+PE = 256
+LAYERS = 3
+TOKENS = 7
+
+ROPE_SHAPE = (1, -1, PE)
+DEEPSTACK_SHAPE = (LAYERS, -1, HIDDEN)
+INPUT_SHAPE = (1, -1, HIDDEN)
+
+
+def _worker(input_shapes, *, is_batch):
+    """A MbltWorker with just enough wired up to exercise the input builders."""
+    w = MbltWorker.__new__(MbltWorker)
+    w._cache_model_input_shapes = lambda _model: list(input_shapes)
+    w._get_cache_model = lambda: SimpleNamespace()
+    w._is_batch_model = lambda: is_batch
+    w._supports_deepstack_input = lambda: True
+    return w
+
+
+def _embeds(seq=TOKENS):
+    return (
+        np.arange(seq * HIDDEN, dtype=np.float32).reshape(seq, HIDDEN),
+        np.full((LAYERS, seq, HIDDEN), 2.0, dtype=np.float32),
+        np.full((1, seq, PE), 3.0, dtype=np.float32),
+    )
+
+
+class TestDetectTailOrder:
+    def test_shipped_batch_layout_rope_first(self) -> None:
+        order = MbltWorker._detect_qwen3_vl_tail_order(
+            [ROPE_SHAPE, DEEPSTACK_SHAPE], HIDDEN, ("rope", "deepstack")
+        )
+        assert order == ("rope", "deepstack")
+
+    def test_rebuilt_layout_deepstack_first(self) -> None:
+        order = MbltWorker._detect_qwen3_vl_tail_order(
+            [DEEPSTACK_SHAPE, ROPE_SHAPE], HIDDEN, ("rope", "deepstack")
+        )
+        assert order == ("deepstack", "rope")
+
+    def test_dynamic_last_axis_falls_back_to_default(self) -> None:
+        # A deepstack input with a dynamic hidden axis cannot be classified.
+        # Falling back keeps whatever the positional convention already did.
+        order = MbltWorker._detect_qwen3_vl_tail_order(
+            [(LAYERS, -1, -1), ROPE_SHAPE], HIDDEN, ("deepstack", "rope")
+        )
+        assert order == ("deepstack", "rope")
+
+    def test_pe_size_equal_to_hidden_falls_back_to_default(self) -> None:
+        # Ambiguous: both tails end in hidden_size. Guessing here would flip
+        # artifacts the positional convention already handled correctly.
+        order = MbltWorker._detect_qwen3_vl_tail_order(
+            [(1, -1, HIDDEN), DEEPSTACK_SHAPE], HIDDEN, ("rope", "deepstack")
+        )
+        assert order == ("rope", "deepstack")
+
+    def test_two_input_layout_is_left_alone(self) -> None:
+        order = MbltWorker._detect_qwen3_vl_tail_order(
+            [DEEPSTACK_SHAPE], HIDDEN, ("rope", "deepstack")
+        )
+        assert order == ("rope", "deepstack")
+
+
+@pytest.mark.parametrize(
+    "tail_shapes, expect_rope_at",
+    [((ROPE_SHAPE, DEEPSTACK_SHAPE), 1), ((DEEPSTACK_SHAPE, ROPE_SHAPE), 2)],
+)
+class TestEmittedOrderMatchesDeclaration:
+    """The detected order must drive the returned tensors, not just validation."""
+
+    def test_batch_path(self, tail_shapes, expect_rope_at) -> None:
+        w = _worker((INPUT_SHAPE, *tail_shapes), is_batch=True)
+        emb, deep, rope = _embeds()
+        out = w._build_batch_infer_inputs([emb], [deep], [rope])
+        assert len(out) == 3
+        expect_ds_at = 2 if expect_rope_at == 1 else 1
+        assert out[expect_rope_at].shape[-1] == PE
+        assert out[expect_ds_at].shape[-1] == HIDDEN
+        np.testing.assert_allclose(out[expect_rope_at], rope)
+        np.testing.assert_allclose(out[expect_ds_at], deep)
+
+    def test_single_request_path(self, tail_shapes, expect_rope_at) -> None:
+        w = _worker((INPUT_SHAPE, *tail_shapes), is_batch=True)
+        emb, deep, rope = _embeds()
+        out = w._build_infer_inputs(emb, deep, rope)
+        assert len(out) == 3
+        expect_ds_at = 2 if expect_rope_at == 1 else 1
+        assert out[expect_rope_at].shape[-1] == PE
+        assert out[expect_ds_at].shape[-1] == HIDDEN
+
+
+class TestPathsAgree:
+    def test_both_builders_pick_the_same_order(self) -> None:
+        for tail in ((ROPE_SHAPE, DEEPSTACK_SHAPE), (DEEPSTACK_SHAPE, ROPE_SHAPE)):
+            for is_batch in (True, False):
+                w = _worker((INPUT_SHAPE, *tail), is_batch=is_batch)
+                emb, deep, rope = _embeds()
+                batch_out = w._build_batch_infer_inputs([emb], [deep], [rope])
+                single_out = w._build_infer_inputs(emb, deep, rope)
+                assert [t.shape[-1] for t in batch_out] == [t.shape[-1] for t in single_out], (
+                    f"batch and single-request paths disagree for tail={tail}, is_batch={is_batch}"
+                )

--- a/tests/test_qwen3_vl_extra_input_order.py
+++ b/tests/test_qwen3_vl_extra_input_order.py
@@ -55,21 +55,33 @@ class TestDetectTailOrder:
         )
         assert order == ("deepstack", "rope")
 
-    def test_dynamic_last_axis_falls_back_to_default(self) -> None:
-        # A deepstack input with a dynamic hidden axis cannot be classified.
-        # Falling back keeps whatever the positional convention already did.
+    def test_dynamic_hidden_axis_resolved_by_leading_axis(self) -> None:
+        # The last axis is unreadable (dynamic hidden), so the leading axis
+        # decides: only deepstack may declare more than one layer. The default
+        # is the *wrong* answer here, so this fails if detection falls back.
         order = MbltWorker._detect_qwen3_vl_tail_order(
-            [(LAYERS, -1, -1), ROPE_SHAPE], HIDDEN, ("deepstack", "rope")
+            [(LAYERS, -1, -1), ROPE_SHAPE], HIDDEN, ("rope", "deepstack")
         )
         assert order == ("deepstack", "rope")
 
-    def test_pe_size_equal_to_hidden_falls_back_to_default(self) -> None:
-        # Ambiguous: both tails end in hidden_size. Guessing here would flip
-        # artifacts the positional convention already handled correctly.
+    def test_pe_size_equal_to_hidden_resolved_by_leading_axis(self) -> None:
+        # Both tails end in hidden_size, so the last axis cannot separate them.
+        # The leading axis still can, and again the default disagrees.
         order = MbltWorker._detect_qwen3_vl_tail_order(
-            [(1, -1, HIDDEN), DEEPSTACK_SHAPE], HIDDEN, ("rope", "deepstack")
+            [(1, -1, HIDDEN), DEEPSTACK_SHAPE], HIDDEN, ("deepstack", "rope")
         )
         assert order == ("rope", "deepstack")
+
+    @pytest.mark.parametrize("default", [("rope", "deepstack"), ("deepstack", "rope")])
+    def test_unreadable_on_both_axes_falls_back_to_default(self, default) -> None:
+        # A single-layer deepstack sharing the rope input's declared size is
+        # genuinely indistinguishable: neither axis separates the two. Guessing
+        # would flip artifacts the positional convention already handled, so the
+        # fallback has to win -- whichever way it points.
+        order = MbltWorker._detect_qwen3_vl_tail_order(
+            [(1, -1, HIDDEN), (1, -1, HIDDEN)], HIDDEN, default
+        )
+        assert order == default
 
     def test_two_input_layout_is_left_alone(self) -> None:
         order = MbltWorker._detect_qwen3_vl_tail_order(
@@ -81,7 +93,13 @@ class TestDetectTailOrder:
 @pytest.mark.parametrize("is_batch", [True, False])
 @pytest.mark.parametrize(
     "tail_shapes, expect_rope_at",
-    [((ROPE_SHAPE, DEEPSTACK_SHAPE), 1), ((DEEPSTACK_SHAPE, ROPE_SHAPE), 2)],
+    [
+        ((ROPE_SHAPE, DEEPSTACK_SHAPE), 1),
+        ((DEEPSTACK_SHAPE, ROPE_SHAPE), 2),
+        # Dynamic hidden axis: classified by the leading axis, and emitted
+        # end-to-end -- not just resolved by the detection helper in isolation.
+        (((LAYERS, -1, -1), ROPE_SHAPE), 2),
+    ],
 )
 class TestEmittedOrderMatchesDeclaration:
     """The detected order must drive the returned tensors, not just validation.

--- a/tests/test_qwen3_vl_extra_input_order.py
+++ b/tests/test_qwen3_vl_extra_input_order.py
@@ -25,10 +25,21 @@ INPUT_SHAPE = (1, -1, HIDDEN)
 
 
 def _worker(input_shapes, *, is_batch):
-    """A MbltWorker with just enough wired up to exercise the input builders."""
+    """A MbltWorker with just enough wired up to exercise the input builders.
+
+    Fakes the accelerator handle, the way the other builder tests do, rather
+    than shadowing `_cache_model_input_shapes`: that keeps the real reader in
+    the path, including the `except Exception: return []` that decides what the
+    builders see when a shape query fails.
+    """
+
     w = MbltWorker.__new__(MbltWorker)
-    w._cache_model_input_shapes = lambda _model: list(input_shapes)
-    w._get_cache_model = lambda: SimpleNamespace()
+    w.cache_model = SimpleNamespace(
+        get_num_model_variants=lambda: 1,
+        get_model_variant_handle=lambda _idx: SimpleNamespace(
+            get_model_input_shape=lambda: [tuple(shape) for shape in input_shapes]
+        ),
+    )
     w._is_batch_model = lambda: is_batch
     w._supports_deepstack_input = lambda: True
     return w
@@ -142,6 +153,33 @@ class TestEmittedOrderMatchesDeclaration:
         expect_ds_at = 2 if expect_rope_at == 1 else 1
         np.testing.assert_allclose(out[expect_rope_at], rope)
         np.testing.assert_allclose(out[expect_ds_at], deep)
+
+
+class TestShapeQueryFailure:
+    def test_a_failing_shape_query_degrades_to_the_text_input_alone(self) -> None:
+        # The real reader swallows every exception and returns []. Both builders
+        # have to take the len < 2 path then, rather than index a list they
+        # believe has three entries -- the hazard a3e29cc removed by threading
+        # the caller's shapes through instead of re-reading them.
+        def boom():
+            raise RuntimeError("accelerator handle is gone")
+
+        emb, deep, rope = _embeds()
+        for is_batch in (True, False):
+            w = _worker((INPUT_SHAPE, ROPE_SHAPE, DEEPSTACK_SHAPE), is_batch=is_batch)
+            w.cache_model = SimpleNamespace(get_num_model_variants=boom)
+
+            single = w._build_infer_inputs(emb, deep, rope)
+            assert isinstance(single, np.ndarray)
+            np.testing.assert_allclose(single, np.expand_dims(emb, 0))
+
+            # The batch builder rejects deepstack tensors for a model that
+            # declares no deepstack input, which is what [] now looks like...
+            with pytest.raises(RuntimeError, match="require a dual-input Qwen3-VL MXQ"):
+                w._build_batch_infer_inputs([emb], [deep], [rope])
+            # ...and emits the text input alone when none are supplied.
+            batch = w._build_batch_infer_inputs([emb], [None], [rope])
+            assert len(batch) == 1
 
 
 class TestAmbiguousSignatureIsReported:

--- a/tests/test_qwen3_vl_extra_input_order.py
+++ b/tests/test_qwen3_vl_extra_input_order.py
@@ -144,6 +144,38 @@ class TestEmittedOrderMatchesDeclaration:
         np.testing.assert_allclose(out[expect_ds_at], deep)
 
 
+class TestAmbiguousSignatureIsReported:
+    """The fallback is the one path that can emit wrong slots without raising.
+
+    Nothing downstream can catch it -- the declared shapes are identical, so
+    every validation check passes either way -- which leaves the log as the only
+    way to find out. It has to fire, and it has to fire only once: this runs on
+    every decode step.
+    """
+
+    AMBIGUOUS = ((1, -1, HIDDEN), (1, -1, HIDDEN))
+
+    def test_warns_once_for_an_unreadable_signature(self, caplog) -> None:
+        w = _worker((INPUT_SHAPE, *self.AMBIGUOUS), is_batch=True)
+        w._warned_ambiguous_extra_input_order = False
+        with caplog.at_level("WARNING"):
+            for _ in range(3):
+                assert w._qwen3_vl_text_extra_input_order(
+                    [INPUT_SHAPE, *self.AMBIGUOUS], HIDDEN
+                ) == ("rope", "deepstack")
+        warnings = [r for r in caplog.records if "cannot be" in r.getMessage()]
+        assert len(warnings) == 1, f"expected one warning, got {len(warnings)}"
+        assert "(1, -1, 4096)" in warnings[0].getMessage()
+
+    @pytest.mark.parametrize("tails", [(ROPE_SHAPE, DEEPSTACK_SHAPE), (DEEPSTACK_SHAPE, ROPE_SHAPE)])
+    def test_stays_quiet_when_the_shapes_decide(self, tails, caplog) -> None:
+        w = _worker((INPUT_SHAPE, *tails), is_batch=True)
+        w._warned_ambiguous_extra_input_order = False
+        with caplog.at_level("WARNING"):
+            w._qwen3_vl_text_extra_input_order([INPUT_SHAPE, *tails], HIDDEN)
+        assert [r for r in caplog.records if "cannot be" in r.getMessage()] == []
+
+
 class TestPathsAgree:
     def test_both_builders_pick_the_same_order(self) -> None:
         # Compare full shapes, not just the last axis: text_input and deepstack

--- a/tests/test_qwen3_vl_extra_input_order.py
+++ b/tests/test_qwen3_vl_extra_input_order.py
@@ -73,6 +73,23 @@ class TestDetectTailOrder:
         assert order == ("rope", "deepstack")
 
     @pytest.mark.parametrize("default", [("rope", "deepstack"), ("deepstack", "rope")])
+    @pytest.mark.parametrize(
+        "tails, expected",
+        [
+            ([(1, -1, HIDDEN), (LAYERS, -1, -1)], ("rope", "deepstack")),
+            ([(LAYERS, -1, -1), (1, -1, HIDDEN)], ("deepstack", "rope")),
+        ],
+    )
+    def test_leading_axis_wins_when_the_last_axis_disagrees(self, tails, expected, default) -> None:
+        # rope declaring pe_size == hidden_size *and* deepstack declaring a
+        # dynamic hidden axis -- the two signatures the last axis cannot read,
+        # in one pair. The last axis then reads the rope input as deepstack, so
+        # consulting it first inverts the pair. The leading axis is decisive
+        # (LAYERS cannot be a rope batch dimension) and has to win. Both
+        # defaults are tried, so neither answer can be coming from the fallback.
+        assert MbltWorker._detect_qwen3_vl_tail_order(tails, HIDDEN, default) == expected
+
+    @pytest.mark.parametrize("default", [("rope", "deepstack"), ("deepstack", "rope")])
     def test_unreadable_on_both_axes_falls_back_to_default(self, default) -> None:
         # A single-layer deepstack sharing the rope input's declared size is
         # genuinely indistinguishable: neither axis separates the two. Guessing

--- a/tests/test_qwen3_vl_extra_input_order.py
+++ b/tests/test_qwen3_vl_extra_input_order.py
@@ -78,42 +78,51 @@ class TestDetectTailOrder:
         assert order == ("rope", "deepstack")
 
 
+@pytest.mark.parametrize("is_batch", [True, False])
 @pytest.mark.parametrize(
     "tail_shapes, expect_rope_at",
     [((ROPE_SHAPE, DEEPSTACK_SHAPE), 1), ((DEEPSTACK_SHAPE, ROPE_SHAPE), 2)],
 )
 class TestEmittedOrderMatchesDeclaration:
-    """The detected order must drive the returned tensors, not just validation."""
+    """The detected order must drive the returned tensors, not just validation.
 
-    def test_batch_path(self, tail_shapes, expect_rope_at) -> None:
-        w = _worker((INPUT_SHAPE, *tail_shapes), is_batch=True)
+    Parametrized over `is_batch` as well: the two model kinds carry different
+    positional defaults, and detection has to win over both.
+    """
+
+    def test_batch_path(self, tail_shapes, expect_rope_at, is_batch) -> None:
+        w = _worker((INPUT_SHAPE, *tail_shapes), is_batch=is_batch)
         emb, deep, rope = _embeds()
         out = w._build_batch_infer_inputs([emb], [deep], [rope])
         assert len(out) == 3
         expect_ds_at = 2 if expect_rope_at == 1 else 1
-        assert out[expect_rope_at].shape[-1] == PE
-        assert out[expect_ds_at].shape[-1] == HIDDEN
         np.testing.assert_allclose(out[expect_rope_at], rope)
         np.testing.assert_allclose(out[expect_ds_at], deep)
 
-    def test_single_request_path(self, tail_shapes, expect_rope_at) -> None:
-        w = _worker((INPUT_SHAPE, *tail_shapes), is_batch=True)
+    def test_single_request_path(self, tail_shapes, expect_rope_at, is_batch) -> None:
+        w = _worker((INPUT_SHAPE, *tail_shapes), is_batch=is_batch)
         emb, deep, rope = _embeds()
         out = w._build_infer_inputs(emb, deep, rope)
         assert len(out) == 3
         expect_ds_at = 2 if expect_rope_at == 1 else 1
-        assert out[expect_rope_at].shape[-1] == PE
-        assert out[expect_ds_at].shape[-1] == HIDDEN
+        np.testing.assert_allclose(out[expect_rope_at], rope)
+        np.testing.assert_allclose(out[expect_ds_at], deep)
 
 
 class TestPathsAgree:
     def test_both_builders_pick_the_same_order(self) -> None:
+        # Compare full shapes, not just the last axis: text_input and deepstack
+        # both end in HIDDEN, so a builder that swapped slot 0 with the deepstack
+        # slot would pass a last-axis-only assertion.
         for tail in ((ROPE_SHAPE, DEEPSTACK_SHAPE), (DEEPSTACK_SHAPE, ROPE_SHAPE)):
             for is_batch in (True, False):
                 w = _worker((INPUT_SHAPE, *tail), is_batch=is_batch)
                 emb, deep, rope = _embeds()
                 batch_out = w._build_batch_infer_inputs([emb], [deep], [rope])
                 single_out = w._build_infer_inputs(emb, deep, rope)
-                assert [t.shape[-1] for t in batch_out] == [t.shape[-1] for t in single_out], (
+                assert [tuple(t.shape) for t in batch_out] == [tuple(t.shape) for t in single_out], (
                     f"batch and single-request paths disagree for tail={tail}, is_batch={is_batch}"
                 )
+                # slot 0 is always the text input, in both builders
+                np.testing.assert_allclose(batch_out[0], np.expand_dims(emb, 0))
+                np.testing.assert_allclose(single_out[0], np.expand_dims(emb, 0))

--- a/vllm_mblt/__init__.py
+++ b/vllm_mblt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 
 def register():

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1373,11 +1373,11 @@ class MbltWorker(WorkerBase):
         against the shipped Batch16 order. So the declared shapes decide, and
         these defaults are consulted only for a signature they cannot read.
 
-        Both arguments are required, and `input_shapes` is the list the caller
-        already read: re-reading it here would go through
-        `_cache_model_input_shapes`, which swallows every exception and returns
-        `[]`, so a transient failure would silently hand back the positional
-        default while the caller still indexes a 3-entry list.
+        `input_shapes` is the list the caller already read, and is required:
+        re-reading it here would go through `_cache_model_input_shapes`, which
+        swallows every exception and returns `[]`, so a transient failure would
+        hand back the positional default while the caller still indexes a
+        3-entry list.
         """
 
         default = ("rope", "deepstack") if self._is_batch_model() else ("deepstack", "rope")
@@ -1402,6 +1402,29 @@ class MbltWorker(WorkerBase):
             self._warned_ambiguous_extra_input_order = True
         return default
 
+    def _qwen3_vl_text_extra_input_layout(
+        self,
+        input_shapes: Sequence[Sequence[int]],
+        hidden_size: int,
+    ) -> tuple[tuple[str, str], Optional[Sequence[int]], Sequence[int]]:
+        """Resolve (order, rope_shape, deepstack_shape) for a text MXQ signature.
+
+        Both builders need the same three answers from the same shapes, and the
+        order must be the one they later emit in: classifying one way and
+        emitting the other would put RoPE in the deepstack slot and produce
+        wrong logits with no error. Deriving all three here is what keeps them
+        from drifting apart.
+
+        A 2-input signature has no rope input, so rope_shape is None and the
+        order is unused.
+        """
+
+        if len(input_shapes) < 3:
+            return ("rope", "deepstack"), None, input_shapes[1]
+        order = self._qwen3_vl_text_extra_input_order(input_shapes, hidden_size)
+        shapes = dict(zip(order, input_shapes[1:3]))
+        return order, shapes["rope"], shapes["deepstack"]
+
     def _build_infer_inputs(
         self,
         input_embeds: np.ndarray,
@@ -1419,18 +1442,9 @@ class MbltWorker(WorkerBase):
             return batched_input
 
         uses_rope_input = len(input_shapes) >= 3
-        extra_input_order: tuple[str, str] = ("rope", "deepstack")
-        if uses_rope_input:
-            extra_input_order = self._qwen3_vl_text_extra_input_order(
-                input_shapes, int(input_embeds.shape[-1])
-            )
-            first_extra, second_extra = extra_input_order
-            extra_shapes = {first_extra: input_shapes[1], second_extra: input_shapes[2]}
-            rope_shape = extra_shapes["rope"]
-            deepstack_shape = extra_shapes["deepstack"]
-        else:
-            rope_shape = None
-            deepstack_shape = input_shapes[1]
+        extra_input_order, rope_shape, deepstack_shape = self._qwen3_vl_text_extra_input_layout(
+            input_shapes, int(input_embeds.shape[-1])
+        )
         if uses_rope_input:
             if rope_embeds is None:
                 raise RuntimeError("Qwen3-VL 3-input text MXQ requires RoPE embeddings.")
@@ -1552,22 +1566,9 @@ class MbltWorker(WorkerBase):
         hidden_size = int(concat_input.shape[-1])
         packed_tokens = int(concat_input.shape[0])
         uses_rope_input = len(input_shapes) >= 3
-        # The 3-input batch layout is [inputs, rope, deepstack] for the MXQs shipped
-        # so far, but the compiler does not guarantee that order: a rebuild can emit
-        # [inputs, deepstack, rope] instead. Let the declared shapes decide, and use
-        # the same answer for validation and for the order the tensors are emitted in
-        # -- classifying one way and emitting the other would put RoPE in the
-        # deepstack slot and produce wrong logits with no error.
-        extra_input_order: tuple[str, str] = ("rope", "deepstack")
-        if uses_rope_input:
-            extra_input_order = self._qwen3_vl_text_extra_input_order(input_shapes, hidden_size)
-            first_extra, second_extra = extra_input_order
-            extra_shapes = {first_extra: input_shapes[1], second_extra: input_shapes[2]}
-            rope_shape = extra_shapes["rope"]
-            deepstack_shape = extra_shapes["deepstack"]
-        else:
-            rope_shape = None
-            deepstack_shape = input_shapes[1]
+        extra_input_order, rope_shape, deepstack_shape = self._qwen3_vl_text_extra_input_layout(
+            input_shapes, hidden_size
+        )
         if uses_rope_input:
             if rope_embeds_batch is None:
                 raise RuntimeError("Qwen3-VL 3-input batch text MXQ requires batched RoPE embeddings.")

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -4,7 +4,7 @@ import os
 import statistics
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Hashable, List, Optional, Sequence
 
 import numpy as np
 import torch
@@ -1292,17 +1292,49 @@ class MbltWorker(WorkerBase):
             return False
         return len(self._cache_model_input_shapes(self._get_cache_model())) >= 3
 
-    def _qwen3_vl_text_extra_input_order(self) -> tuple[str, str]:
+    @staticmethod
+    def _detect_qwen3_vl_tail_order(
+        tail_shapes: Sequence[Sequence[int]],
+        hidden_size: int,
+        default: tuple[str, str],
+    ) -> tuple[str, str]:
+        """Classify the two trailing text-MXQ inputs as rope / deepstack.
+
+        Deepstack's last axis is the hidden size; rope's is pe_size. A negative
+        (dynamic) axis is unknown and never counts as a match, so an artifact we
+        cannot tell apart -- including one whose pe_size happens to equal the
+        hidden size -- falls back to `default` and keeps the previous behaviour
+        exactly.
+        """
+
+        if len(tail_shapes) != 2 or hidden_size <= 0:
+            return default
+        matches_hidden = tuple(
+            int(shape[-1]) > 0 and int(shape[-1]) == hidden_size for shape in tail_shapes
+        )
+        if matches_hidden == (True, False):
+            return ("deepstack", "rope")
+        if matches_hidden == (False, True):
+            return ("rope", "deepstack")
+        return default
+
+    def _qwen3_vl_text_extra_input_order(self, hidden_size: Optional[int] = None) -> tuple[str, str]:
         """Return the Qwen3-VL 3-input text MXQ extra-input order.
 
         mblt-model-zoo 2.3.0 ships different 3-input signatures for dynamic
         Qwen3-VL text artifacts: non-batch uses [inputs, deepstack, rope],
-        while Batch16 uses [inputs, rope, deepstack].
+        while Batch16 uses [inputs, rope, deepstack]. The compiler does not
+        guarantee either, so when `hidden_size` is known the declared shapes
+        decide and the positional convention is only the fallback.
         """
 
-        if self._is_batch_model():
-            return ("rope", "deepstack")
-        return ("deepstack", "rope")
+        default = ("rope", "deepstack") if self._is_batch_model() else ("deepstack", "rope")
+        if hidden_size is None:
+            return default
+        input_shapes = self._cache_model_input_shapes(self._get_cache_model())
+        if len(input_shapes) < 3:
+            return default
+        return self._detect_qwen3_vl_tail_order(input_shapes[1:3], hidden_size, default)
 
     def _build_infer_inputs(
         self,
@@ -1321,8 +1353,10 @@ class MbltWorker(WorkerBase):
             return batched_input
 
         uses_rope_input = len(input_shapes) >= 3
+        extra_input_order: tuple[str, str] = ("rope", "deepstack")
         if uses_rope_input:
-            first_extra, second_extra = self._qwen3_vl_text_extra_input_order()
+            extra_input_order = self._qwen3_vl_text_extra_input_order(int(input_embeds.shape[-1]))
+            first_extra, second_extra = extra_input_order
             extra_shapes = {first_extra: input_shapes[1], second_extra: input_shapes[2]}
             rope_shape = extra_shapes["rope"]
             deepstack_shape = extra_shapes["deepstack"]
@@ -1401,7 +1435,7 @@ class MbltWorker(WorkerBase):
                 "rope": rope_embeds.astype(np.float32, copy=False),
                 "deepstack": deepstack_embeds.astype(np.float32, copy=False),
             }
-            return [batched_input, *(extras[name] for name in self._qwen3_vl_text_extra_input_order())]
+            return [batched_input, *(extras[name] for name in extra_input_order)]
         return [batched_input, deepstack_embeds.astype(np.float32, copy=False)]
 
     def _build_batch_infer_inputs(
@@ -1452,22 +1486,17 @@ class MbltWorker(WorkerBase):
         uses_rope_input = len(input_shapes) >= 3
         # The 3-input batch layout is [inputs, rope, deepstack] for the MXQs shipped
         # so far, but the compiler does not guarantee that order: a rebuild can emit
-        # [inputs, deepstack, rope] instead. Pick the two by shape signature rather
-        # than by position -- rope is the only tail input whose last axis is not the
-        # hidden size. Fall back to the positional choice whenever that is ambiguous,
-        # so shipped artifacts keep their current behaviour exactly.
+        # [inputs, deepstack, rope] instead. Let the declared shapes decide, and use
+        # the same answer for validation and for the order the tensors are emitted in
+        # -- classifying one way and emitting the other would put RoPE in the
+        # deepstack slot and produce wrong logits with no error.
+        extra_input_order: tuple[str, str] = ("rope", "deepstack")
         if uses_rope_input:
-            tail = list(input_shapes[1:3])
-            rope_candidates = [s for s in tail if int(s[-1]) != hidden_size]
-            deepstack_candidates = [s for s in tail if int(s[-1]) == hidden_size]
-            rope_shape = (
-                rope_candidates[0] if len(rope_candidates) == 1 else input_shapes[1]
-            )
-            deepstack_shape = (
-                deepstack_candidates[0]
-                if len(deepstack_candidates) == 1
-                else input_shapes[2]
-            )
+            extra_input_order = self._qwen3_vl_text_extra_input_order(hidden_size)
+            first_extra, second_extra = extra_input_order
+            extra_shapes = {first_extra: input_shapes[1], second_extra: input_shapes[2]}
+            rope_shape = extra_shapes["rope"]
+            deepstack_shape = extra_shapes["deepstack"]
         else:
             rope_shape = None
             deepstack_shape = input_shapes[1]
@@ -1549,11 +1578,11 @@ class MbltWorker(WorkerBase):
                 )
             rope_chunks.append(rope_embeds.astype(np.float32, copy=False))
 
-        return [
-            text_input,
-            np.concatenate(rope_chunks, axis=1),
-            np.concatenate(deepstack_chunks, axis=1),
-        ]
+        extras = {
+            "rope": np.concatenate(rope_chunks, axis=1),
+            "deepstack": np.concatenate(deepstack_chunks, axis=1),
+        }
+        return [text_input, *(extras[name] for name in extra_input_order)]
 
     @staticmethod
     def _last_token_logits(logits: np.ndarray) -> np.ndarray:

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1300,21 +1300,24 @@ class MbltWorker(WorkerBase):
     ) -> tuple[str, str]:
         """Classify the two trailing text-MXQ inputs as rope / deepstack.
 
-        Two independent discriminators, tried in that order:
+        Two discriminators, strongest first:
 
-        * the last axis -- deepstack's is the hidden size, rope's is pe_size;
         * the leading axis -- deepstack's is its layer count, which both callers
           require to be fixed and positive, while rope's must be 1 or dynamic.
-          So a leading axis greater than 1 can only be deepstack.
+          A leading axis greater than 1 therefore cannot be rope. This holds
+          unconditionally.
+        * the last axis -- deepstack's is the hidden size, rope's is pe_size.
+          Weaker, because rope satisfies it too whenever pe_size == hidden_size,
+          so it is consulted only when the leading axis is 1 or dynamic on both
+          tails and cannot separate them.
 
-        The leading axis settles the two signatures the last axis cannot read: a
-        deepstack input declaring a dynamic hidden axis, and an artifact whose
-        pe_size happens to equal the hidden size. Both used to fall back to the
-        positional guess, which then failed validation on the very artifacts
-        this classification exists to accept.
+        The order is the point. With the weak test first, a pair combining the
+        two signatures it cannot read -- rope declaring pe_size == hidden_size
+        and deepstack declaring a dynamic hidden axis -- gets actively inverted
+        and the reliable test never runs.
 
-        What neither can tell apart -- a single-layer deepstack whose hidden size
-        the rope input shares, say -- still falls back to `default`, so shipped
+        What neither can tell apart -- a single-layer deepstack whose declared
+        size the rope input shares, say -- falls back to `default`, so shipped
         artifacts keep their behaviour exactly.
         """
 
@@ -1326,20 +1329,19 @@ class MbltWorker(WorkerBase):
         if any(len(shape) < 1 for shape in tail_shapes):
             return default
 
+        holds_layers = tuple(int(shape[0]) > 1 for shape in tail_shapes)
+        if holds_layers == (True, False):
+            return ("deepstack", "rope")
+        if holds_layers == (False, True):
+            return ("rope", "deepstack")
+
+        # Both leading axes are 1 or dynamic, so fall through to the weaker test.
         matches_hidden = tuple(
             int(shape[-1]) > 0 and int(shape[-1]) == hidden_size for shape in tail_shapes
         )
         if matches_hidden == (True, False):
             return ("deepstack", "rope")
         if matches_hidden == (False, True):
-            return ("rope", "deepstack")
-
-        # The last axis was unreadable on both tails; the leading axis is
-        # independent of it and only deepstack may declare more than one layer.
-        holds_layers = tuple(int(shape[0]) > 1 for shape in tail_shapes)
-        if holds_layers == (True, False):
-            return ("deepstack", "rope")
-        if holds_layers == (False, True):
             return ("rope", "deepstack")
         return default
 

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -395,6 +395,7 @@ class MbltWorker(WorkerBase):
             os.getenv("VLLM_MBLT_ENABLE_SAMPLING_PENALTIES")
         )
         self._warned_penalties_disabled = False
+        self._warned_ambiguous_extra_input_order = False
 
     def _log_init_stage(self, stage: str, start_time: Optional[float] = None, **fields: object) -> None:
         payload = {
@@ -1293,11 +1294,10 @@ class MbltWorker(WorkerBase):
         return len(self._cache_model_input_shapes(self._get_cache_model())) >= 3
 
     @staticmethod
-    def _detect_qwen3_vl_tail_order(
+    def _classify_qwen3_vl_tail_order(
         tail_shapes: Sequence[Sequence[int]],
         hidden_size: int,
-        default: tuple[str, str],
-    ) -> tuple[str, str]:
+    ) -> Optional[tuple[str, str]]:
         """Classify the two trailing text-MXQ inputs as rope / deepstack.
 
         Two discriminators, strongest first:
@@ -1316,18 +1316,19 @@ class MbltWorker(WorkerBase):
         and deepstack declaring a dynamic hidden axis -- gets actively inverted
         and the reliable test never runs.
 
-        What neither can tell apart -- a single-layer deepstack whose declared
-        size the rope input shares, say -- falls back to `default`, so shipped
-        artifacts keep their behaviour exactly.
+        Returns None for what neither can tell apart -- a single-layer deepstack
+        whose declared size the rope input shares, say. Callers decide what to
+        do with an unreadable signature; None is deliberately not the positional
+        guess, so that choice is theirs to make and to report.
         """
 
         if len(tail_shapes) != 2 or hidden_size <= 0:
-            return default
+            return None
         # A rank-0 shape cannot be classified. Leave it to the rank checks that
         # follow in the callers, which say what is wrong with the signature --
         # indexing into it here would replace that with a bare IndexError.
         if any(len(shape) < 1 for shape in tail_shapes):
-            return default
+            return None
 
         holds_layers = tuple(int(shape[0]) > 1 for shape in tail_shapes)
         if holds_layers == (True, False):
@@ -1343,7 +1344,19 @@ class MbltWorker(WorkerBase):
             return ("deepstack", "rope")
         if matches_hidden == (False, True):
             return ("rope", "deepstack")
-        return default
+        return None
+
+    @classmethod
+    def _detect_qwen3_vl_tail_order(
+        cls,
+        tail_shapes: Sequence[Sequence[int]],
+        hidden_size: int,
+        default: tuple[str, str],
+    ) -> tuple[str, str]:
+        """`_classify_qwen3_vl_tail_order`, with `default` for an unreadable pair."""
+
+        classified = cls._classify_qwen3_vl_tail_order(tail_shapes, hidden_size)
+        return default if classified is None else classified
 
     def _qwen3_vl_text_extra_input_order(
         self,
@@ -1370,7 +1383,24 @@ class MbltWorker(WorkerBase):
         default = ("rope", "deepstack") if self._is_batch_model() else ("deepstack", "rope")
         if len(input_shapes) < 3:
             return default
-        return self._detect_qwen3_vl_tail_order(input_shapes[1:3], hidden_size, default)
+        classified = self._classify_qwen3_vl_tail_order(input_shapes[1:3], hidden_size)
+        if classified is not None:
+            return classified
+        # Unreadable, so the positional guess decides -- and this is the one path
+        # that can put the tensors in the wrong slots without raising: the two
+        # declared shapes are indistinguishable, so every validation check below
+        # passes either way. Say so once per worker; this runs every decode step.
+        if not getattr(self, "_warned_ambiguous_extra_input_order", False):
+            logger.warning(
+                "Qwen3-VL 3-input text MXQ declares rope and deepstack shapes that cannot be "
+                "told apart (%s, %s). Assuming %s, the order shipped for this model kind. If "
+                "this artifact wants the other order, the logits will be wrong with no error.",
+                tuple(input_shapes[1]),
+                tuple(input_shapes[2]),
+                default,
+            )
+            self._warned_ambiguous_extra_input_order = True
+        return default
 
     def _build_infer_inputs(
         self,

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1309,8 +1309,12 @@ class MbltWorker(WorkerBase):
 
         if len(tail_shapes) != 2 or hidden_size <= 0:
             return default
+        # A rank-0 shape cannot be classified. Leave it to the rank checks that
+        # follow in the callers, which say what is wrong with the signature --
+        # indexing shape[-1] here would replace that with a bare IndexError.
         matches_hidden = tuple(
-            int(shape[-1]) > 0 and int(shape[-1]) == hidden_size for shape in tail_shapes
+            len(shape) >= 1 and int(shape[-1]) > 0 and int(shape[-1]) == hidden_size
+            for shape in tail_shapes
         )
         if matches_hidden == (True, False):
             return ("deepstack", "rope")
@@ -1318,20 +1322,27 @@ class MbltWorker(WorkerBase):
             return ("rope", "deepstack")
         return default
 
-    def _qwen3_vl_text_extra_input_order(self, hidden_size: Optional[int] = None) -> tuple[str, str]:
+    def _qwen3_vl_text_extra_input_order(
+        self,
+        input_shapes: Sequence[Sequence[int]],
+        hidden_size: int,
+    ) -> tuple[str, str]:
         """Return the Qwen3-VL 3-input text MXQ extra-input order.
 
         mblt-model-zoo 2.3.0 ships different 3-input signatures for dynamic
         Qwen3-VL text artifacts: non-batch uses [inputs, deepstack, rope],
         while Batch16 uses [inputs, rope, deepstack]. The compiler does not
-        guarantee either, so when `hidden_size` is known the declared shapes
-        decide and the positional convention is only the fallback.
+        guarantee either, so the declared shapes decide and the positional
+        convention is only the fallback.
+
+        Both arguments are required, and `input_shapes` is the list the caller
+        already read: re-reading it here would go through
+        `_cache_model_input_shapes`, which swallows every exception and returns
+        `[]`, so a transient failure would silently hand back the positional
+        default while the caller still indexes a 3-entry list.
         """
 
         default = ("rope", "deepstack") if self._is_batch_model() else ("deepstack", "rope")
-        if hidden_size is None:
-            return default
-        input_shapes = self._cache_model_input_shapes(self._get_cache_model())
         if len(input_shapes) < 3:
             return default
         return self._detect_qwen3_vl_tail_order(input_shapes[1:3], hidden_size, default)
@@ -1355,7 +1366,9 @@ class MbltWorker(WorkerBase):
         uses_rope_input = len(input_shapes) >= 3
         extra_input_order: tuple[str, str] = ("rope", "deepstack")
         if uses_rope_input:
-            extra_input_order = self._qwen3_vl_text_extra_input_order(int(input_embeds.shape[-1]))
+            extra_input_order = self._qwen3_vl_text_extra_input_order(
+                input_shapes, int(input_embeds.shape[-1])
+            )
             first_extra, second_extra = extra_input_order
             extra_shapes = {first_extra: input_shapes[1], second_extra: input_shapes[2]}
             rope_shape = extra_shapes["rope"]
@@ -1492,7 +1505,7 @@ class MbltWorker(WorkerBase):
         # deepstack slot and produce wrong logits with no error.
         extra_input_order: tuple[str, str] = ("rope", "deepstack")
         if uses_rope_input:
-            extra_input_order = self._qwen3_vl_text_extra_input_order(hidden_size)
+            extra_input_order = self._qwen3_vl_text_extra_input_order(input_shapes, hidden_size)
             first_extra, second_extra = extra_input_order
             extra_shapes = {first_extra: input_shapes[1], second_extra: input_shapes[2]}
             rope_shape = extra_shapes["rope"]

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1450,8 +1450,27 @@ class MbltWorker(WorkerBase):
         hidden_size = int(concat_input.shape[-1])
         packed_tokens = int(concat_input.shape[0])
         uses_rope_input = len(input_shapes) >= 3
-        rope_shape = input_shapes[1] if uses_rope_input else None
-        deepstack_shape = input_shapes[2] if uses_rope_input else input_shapes[1]
+        # The 3-input batch layout is [inputs, rope, deepstack] for the MXQs shipped
+        # so far, but the compiler does not guarantee that order: a rebuild can emit
+        # [inputs, deepstack, rope] instead. Pick the two by shape signature rather
+        # than by position -- rope is the only tail input whose last axis is not the
+        # hidden size. Fall back to the positional choice whenever that is ambiguous,
+        # so shipped artifacts keep their current behaviour exactly.
+        if uses_rope_input:
+            tail = list(input_shapes[1:3])
+            rope_candidates = [s for s in tail if int(s[-1]) != hidden_size]
+            deepstack_candidates = [s for s in tail if int(s[-1]) == hidden_size]
+            rope_shape = (
+                rope_candidates[0] if len(rope_candidates) == 1 else input_shapes[1]
+            )
+            deepstack_shape = (
+                deepstack_candidates[0]
+                if len(deepstack_candidates) == 1
+                else input_shapes[2]
+            )
+        else:
+            rope_shape = None
+            deepstack_shape = input_shapes[1]
         if uses_rope_input:
             if rope_embeds_batch is None:
                 raise RuntimeError("Qwen3-VL 3-input batch text MXQ requires batched RoPE embeddings.")

--- a/vllm_mblt/mblt_worker.py
+++ b/vllm_mblt/mblt_worker.py
@@ -1300,25 +1300,46 @@ class MbltWorker(WorkerBase):
     ) -> tuple[str, str]:
         """Classify the two trailing text-MXQ inputs as rope / deepstack.
 
-        Deepstack's last axis is the hidden size; rope's is pe_size. A negative
-        (dynamic) axis is unknown and never counts as a match, so an artifact we
-        cannot tell apart -- including one whose pe_size happens to equal the
-        hidden size -- falls back to `default` and keeps the previous behaviour
-        exactly.
+        Two independent discriminators, tried in that order:
+
+        * the last axis -- deepstack's is the hidden size, rope's is pe_size;
+        * the leading axis -- deepstack's is its layer count, which both callers
+          require to be fixed and positive, while rope's must be 1 or dynamic.
+          So a leading axis greater than 1 can only be deepstack.
+
+        The leading axis settles the two signatures the last axis cannot read: a
+        deepstack input declaring a dynamic hidden axis, and an artifact whose
+        pe_size happens to equal the hidden size. Both used to fall back to the
+        positional guess, which then failed validation on the very artifacts
+        this classification exists to accept.
+
+        What neither can tell apart -- a single-layer deepstack whose hidden size
+        the rope input shares, say -- still falls back to `default`, so shipped
+        artifacts keep their behaviour exactly.
         """
 
         if len(tail_shapes) != 2 or hidden_size <= 0:
             return default
         # A rank-0 shape cannot be classified. Leave it to the rank checks that
         # follow in the callers, which say what is wrong with the signature --
-        # indexing shape[-1] here would replace that with a bare IndexError.
+        # indexing into it here would replace that with a bare IndexError.
+        if any(len(shape) < 1 for shape in tail_shapes):
+            return default
+
         matches_hidden = tuple(
-            len(shape) >= 1 and int(shape[-1]) > 0 and int(shape[-1]) == hidden_size
-            for shape in tail_shapes
+            int(shape[-1]) > 0 and int(shape[-1]) == hidden_size for shape in tail_shapes
         )
         if matches_hidden == (True, False):
             return ("deepstack", "rope")
         if matches_hidden == (False, True):
+            return ("rope", "deepstack")
+
+        # The last axis was unreadable on both tails; the leading axis is
+        # independent of it and only deepstack may declare more than one layer.
+        holds_layers = tuple(int(shape[0]) > 1 for shape in tail_shapes)
+        if holds_layers == (True, False):
+            return ("deepstack", "rope")
+        if holds_layers == (False, True):
             return ("rope", "deepstack")
         return default
 
@@ -1329,11 +1350,13 @@ class MbltWorker(WorkerBase):
     ) -> tuple[str, str]:
         """Return the Qwen3-VL 3-input text MXQ extra-input order.
 
-        mblt-model-zoo 2.3.0 ships different 3-input signatures for dynamic
-        Qwen3-VL text artifacts: non-batch uses [inputs, deepstack, rope],
-        while Batch16 uses [inputs, rope, deepstack]. The compiler does not
-        guarantee either, so the declared shapes decide and the positional
-        convention is only the fallback.
+        The positional fallback records only what mblt-model-zoo 2.3.0 happened
+        to ship: non-batch [inputs, deepstack, rope], Batch16 [inputs, rope,
+        deepstack]. The compiler guarantees neither -- the reference Batch16
+        rebuild this classification was written against declares
+        [(1,-1,4096), (3,-1,4096), (1,-1,256)], i.e. deepstack before rope,
+        against the shipped Batch16 order. So the declared shapes decide, and
+        these defaults are consulted only for a signature they cannot read.
 
         Both arguments are required, and `input_shapes` is the list the caller
         already read: re-reading it here would go through


### PR DESCRIPTION
## Problem

`_build_batch_infer_inputs` assumes the 3-input batch text MXQ always declares its
inputs as `[inputs, rope, deepstack]` and reads them positionally:

```python
rope_shape = input_shapes[1] if uses_rope_input else None
deepstack_shape = input_shapes[2] if uses_rope_input else input_shapes[1]
```

That holds for the MXQs shipped so far, but the compiler does not guarantee the
order. A rebuild of the same model (Qwen3-VL-8B, recompiled with a different
inference scheme) declares `[inputs, deepstack, rope]` instead, and the worker
then rejects a perfectly valid artifact:

```
RuntimeError: 3-input Qwen3-VL batch text MXQ rope batch dimension must be 1,
              got (3, -1, 4096).
```

The deepstack tensor `(3, -1, 4096)` is being validated as if it were rope.

## Fix

Pick the two tail inputs by **shape signature** instead of position. `rope` is the
only tail input whose last axis is not the hidden size, so the two are
distinguishable without relying on declaration order.

When the signature is ambiguous — both tail inputs share the hidden size — the code
falls back to the original positional choice, so **shipped artifacts keep their
current behaviour exactly**. This is a strict generalization, not a behaviour change.

## Verification

Exercised the selection against four layouts:

| layout | input_shapes | result |
|---|---|---|
| shipped | `[(1,-1,H), (1,-1,256), (3,-1,H)]` | rope `(1,-1,256)`, deepstack `(3,-1,H)` |
| rebuilt | `[(1,-1,H), (3,-1,H), (1,-1,256)]` | rope `(1,-1,256)`, deepstack `(3,-1,H)` |
| 2-input | `[(1,-1,H), (3,-1,H)]` | rope `None`, deepstack `(3,-1,H)` |
| ambiguous | `[(1,-1,H), (1,-1,H), (3,-1,H)]` | identical to the positional result |

End-to-end: with this change the recompiled Qwen3-VL-8B decoder loads and runs
through `vllm bench throughput` on MLA100. Without it the run aborts at the
validation above.

## Notes

- Also relevant to `mblt-model-zoo`, which hardcodes the same order on the
  HF-transformers path; that side is being handled separately.
- Concurrent per-request vision submission (`VLLM_MBLT_VISION_SUBMIT_WORKERS`) was
  deliberately **left out** of this PR. Measured over three runs it gave
  172.25 / 172.43 / 234.92 total tok/s — the mean gain is not established and the
  spread (±15%) is much worse than the sequential path (±2.4%), so it deserves its
  own discussion.
